### PR TITLE
docs: テスト実行手順をmake testに更新 (issue#179)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -793,15 +793,20 @@ end
 
 ### テスト実行
 
+> **注意**: `.env.development` の `DATABASE_URL` が開発DB（`platform_development`）を指しているため、コンテナ内で直接 `bundle exec rspec` を実行するとテストDBではなく開発DBに対してテストが走ります。必ず `make test` を使用してください。
+
 ```bash
+# 初回のみ: テストDB準備
+make test-prepare
+
 # 全テスト実行
-bundle exec rspec
+make test
 
 # 特定ファイルのみ
-bundle exec rspec spec/models/client_spec.rb
+make test ARGS="spec/models/client_spec.rb"
 
 # カバレッジ確認
-bundle exec rspec --format documentation
+make test ARGS="--format documentation"
 ```
 
 ---


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md のテスト実行手順を `bundle exec rspec` → `make test` に更新
- `DATABASE_URL` が開発DBを上書きする問題についての注意書きを追加
- `make test-prepare`（初回テストDB準備）の手順を追加

## 背景

`.env.development` の `DATABASE_URL` が `platform_development` にハードコードされており、`RAILS_ENV=test` でも `database.yml` のtest設定が上書きされる。`make test` は `DATABASE_URL` をテストDB向けにオーバーライドして実行するため、この問題を回避できる。

Closes #179