### PR TITLE
git pull 忘れ防止のため警告を強調 (issue#86)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,9 +330,9 @@ LandBase AI Suite プロジェクトへようこそ！このガイドでは、�
    ```bash
    # ✅ GOOD: 正しい手順
    # Step 1: Issue 作成（GitHub で実施）
-   # Step 2: main を最新化
+   # Step 2: main を最新化 👈 これを忘れない！
    git checkout main
-   git pull origin main
+   git pull origin main  # 🚨 必須！古いコードから分岐するとコンフリクト多発
 
    # Step 3: 新しいブランチを作成
    git checkout -b feature/76-knowledge-base-implementation


### PR DESCRIPTION
## 概要

CONTRIBUTING.md の Git ワークフローセクションで、`git pull origin main` の行を目立たせ、開発者が忘れないようにしました。

## 変更内容

- `git pull origin main` の行に絵文字（🚨）と警告コメントを追加
- Step 2 のコメントに「👈 これを忘れない！」を追加

## 変更箇所

CONTRIBUTING.md:333-335

**変更前:**
```bash
# Step 2: main を最新化
git checkout main
git pull origin main
```

**変更後:**
```bash
# Step 2: main を最新化 👈 これを忘れない！
git checkout main
git pull origin main  # 🚨 必須！古いコードから分岐するとコンフリクト多発
```

## テスト方法

```bash
# CONTRIBUTING.md を確認
cat CONTRIBUTING.md | grep -A 3 "Step 2"
```

## チェックリスト

- [x] シンプルで読みやすい
- [x] 絵文字と警告コメントが追加されている
- [x] 既存のドキュメントスタイルと統一感がある
- [x] Issue を更新済み

Closes #86