### PR TITLE
feat(platform): クライアント検索・選択ページを新設しルートに配置 (issue#159)

### DIFF
--- a/rails/platform/app/controllers/amex_statements_controller.rb
+++ b/rails/platform/app/controllers/amex_statements_controller.rb
@@ -1,4 +1,5 @@
 class AmexStatementsController < ApplicationController
   def new
+    @client = Client.find_by(code: params[:client_code])
   end
 end

--- a/rails/platform/app/controllers/bank_statements_controller.rb
+++ b/rails/platform/app/controllers/bank_statements_controller.rb
@@ -1,4 +1,5 @@
 class BankStatementsController < ApplicationController
   def new
+    @client = Client.find_by(code: params[:client_code])
   end
 end

--- a/rails/platform/app/controllers/cleaning_manuals_controller.rb
+++ b/rails/platform/app/controllers/cleaning_manuals_controller.rb
@@ -3,6 +3,7 @@ class CleaningManualsController < ApplicationController
 
   def index
     @client_code = params[:client_code] || ""
+    @client = Client.find_by(code: @client_code)
     @manuals = if @client_code.present?
                  CleaningManual.for_client(@client_code).recent
                else
@@ -12,10 +13,12 @@ class CleaningManualsController < ApplicationController
 
   def show
     @client_code = params[:client_code]
+    @client = Client.find_by(code: @client_code)
     @manual = CleaningManual.for_client(@client_code).find(params[:id])
   end
 
   def new
+    @client = Client.find_by(code: params[:client_code])
   end
 
   private

--- a/rails/platform/app/controllers/clients_controller.rb
+++ b/rails/platform/app/controllers/clients_controller.rb
@@ -1,0 +1,17 @@
+class ClientsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  def index
+    @clients = Client.visible.search(params[:query]).order(:code)
+  end
+
+  def show
+    @client = Client.find_by!(code: params[:id])
+  end
+
+  private
+
+  def record_not_found
+    redirect_to clients_path, alert: "クライアントが見つかりません"
+  end
+end

--- a/rails/platform/app/models/client.rb
+++ b/rails/platform/app/models/client.rb
@@ -13,4 +13,17 @@ class Client < ApplicationRecord
 
   # === スコープ ===
   scope :active, -> { where(status: "active") }
+  scope :visible, -> { where(status: %w[active trial]) }
+  scope :search, ->(query) {
+    if query.present?
+      sanitized = "%#{sanitize_sql_like(query)}%"
+      where("code ILIKE :q OR name ILIKE :q", q: sanitized)
+    else
+      all
+    end
+  }
+
+  def to_param
+    code
+  end
 end

--- a/rails/platform/app/views/amex_statements/new.html.erb
+++ b/rails/platform/app/views/amex_statements/new.html.erb
@@ -1,12 +1,23 @@
 <% content_for(:title) { "Amex明細PDF処理" } %>
 
 <div class="w-full max-w-4xl mx-auto" data-controller="pdf-upload">
+  <% if @client %>
+    <div class="mb-4 text-sm text-gray-500">
+      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <span>Amex明細処理</span>
+    </div>
+  <% end %>
+
   <h1 class="text-2xl font-bold mb-6">Amex明細PDF → 仕訳台帳変換</h1>
 
   <form data-pdf-upload-target="form" data-action="submit->pdf-upload#submit" class="space-y-6">
     <div>
       <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
       <input type="text" name="client_code" id="client_code" required
+             value="<%= params[:client_code] %>"
              class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
              data-pdf-upload-target="clientCode">
     </div>

--- a/rails/platform/app/views/bank_statements/new.html.erb
+++ b/rails/platform/app/views/bank_statements/new.html.erb
@@ -1,12 +1,23 @@
 <% content_for(:title) { "銀行明細PDF処理" } %>
 
 <div class="w-full max-w-4xl mx-auto" data-controller="bank-pdf-upload">
+  <% if @client %>
+    <div class="mb-4 text-sm text-gray-500">
+      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <span>銀行明細処理</span>
+    </div>
+  <% end %>
+
   <h1 class="text-2xl font-bold mb-6">銀行明細PDF → 仕訳台帳変換</h1>
 
   <form data-bank-pdf-upload-target="form" data-action="submit->bank-pdf-upload#submit" class="space-y-6">
     <div>
       <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
       <input type="text" name="client_code" id="client_code" required
+             value="<%= params[:client_code] %>"
              class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
              data-bank-pdf-upload-target="clientCode">
     </div>

--- a/rails/platform/app/views/cleaning_manuals/index.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/index.html.erb
@@ -1,6 +1,16 @@
 <% content_for(:title) { "清掃マニュアル一覧" } %>
 
 <div class="w-full max-w-4xl mx-auto">
+  <% if @client %>
+    <div class="mb-4 text-sm text-gray-500">
+      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <span>清掃マニュアル</span>
+    </div>
+  <% end %>
+
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">清掃マニュアル一覧</h1>
     <%= link_to "新規作成", new_cleaning_manual_path, class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>

--- a/rails/platform/app/views/cleaning_manuals/new.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/new.html.erb
@@ -1,6 +1,16 @@
 <% content_for(:title) { "清掃マニュアル生成" } %>
 
 <div class="w-full max-w-4xl mx-auto" data-controller="image-upload">
+  <% if @client %>
+    <div class="mb-4 text-sm text-gray-500">
+      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <span>清掃マニュアル生成</span>
+    </div>
+  <% end %>
+
   <h1 class="text-2xl font-bold mb-6">清掃マニュアル自動生成</h1>
 
   <form data-image-upload-target="form" data-action="submit->image-upload#submit" class="space-y-6">
@@ -8,6 +18,7 @@
       <div>
         <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
         <input type="text" name="client_code" id="client_code" required
+               value="<%= params[:client_code] %>"
                class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
                data-image-upload-target="clientCode">
       </div>

--- a/rails/platform/app/views/cleaning_manuals/show.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/show.html.erb
@@ -1,9 +1,21 @@
 <% content_for(:title) { "#{@manual.property_name} - 清掃マニュアル" } %>
 
 <div class="w-full max-w-4xl mx-auto">
-  <div class="mb-6">
-    <%= link_to "← 一覧に戻る", cleaning_manuals_path(client_code: @manual.client.code), class: "text-blue-600 hover:text-blue-800 text-sm" %>
-  </div>
+  <% if @client %>
+    <div class="mb-4 text-sm text-gray-500">
+      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <%= link_to "清掃マニュアル", cleaning_manuals_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+      <span class="mx-1">/</span>
+      <span><%= @manual.property_name %></span>
+    </div>
+  <% else %>
+    <div class="mb-6">
+      <%= link_to "← 一覧に戻る", cleaning_manuals_path(client_code: @manual.client.code), class: "text-blue-600 hover:text-blue-800 text-sm" %>
+    </div>
+  <% end %>
 
   <div class="flex items-center justify-between mb-6">
     <div>

--- a/rails/platform/app/views/clients/index.html.erb
+++ b/rails/platform/app/views/clients/index.html.erb
@@ -1,0 +1,53 @@
+<% content_for(:title) { "クライアント一覧" } %>
+
+<div class="w-full mx-auto px-4">
+  <h1 class="text-2xl font-bold mb-6">クライアント一覧</h1>
+
+  <form method="get" class="mb-6 flex flex-wrap gap-4 items-end">
+    <div>
+      <label for="query" class="block text-sm font-medium text-gray-700 mb-1">名前 / コードで検索</label>
+      <input type="text" name="query" id="query" value="<%= params[:query] %>"
+             placeholder="クライアント名またはコード"
+             class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border w-72">
+    </div>
+    <button type="submit" class="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 transition-colors">
+      検索
+    </button>
+    <% if params[:query].present? %>
+      <%= link_to "クリア", clients_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-2" %>
+    <% end %>
+  </form>
+
+  <% if @clients.empty? %>
+    <p class="text-gray-500">クライアントが見つかりません。</p>
+  <% else %>
+    <div class="bg-white shadow rounded-lg overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">コード</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">名前</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">業種</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">ステータス</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+          <% @clients.each do |client| %>
+            <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='<%= client_path(client) %>'">
+              <td class="px-6 py-4 text-sm font-mono text-gray-900"><%= client.code %></td>
+              <td class="px-6 py-4 text-sm font-medium text-gray-900"><%= client.name %></td>
+              <td class="px-6 py-4 text-sm text-gray-500"><%= client.industry.presence || "—" %></td>
+              <td class="px-6 py-4">
+                <% if client.status == "active" %>
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                <% elsif client.status == "trial" %>
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Trial</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -1,0 +1,48 @@
+<% content_for(:title) { @client.name } %>
+
+<div class="w-full max-w-4xl mx-auto px-4">
+  <div class="mb-6">
+    <%= link_to "← クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800 text-sm" %>
+  </div>
+
+  <div class="bg-white shadow rounded-lg p-6 mb-8">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900"><%= @client.name %></h1>
+        <p class="text-sm font-mono text-gray-500 mt-1"><%= @client.code %></p>
+      </div>
+      <div class="flex items-center gap-3">
+        <% if @client.industry.present? %>
+          <span class="text-sm text-gray-600"><%= @client.industry %></span>
+        <% end %>
+        <% if @client.status == "active" %>
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+        <% elsif @client.status == "trial" %>
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Trial</span>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <%= link_to journal_entries_path(client_code: @client.code), class: "block bg-white shadow rounded-lg p-6 hover:shadow-md transition-shadow" do %>
+      <h2 class="text-lg font-semibold text-gray-900 mb-2">仕訳台帳</h2>
+      <p class="text-sm text-gray-500">仕訳データの一覧表示・編集・CSVエクスポート</p>
+    <% end %>
+
+    <%= link_to new_amex_statement_path(client_code: @client.code), class: "block bg-white shadow rounded-lg p-6 hover:shadow-md transition-shadow" do %>
+      <h2 class="text-lg font-semibold text-gray-900 mb-2">Amex明細処理</h2>
+      <p class="text-sm text-gray-500">Amex利用明細PDFをAIで仕訳データに変換</p>
+    <% end %>
+
+    <%= link_to new_bank_statement_path(client_code: @client.code), class: "block bg-white shadow rounded-lg p-6 hover:shadow-md transition-shadow" do %>
+      <h2 class="text-lg font-semibold text-gray-900 mb-2">銀行明細処理</h2>
+      <p class="text-sm text-gray-500">銀行入出金明細PDFをAIで仕訳データに変換</p>
+    <% end %>
+
+    <%= link_to cleaning_manuals_path(client_code: @client.code), class: "block bg-white shadow rounded-lg p-6 hover:shadow-md transition-shadow" do %>
+      <h2 class="text-lg font-semibold text-gray-900 mb-2">清掃マニュアル</h2>
+      <p class="text-sm text-gray-500">AI生成の清掃基準マニュアル管理</p>
+    <% end %>
+  </div>
+</div>

--- a/rails/platform/app/views/journal_entries/edit.html.erb
+++ b/rails/platform/app/views/journal_entries/edit.html.erb
@@ -1,8 +1,16 @@
 <% content_for(:title) { "仕訳編集 ##{@entry.transaction_no}" } %>
 
 <div class="w-full max-w-4xl mx-auto">
-  <div class="mb-6">
-    <%= link_to "← 詳細に戻る", journal_entry_path(@entry, client_code: @client_code), class: "text-blue-600 hover:text-blue-800 text-sm" %>
+  <div class="mb-4 text-sm text-gray-500">
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to "仕訳一覧", journal_entries_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to "##{@entry.transaction_no}", journal_entry_path(@entry, client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>編集</span>
   </div>
 
   <h1 class="text-2xl font-bold mb-6">仕訳編集 #<%= @entry.transaction_no %></h1>

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -1,21 +1,25 @@
-<% content_for(:title) { "仕訳一覧" } %>
+<% content_for(:title) { "仕訳一覧 - #{@client.name}" } %>
 
 <div class="w-full mx-auto px-4">
+  <div class="mb-4 text-sm text-gray-500">
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>仕訳一覧</span>
+  </div>
+
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">仕訳一覧</h1>
     <div class="flex gap-2">
-      <%= link_to "Amex明細処理", new_amex_statement_path, class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>
-      <%= link_to "銀行明細処理", new_bank_statement_path, class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>
-      <%= link_to "請求書処理", new_invoice_path, class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>
+      <%= link_to "Amex明細処理", new_amex_statement_path(client_code: @client_code), class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>
+      <%= link_to "銀行明細処理", new_bank_statement_path(client_code: @client_code), class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>
+      <%= link_to "請求書処理", new_invoice_path(client_code: @client_code), class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>
     </div>
   </div>
 
   <form method="get" class="mb-6 flex flex-wrap gap-4 items-end">
-    <div>
-      <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード</label>
-      <input type="text" name="client_code" id="client_code" value="<%= @client_code %>"
-             class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border">
-    </div>
+    <input type="hidden" name="client_code" value="<%= @client_code %>">
     <div>
       <label for="source_type" class="block text-sm font-medium text-gray-700 mb-1">ソースタイプ</label>
       <select name="source_type" id="source_type"
@@ -30,16 +34,12 @@
     <button type="submit" class="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 transition-colors">
       検索
     </button>
-    <% if @client_code.present? %>
-      <%= link_to "CSVエクスポート",
-            export_api_v1_journal_entries_path(client_code: @client_code, source_type: @source_type.presence),
-            class: "bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors" %>
-    <% end %>
+    <%= link_to "CSVエクスポート",
+          export_api_v1_journal_entries_path(client_code: @client_code, source_type: @source_type.presence),
+          class: "bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors" %>
   </form>
 
-  <% if @client_code.blank? %>
-    <p class="text-gray-500">クライアントコードを入力して検索してください。</p>
-  <% elsif @entries.empty? %>
+  <% if @entries.empty? %>
     <p class="text-gray-500">仕訳が見つかりません。</p>
   <% else %>
     <div class="bg-white shadow rounded-lg overflow-x-auto relative">

--- a/rails/platform/app/views/journal_entries/show.html.erb
+++ b/rails/platform/app/views/journal_entries/show.html.erb
@@ -1,8 +1,14 @@
 <% content_for(:title) { "仕訳詳細 ##{@entry.transaction_no}" } %>
 
 <div class="w-full max-w-4xl mx-auto">
-  <div class="mb-6">
-    <%= link_to "← 一覧に戻る", journal_entries_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800 text-sm" %>
+  <div class="mb-4 text-sm text-gray-500">
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to "仕訳一覧", journal_entries_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>#<%= @entry.transaction_no %></span>
   </div>
 
   <div class="flex items-center justify-between mb-6">

--- a/rails/platform/app/views/layouts/application.html.erb
+++ b/rails/platform/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? %>
       <nav class="bg-white border-b border-gray-200 fixed w-full z-10 top-0">
         <div class="container mx-auto px-5 py-3 flex items-center justify-between">
-          <span class="font-semibold text-gray-800">LandBase Platform</span>
+          <%= link_to "LandBase Platform", root_path, class: "font-semibold text-gray-800 hover:text-gray-600 transition-colors" %>
           <div class="flex items-center gap-4">
             <span class="text-sm text-gray-600"><%= current_user.email %></span>
             <%= button_to "ログアウト", destroy_user_session_path, method: :delete,

--- a/rails/platform/config/routes.rb
+++ b/rails/platform/config/routes.rb
@@ -58,11 +58,12 @@ Rails.application.routes.draw do
   end
 
   # Web UI
+  resources :clients, only: [ :index, :show ]
   resources :cleaning_manuals, only: [ :index, :show, :new ]
   resources :amex_statements, only: [ :new ]
   resources :bank_statements, only: [ :new ]
   resources :invoices, only: [ :new ]
   resources :journal_entries, only: [ :index, :show, :edit, :update ]
 
-  root "journal_entries#index"
+  root "clients#index"
 end

--- a/rails/platform/spec/requests/web/clients_spec.rb
+++ b/rails/platform/spec/requests/web/clients_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe "Web::Clients", type: :request do
+  let(:user) { create(:user) }
+
+  describe "GET /clients (index)" do
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        get clients_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "200を返すこと" do
+        get clients_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "activeとtrialのクライアントが表示されること" do
+        active = create(:client, status: "active", name: "アクティブ社")
+        trial = create(:client, status: "trial", name: "トライアル社")
+        create(:client, status: "inactive", name: "非アクティブ社")
+
+        get clients_path
+        expect(response.body).to include("アクティブ社")
+        expect(response.body).to include("トライアル社")
+        expect(response.body).not_to include("非アクティブ社")
+      end
+
+      it "検索でフィルタできること" do
+        create(:client, code: "ikigai_stay", name: "イキガイステイ")
+        create(:client, code: "oku_resort", name: "奥リゾート")
+
+        get clients_path(query: "ikigai")
+        expect(response.body).to include("イキガイステイ")
+        expect(response.body).not_to include("奥リゾート")
+      end
+
+      it "結果が空の場合メッセージが表示されること" do
+        get clients_path(query: "存在しない")
+        expect(response.body).to include("クライアントが見つかりません")
+      end
+    end
+  end
+
+  describe "GET /clients/:code (show)" do
+    let!(:client) { create(:client, code: "test_client", name: "テスト社") }
+
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        get client_path(client)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "200を返すこと" do
+        get client_path(client)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "クライアント情報が表示されること" do
+        get client_path(client)
+        expect(response.body).to include("テスト社")
+        expect(response.body).to include("test_client")
+      end
+
+      it "機能カードのリンクが表示されること" do
+        get client_path(client)
+        expect(response.body).to include("仕訳台帳")
+        expect(response.body).to include("Amex明細処理")
+        expect(response.body).to include("銀行明細処理")
+        expect(response.body).to include("清掃マニュアル")
+      end
+
+      it "存在しないコードの場合リダイレクトすること" do
+        get client_path(id: "nonexistent")
+        expect(response).to redirect_to(clients_path)
+        expect(flash[:alert]).to eq("クライアントが見つかりません")
+      end
+    end
+  end
+
+  describe "GET / (root)" do
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "クライアント一覧が表示されること" do
+        get root_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("クライアント一覧")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

issue#159のクライアント検索・選択ページを新設し、ルートページをクライアント一覧に変更。
ログイン→クライアント一覧(root)→ダッシュボード→各機能の3ステップナビゲーションを確立。

## 変更内容

- Clientモデルに`to_param`、`visible`/`search`スコープを追加
- ClientsController新規作成（index/show）
- クライアント一覧ページ（検索フォーム、行クリックで遷移）
- クライアントダッシュボード（仕訳台帳、Amex/銀行明細処理、清掃マニュアルへのカードリンク）
- ルートを`clients#index`に変更
- JournalEntriesControllerにclient_code必須化とClient参照を追加
- 全ページにパンくずナビゲーションを追加
- 明細処理・清掃マニュアルページにclient_codeプリフィルを追加
- ナビバーのロゴをroot_pathリンク化

## テスト方法

```bash
# テスト実行
docker compose -f compose.development.yaml --env-file .env.development exec platform bash -lc "DATABASE_URL=postgresql://landbase:landbase_dev_password@postgres:5432/platform_test RAILS_ENV=test bundle exec rspec"
```

### ブラウザ確認
1. ログイン後 → クライアント一覧（ルート）
2. 検索でフィルタ → 行クリックでダッシュボードに遷移
3. ダッシュボード → 仕訳一覧（パンくず表示、client_code入力フォームなし）
4. ダッシュボード → Amex/銀行明細処理（client_codeプリフィル、パンくず表示）
5. ダッシュボード → 清掃マニュアル（client_codeプリフィル、パンくず表示）

## チェックリスト

- [x] テスト追加
- [x] RuboCop 準拠
- [ ] マイグレーション作成（該当なし）
- [ ] ドキュメント更新（該当なし）
- [x] セキュリティチェック（sanitize_sql_like使用、Strong Parameters維持）

Closes #159