### PR TITLE
feat(platform): APIセッション認証にOrigin検証によるCSRF対策を追加 (issue#169)

### DIFF
--- a/rails/platform/spec/requests/api/v1/amex_statements_spec.rb
+++ b/rails/platform/spec/requests/api/v1/amex_statements_spec.rb
@@ -129,6 +129,20 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
       get "/api/v1/amex_statements/#{batch.id}/status", params: { client_code: client_code }
       expect(response).to have_http_status(:ok)
     end
+
+    it "同一オリジンからのリクエストを許可すること" do
+      post "/api/v1/amex_statements/process_statement",
+        params: { client_code: client_code, pdf: test_pdf },
+        headers: { "Origin" => "http://www.example.com" }
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it "異なるオリジンからのセッション認証リクエストを拒否すること" do
+      post "/api/v1/amex_statements/process_statement",
+        params: { client_code: client_code, pdf: test_pdf },
+        headers: { "Origin" => "https://evil.example.com" }
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   context "認証なし" do


### PR DESCRIPTION
## Summary
- セッション認証経由の API 呼び出し時に `Origin` ヘッダーを検証する `valid_session_origin?` を追加
- `ActionController::API` が CSRF トークン検証を含まないことへの多層防御（Defense in Depth）
- リバースプロキシ環境向けに `APP_ORIGIN` 環境変数での許可オリジン設定に対応

## 検証ロジック
- `Origin` が空（同一オリジンの通常リクエスト）→ 許可
- `Origin` が `request.base_url` または `APP_ORIGIN` と一致 → 許可
- `Origin` が異なる外部サイト → 401 Unauthorized（`@current_user` は設定されない）

## 補足
- Bearer トークン認証のリクエストには影響なし（Origin 検証はセッション認証パスのみ）
- `SameSite=Lax` Cookie と合わせた二重の防御
- 本番環境（Caddy → Rails）では `APP_ORIGIN=https://www.land-bank.ai` を設定する想定

## 依存
- issue#167 (PR #170) — セッション認証フォールバック

## Test plan
- [x] Origin なしのセッション認証リクエストが許可されること
- [x] 同一オリジンのリクエストが許可されること
- [x] 異なるオリジンのリクエストが 401 で拒否されること
- [x] Origin 検証失敗時に `@current_user` が設定されないこと
- [x] 既存の Bearer トークン認証テストが全てパスすること
- [x] 全テスト（230 examples）パス

Closes #169