### PR TITLE
docs: .env.local.exampleにn8n Credential用の環境変数を追加 (issue#64)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,9 +9,41 @@
 #    https://developers.line.biz/console/
 # 3. 取得した認証情報を以下に設定
 
+# ================================
+# n8n Credentials (Automation Layer)
+# ================================
+
+# OpenAI API設定
+# n8n Credential: OpenAI
+# 取得方法: https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-proj-your_openai_api_key_here
+
+# Google Sheets OAuth2設定
+# n8n Credential: Google Sheets OAuth2
+# 取得方法: https://console.cloud.google.com/apis/credentials
+GOOGLE_SHEETS_OAUTH2_CLIENT_ID=your_google_sheets_oauth2_client_id_here.apps.googleusercontent.com
+GOOGLE_SHEETS_OAUTH2_CLIENT_SECRET=your_google_sheets_oauth2_client_secret_here
+
+# Google Drive OAuth2設定
+# n8n Credential: Google Drive OAuth2
+# 取得方法: https://console.cloud.google.com/apis/credentials
+GOOGLE_DRIVE_OAUTH2_CLIENT_ID=your_google_drive_oauth2_client_id_here.apps.googleusercontent.com
+GOOGLE_DRIVE_OAUTH2_CLIENT_SECRET=your_google_drive_oauth2_client_secret_here
+
+# ================================
 # Integration Layer: LINE Bot設定
+# ================================
+
+# LINE Messaging API設定
+# n8n Credential: LINE Bot Auth (HTTP Header Auth)
+# 取得方法: https://developers.line.biz/console/
 LINE_CHANNEL_SECRET=your_line_channel_secret_here
 LINE_CHANNEL_ACCESS_TOKEN=your_line_channel_access_token_here
+
+# LINE会計自動化用スプレッドシートID
+# Master_User_Config と Master_Account_Mapping シートが含まれるスプレッドシートのID
+# 例: https://docs.google.com/spreadsheets/d/[このID部分]/edit
+LINE_ACCOUNTING_SHEET_ID=your_google_sheets_id_here
 
 # ngrok設定 (オプション: 固定URLを使いたい場合)
 # NGROK_AUTHTOKEN=your_ngrok_authtoken_here


### PR DESCRIPTION
## 📋 概要

n8nワークフローで使用する機密情報やIDを `.env.local` で一元管理できるようにテンプレートを更新しました。

Closes #64

---

## 🔧 変更内容

### 追加した環境変数

1. **OpenAI API設定**
   - `OPENAI_API_KEY`: OpenAI APIキー
   - n8n Credential: `OpenAI`

2. **Google Sheets OAuth2設定**
   - `GOOGLE_SHEETS_OAUTH2_CLIENT_ID`: クライアントID
   - `GOOGLE_SHEETS_OAUTH2_CLIENT_SECRET`: クライアントシークレット
   - n8n Credential: `Google Sheets OAuth2`

3. **Google Drive OAuth2設定**
   - `GOOGLE_DRIVE_OAUTH2_CLIENT_ID`: クライアントID
   - `GOOGLE_DRIVE_OAUTH2_CLIENT_SECRET`: クライアントシークレット
   - n8n Credential: `Google Drive OAuth2`

4. **LINE会計自動化設定**
   - `LINE_ACCOUNTING_SHEET_ID`: Master_User_ConfigとMaster_Account_Mappingが含まれるスプレッドシートのID

### ドキュメント改善

- 各環境変数に以下を記載：
  - 対応するn8n Credential名
  - 取得方法のURL
  - 使用例や補足説明
- セクション分けで見やすく整理

---

## ✅ メリット

- ✅ n8n Credentialの設定が明確化
- ✅ 環境変数の一元管理が可能
- ✅ セットアップ時の迷いを削減
- ✅ チーム開発での情報共有が容易

---

## 📋 関連Issue

- #64 (このPRでクローズ)
- #65 (次にこの環境変数を使用してクレデンシャル設定を実施)