### PR TITLE
n8nバージョンを2.4.0にアップグレード

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # LandBase AI Suite Development Environment Variables
 
 # Automation Layer: n8n設定
-N8N_VERSION=2.1.1
+N8N_VERSION=2.4.0
 N8N_PORT=5678
 WEBHOOK_URL=http://localhost:5678
 


### PR DESCRIPTION
## 概要

issue#89に基づき、n8nのバージョンを2.1.1から2.4.0にアップグレードしました。

## 変更内容

- .envファイルのN8N_VERSIONを2.1.1から2.4.0に変更

## テスト方法

```bash
# 1. 全データをクリーンアップ
make clean

# 2. 新バージョンで起動
make up

# 3. 動作確認
curl http://localhost:5678

# 4. UIでバージョン確認
# http://localhost:5678 にアクセスして、n8nのバージョンが2.4.0であることを確認
```

## チェックリスト

- [x] .envファイルのN8N_VERSIONを変更
- [ ] make cleanでデータクリーンアップ（マージ後に実行）
- [ ] make upで起動確認（マージ後に実行）
- [ ] バージョン確認（マージ後に実行）

## 注意事項

- このPRをマージした後、必ず`make clean`を実行してから`make up`を実行してください
- 既存のn8nワークフローは削除されますので、必要に応じてバックアップを取得してください

Closes #89