### PR TITLE
refactor(infra): Docker Compose・環境変数ファイルの整理統合 (issue#174)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,105 +1,52 @@
-# LandBase AI Suite Development Environment Variables
+# LandBase AI Suite - Development Environment Variables
 
-# Automation Layer: n8n設定
-N8N_VERSION=2.4.0
-N8N_PORT=5678
-WEBHOOK_URL=http://localhost:5678
-
-# n8n Database Configuration
-N8N_ENCRYPTION_KEY=landbase_dev_encryption_key_change_in_production
-DB_TYPE=postgresdb
-DB_POSTGRESDB_HOST=postgres
-DB_POSTGRESDB_PORT=5432
-
-# Data Layer: PostgreSQL設定
-POSTGRES_VERSION=16-bookworm
-POSTGRES_USER=landbase
-POSTGRES_PASSWORD=landbase_dev_password
-POSTGRES_DB=landbase_development
-POSTGRES_PORT=5432
-DATABASE_URL=postgresql://landbase:landbase_dev_password@postgres:5432/landbase_development
-
-# API Layer: Rails設定
+# ================================
+# Docker Build
+# ================================
 RUBY_VERSION=3.4.6
 NODE_VERSION=22.19.0
 YARN_VERSION=4.9.2
 RAILS_VERSION=8.0.2.1
-RAILS_ENV=development
-BINDING=0.0.0.0
-RAILS_PORT=3000
-RAILS_APP_NAME=railsapp
-BUNDLE_JOBS=4
-BUNDLE_RETRY=3
+POSTGRES_VERSION=16-bookworm
 
-# UI Layer: Flutter設定
-FLUTTER_VERSION=3.32.5
-FLUTTER_WEB_HOSTNAME=0.0.0.0
-FLUTTER_PORT=8080
-API_BASE_URL=http://localhost:3000
-N8N_BASE_URL=http://localhost:5678
-FLUTTER_APP_NAME=flutterapp
+# ================================
+# PostgreSQL
+# ================================
+POSTGRES_HOST=db-suite
+POSTGRES_PORT=5432
+POSTGRES_USER=landbase
+POSTGRES_PASSWORD=landbase_dev_password
+POSTGRES_DB=platform_development
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
-# Marketing Layer: Next.js設定
-NEXTJS_VERSION=15.1.6
-NEXTJS_PORT=3001
-NEXTJS_APP_NAME=nextjsapp
+# ================================
+# n8n
+# ================================
+N8N_VERSION=2.4.0
+N8N_ENCRYPTION_KEY=landbase_dev_encryption_key_change_in_production
+WEBHOOK_URL=http://localhost:5678
+DB_TYPE=postgresdb
+DB_POSTGRESDB_HOST=${POSTGRES_HOST}
+DB_POSTGRESDB_PORT=${POSTGRES_PORT}
+DB_POSTGRESDB_DATABASE=${POSTGRES_DB}
+DB_POSTGRESDB_USER=${POSTGRES_USER}
+DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD}
+DB_POSTGRESDB_SCHEMA=n8n
 
-# Communication Layer: Mattermost設定
+# ================================
+# Mattermost
+# ================================
 MATTERMOST_VERSION=9.11
-MATTERMOST_PORT=8065
 MATTERMOST_DOMAIN=localhost
 MM_SQLSETTINGS_DRIVERNAME=postgres
-MM_SQLSETTINGS_DATASOURCE=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable&connect_timeout=10
-
-# Mattermost Branding
+MM_SQLSETTINGS_DATASOURCE=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable&connect_timeout=10
 MM_SERVICESETTINGS_SITENAME="LandBase AI Suite"
 MM_TEAMSETTINGS_SITENAME="LandBase AI Suite"
 MM_SERVICESETTINGS_SITEURL=http://localhost:8065
 MM_TEAMSETTINGS_ENABLECUSTOMBRANDING=true
 MM_TEAMSETTINGS_CUSTOMBRANDTEXT="LandBase AI Suite"
 
-# Platform (基幹Railsアプリ)
-PLATFORM_APP_NAME=platform
-PLATFORM_PORT=3000
-
-# Integration Layer: LINE Bot設定
-# LINE認証情報は .env.local に設定してください
-# 詳細: .env.local.example を参照
-
-# Docker設定
-DOCKER_BUILDKIT=1
-COMPOSE_DOCKER_CLI_BUILD=1
-
 # ================================
-# Production Environment Variables
+# Platform
 # ================================
-
-# n8n Production
-# N8N_BASIC_AUTH_ACTIVE=false
-# N8N_ENCRYPTION_KEY=your-encryption-key
-# N8N_USER_MANAGEMENT_JWT_SECRET=your-jwt-secret
-
-# PostgreSQL Production
-# POSTGRES_PASSWORD=your-strong-production-password
-# DATABASE_URL=postgresql://user:password@db-host:5432/landbase_production
-
-# Rails Production
-# RAILS_ENV=production
-# SECRET_KEY_BASE=your-production-secret-key-generate-with-rails-secret
-# RAILS_LOG_LEVEL=info
-
-# AWS S3 (for Active Storage)
-# AWS_ACCESS_KEY_ID=your-access-key
-# AWS_SECRET_ACCESS_KEY=your-secret-key
-# AWS_REGION=ap-northeast-1
-# AWS_BUCKET=your-bucket-name
-
-# Email Configuration (Production)
-# SMTP_ADDRESS=smtp.gmail.com
-# SMTP_PORT=587
-# SMTP_DOMAIN=yourdomain.com
-# SMTP_USER_NAME=your-email@gmail.com
-# SMTP_PASSWORD=your-app-password
-
-# Sentry (Error Tracking)
-# SENTRY_DSN=https://your-sentry-dsn@sentry.io/project-id
+LANG=ja_JP.UTF-8

--- a/.env.production
+++ b/.env.production
@@ -18,9 +18,10 @@ POSTGRES_PORT=5432
 POSTGRES_USER=platform
 POSTGRES_PASSWORD=change-this-password
 POSTGRES_DB=platform_production
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # ================================
-# Rails
+# Platform
 # ================================
 RAILS_ENV=production
 SECRET_KEY_BASE=change-this-to-generated-secret-key-base
@@ -29,11 +30,4 @@ RAILS_LOG_LEVEL=info
 RAILS_SERVE_STATIC_FILES=true
 RAILS_MAX_THREADS=5
 WEB_CONCURRENCY=2
-PORT=3000
 LANG=ja_JP.UTF-8
-
-# ================================
-# Docker
-# ================================
-DOCKER_BUILDKIT=1
-COMPOSE_DOCKER_CLI_BUILD=1

--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -1,7 +1,7 @@
 name: landbase_ai_suite
 
 services:
-  postgres:
+  db-suite:
     image: postgres:${POSTGRES_VERSION}
     env_file:
       - .env.development
@@ -22,7 +22,7 @@ services:
       - .env.development
       - .env.local
     ports:
-      - "${MATTERMOST_PORT}:8065"
+      - "8065:8065"
     volumes:
       - mattermost_config:/mattermost/config
       - mattermost_data:/mattermost/data
@@ -30,7 +30,7 @@ services:
       - mattermost_plugins:/mattermost/plugins
       - mattermost_client_plugins:/mattermost/client/plugins
     depends_on:
-      postgres:
+      db-suite:
         condition: service_healthy
 
   n8n:
@@ -38,17 +38,12 @@ services:
     env_file:
       - .env.development
       - .env.local
-    environment:
-      - DB_POSTGRESDB_DATABASE=landbase_development
-      - DB_POSTGRESDB_USER=landbase
-      - DB_POSTGRESDB_PASSWORD=landbase_dev_password
-      - DB_POSTGRESDB_SCHEMA=n8n_platform
     ports:
-      - "${N8N_PORT}:5678"
+      - "5678:5678"
     volumes:
       - n8n_data:/home/node/.n8n
     depends_on:
-      postgres:
+      db-suite:
         condition: service_healthy
 
   platform:
@@ -59,24 +54,17 @@ services:
       args:
         RUBY_VERSION: ${RUBY_VERSION}
         RAILS_VERSION: ${RAILS_VERSION}
-    command: bash -c "rm -f tmp/pids/server.pid && bin/dev"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/setup && bin/dev"
     volumes:
       - ./rails/platform:/platform
       - platform_bundle_cache:/usr/local/bundle
     ports:
-      - "${PLATFORM_PORT}:3000"
+      - "3000:3000"
     env_file:
       - .env.development
       - .env.local
-    environment:
-      - RAILS_ENV=development
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platform_development
     depends_on:
-      postgres:
+      db-suite:
         condition: service_healthy
     stdin_open: true
     tty: true

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -1,17 +1,11 @@
-# LandBase AI Suite - Production Compose
-#
-# 起動: make prod-deploy
-# ログ: make prod-logs
-
-name: landbase_suite
+name: landbase_ai_suite
 
 services:
   db-suite:
     image: postgres:${POSTGRES_VERSION}
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+    env_file:
+      - .env.production
+      - .env.local
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -23,7 +17,7 @@ services:
       retries: 5
     restart: unless-stopped
 
-  app-suite:
+  platform:
     build:
       context: ./rails
       dockerfile: Dockerfile.platform
@@ -33,11 +27,7 @@ services:
         RAILS_VERSION: ${RAILS_VERSION}
     env_file:
       - .env.production
-    environment:
-      - RAILS_ENV=production
-      - POSTGRES_HOST=db-suite
-      - POSTGRES_PORT=5432
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db-suite:5432/${POSTGRES_DB}
+      - .env.local
     expose:
       - "3000"
     depends_on:


### PR DESCRIPTION
## 概要

Docker Compose の `environment` ブロックと `.env.*` ファイルの重複・不整合を解消し、環境変数管理を `env_file` に一本化。

Closes #174

## 変更内容

### compose.development.yaml
- `platform` / `n8n` サービスの `environment` ブロックを除去
- サービス名 `postgres` → `db-suite` に統一（production と一致）
- ポートマッピングを直接指定（`${*_PORT}` 変数を廃止）
- platform コマンドに `bin/setup` を追加（`make clean` 後の自動復旧）

### compose.production.yaml
- `db-suite` / `platform`（旧 `app-suite`）の `environment` ブロックを除去
- `app-suite` → `platform` にリネーム
- `name: landbase_suite` → `landbase_ai_suite` に統一
- `.env.local` を env_file に追加

### .env.development
- `DATABASE_URL` の DB 名を `landbase_development` → `platform_development` に修正（database.yml と一致）
- n8n DB 設定を compose から移動（`${VAR}` 参照で DRY 化）
- 削除済みの Flutter / Next.js セクション、Production テンプレートを除去
- 不要な変数を除去（`DOCKER_BUILDKIT`, `RAILS_ENV`, `BINDING`, `*_PORT` 変数群）
- `.env.production` とレイアウトを統一

### .env.production
- `DATABASE_URL` を追加（`${VAR}` 参照）
- セクション名 `Rails` → `Platform` に統一
- `PORT` → 廃止、`DOCKER_BUILDKIT` 関連を除去

### Makefile
- `postgres` → `db-suite`、`app-suite` → `platform` に統一
- ポート変数参照を直接値に置換

## テスト方法

```bash
make down && make up
# 全サービス正常起動を確認

docker compose -f compose.development.yaml --env-file .env.development exec platform bash -lc "bundle exec rspec"
# => 256 examples, 0 failures
```

## チェックリスト

- [x] テスト追加（既存テスト256件が検証を兼ねる）
- [x] RuboCop 準拠（インフラファイルのみ変更のため該当なし）
- [ ] マイグレーション作成（該当なし）
- [ ] ドキュメント更新（該当なし）
- [x] セキュリティチェック（認証情報の管理方法変更なし）