### PR TITLE
Mattermostの匿名volumeを名前付きvolumeに変更

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,7 +24,11 @@ services:
     ports:
       - "${MATTERMOST_PORT}:8065"
     volumes:
-      - mattermost_data:/mattermost
+      - mattermost_config:/mattermost/config
+      - mattermost_data:/mattermost/data
+      - mattermost_logs:/mattermost/logs
+      - mattermost_plugins:/mattermost/plugins
+      - mattermost_client_plugins:/mattermost/client/plugins
     depends_on:
       postgres:
         condition: service_healthy
@@ -117,7 +121,15 @@ services:
 volumes:
   postgres_data:
     driver: local
+  mattermost_config:
+    driver: local
   mattermost_data:
+    driver: local
+  mattermost_logs:
+    driver: local
+  mattermost_plugins:
+    driver: local
+  mattermost_client_plugins:
     driver: local
   n8n_data:
     driver: local


### PR DESCRIPTION
## 概要

issue#94 - Mattermostの公式Dockerイメージが作成する匿名volumeを名前付きvolumeに変更。

## 変更内容

- `/mattermost/config` → `mattermost_config`
- `/mattermost/data` → `mattermost_data`
- `/mattermost/logs` → `mattermost_logs`
- `/mattermost/plugins` → `mattermost_plugins`
- `/mattermost/client/plugins` → `mattermost_client_plugins`

## テスト方法

```bash
docker compose down
docker compose up -d
docker volume ls  # 匿名volumeがないことを確認
```

## チェックリスト

- [x] compose.yaml修正完了
- [ ] Mattermostが正常起動
- [ ] 匿名volumeが作成されないことを確認

Closes #94