### PR TITLE
chore(make): 不要/低頻度コマンドを削除 (issue#99)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,8 @@ clean: ## クリーンアップ（コンテナ・ボリューム・プロジェ�
 	docker compose --env-file .env down -v --rmi local
 	@echo "${GREEN}Cleaned up Docker resources.${NC}"
 
-.PHONY: build
-build: ## サービスビルド（キャッシュ無効）
-	docker compose build --no-cache
-
 # ================================
-# LINE Bot 統合
+# ngrok（LINE Webhook用）
 # ================================
 
 .PHONY: ngrok
@@ -140,45 +136,3 @@ ngrok-status: ## ngrokの状態確認
 	fi
 	@echo ""
 
-.PHONY: line-bot-info
-line-bot-info: ## LINE Bot設定情報表示
-	@echo "${GREEN}========================================${NC}"
-	@echo "${GREEN}📱 LINE Bot 設定情報${NC}"
-	@echo "${GREEN}========================================${NC}"
-	@echo ""
-	@echo "${YELLOW}LINE Developers Console:${NC}"
-	@echo "  https://developers.line.biz/console/"
-	@echo ""
-	@echo "${YELLOW}必要な設定:${NC}"
-	@echo "  1. Channel Secret → .env.local の LINE_CHANNEL_SECRET に設定"
-	@echo "  2. Channel Access Token → .env.local の LINE_CHANNEL_ACCESS_TOKEN に設定"
-	@echo "  3. Webhook URL → ngrokで取得したURL/webhook/line-webhook"
-	@echo "  4. Webhook送信 → ON"
-	@echo "  5. グループトーク参加 → ON"
-	@echo ""
-	@echo "${YELLOW}現在の環境変数:${NC}"
-	@if [ "$(LINE_CHANNEL_SECRET)" = "your_line_channel_secret_here" ]; then \
-		echo "  LINE_CHANNEL_SECRET: ${RED}未設定${NC}"; \
-	else \
-		echo "  LINE_CHANNEL_SECRET: ${GREEN}設定済み${NC}"; \
-	fi
-	@if [ "$(LINE_CHANNEL_ACCESS_TOKEN)" = "your_line_channel_access_token_here" ]; then \
-		echo "  LINE_CHANNEL_ACCESS_TOKEN: ${RED}未設定${NC}"; \
-	else \
-		echo "  LINE_CHANNEL_ACCESS_TOKEN: ${GREEN}設定済み${NC}"; \
-	fi
-	@echo ""
-	@echo "${YELLOW}ワークフロー:${NC}"
-	@echo "  n8n/workflows/line-to-gdrive.json"
-	@echo ""
-	@echo "${GREEN}========================================${NC}"
-
-.PHONY: line-bot-test
-line-bot-test: ## LINE Bot Webhook接続テスト
-	@echo "${GREEN}LINE Bot Webhook接続テスト${NC}"
-	@echo "${YELLOW}n8nのWebhookエンドポイントをテストします...${NC}"
-	@curl -X POST http://localhost:${N8N_PORT}/webhook/line-webhook \
-		-H "Content-Type: application/json" \
-		-d '{"events":[{"type":"message","message":{"type":"text","text":"test"}}]}' \
-		&& echo "\n${GREEN}✅ Webhook接続成功${NC}" \
-		|| echo "\n${RED}❌ Webhook接続失敗${NC}"


### PR DESCRIPTION
## 概要

Makefile から不要/低頻度コマンドを削除し、コマンド一覧を整理しました。

## 変更内容

### 削除したコマンド（3件）
- `build` - 低頻度（`docker compose build --no-cache`で代替可能）
- `line-bot-info` - 低頻度
- `line-bot-test` - 低頻度

### 残したコマンド（14件）
- `help`, `up`, `down`, `logs`, `clean` - 基本操作
- `init` - 初期セットアップ
- `n8n-logs`, `postgres-logs`, `mattermost-logs`, `postgres-shell` - 個別サービス
- `ngrok`, `ngrok-stop`, `ngrok-restart`, `ngrok-status` - LINE Webhook用

## テスト方法

```bash
make help
```

## チェックリスト

- [x] Makefile修正完了
- [x] `make help` で動作確認

Closes #99