### PR TITLE
chore: compose.yamlの不要な空白行を削除

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -66,9 +66,6 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/shrimp_shells_ec_development
-      
-     
-      
     ports:
       - "${SHRIMP_SHELLS_PORT}:3000"
     volumes:


### PR DESCRIPTION
compose.yamlのshrimpshells-ec environment設定内の不要な空白行3行を削除しました。