### PR TITLE
chore(infra): n8nを2.4.0から2.9.0にアップデート (issue#153)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -22,7 +22,7 @@ DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}
 # ================================
 # n8n
 # ================================
-N8N_VERSION=2.4.0
+N8N_VERSION=2.9.0
 N8N_ENCRYPTION_KEY=landbase_dev_encryption_key_change_in_production
 WEBHOOK_URL=http://localhost:5678
 DB_TYPE=postgresdb


### PR DESCRIPTION
## Summary

- `.env.development` の `N8N_VERSION` を `2.4.0` → `2.9.0` に更新

## 背景

n8nが5マイナーバージョン遅れており、以下の改善が未適用だった：
- AIビルダーの改善（eval改善、チャットメモリ処理）
- SSOバイパス防止などのセキュリティ修正
- Chat hubのデッドロック解消やワークフローインデックス改善

## テスト方法

- [x] `make down && make up` で n8n コンテナが正常起動
- [x] n8n UI（:5678）にアクセスできる
- [ ] 既存ワークフローが正常に表示・実行できる
- [ ] 登録済みクレデンシャルが維持されている

Closes #153