### PR TITLE
fix(platform): RSpec実行時にRAILS_ENVをtestに強制設定 (issue#166)

### DIFF
--- a/rails/platform/spec/rails_helper.rb
+++ b/rails/platform/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
## 概要

Docker Compose環境でRSpecテスト実行時に `RAILS_ENV` が `development` のまま実行され、API Request Specが全て403を返す問題を修正。

Closes #166

## 変更内容

- `rails/platform/spec/rails_helper.rb`: `ENV['RAILS_ENV'] ||= 'test'` → `ENV['RAILS_ENV'] = 'test'` に変更
  - `compose.development.yaml` で `RAILS_ENV=development` が設定されているため、`||=` では上書きできなかった
  - `development` 環境では `ActionDispatch::HostAuthorization` が有効で、RSpecデフォルトの `www.example.com` がブロックされていた

## テスト方法

```bash
# プレフィックスなしで全テストがパスすることを確認
docker compose -f compose.development.yaml exec platform bash -lc "bundle exec rspec"
# => 226 examples, 0 failures
```

## チェックリスト

- [x] テスト追加（既存テスト226件が修正の検証を兼ねる）
- [x] RuboCop 準拠（1 file inspected, no offenses detected）
- [ ] マイグレーション作成（該当なし）
- [ ] ドキュメント更新（該当なし）
- [x] セキュリティチェック（Brakeman: No warnings found）