### PR TITLE
feat(platform): クライアントダッシュボードに請求書処理リンクを追加 (issue#183)

### DIFF
--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -40,6 +40,11 @@
       <p class="text-sm text-gray-500">銀行入出金明細PDFをAIで仕訳データに変換</p>
     <% end %>
 
+    <%= link_to new_invoice_path(client_code: @client.code), class: "block bg-white shadow rounded-lg p-6 hover:shadow-md transition-shadow" do %>
+      <h2 class="text-lg font-semibold text-gray-900 mb-2">請求書処理</h2>
+      <p class="text-sm text-gray-500">請求書PDFをAIで仕訳データに変換</p>
+    <% end %>
+
     <%= link_to cleaning_manuals_path(client_code: @client.code), class: "block bg-white shadow rounded-lg p-6 hover:shadow-md transition-shadow" do %>
       <h2 class="text-lg font-semibold text-gray-900 mb-2">清掃マニュアル</h2>
       <p class="text-sm text-gray-500">AI生成の清掃基準マニュアル管理</p>

--- a/rails/platform/spec/requests/web/clients_spec.rb
+++ b/rails/platform/spec/requests/web/clients_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "Web::Clients", type: :request do
         expect(response.body).to include("仕訳台帳")
         expect(response.body).to include("Amex明細処理")
         expect(response.body).to include("銀行明細処理")
+        expect(response.body).to include("請求書処理")
         expect(response.body).to include("清掃マニュアル")
       end
 


### PR DESCRIPTION
## 概要

クライアントダッシュボード（`clients/show`）に請求書処理カードリンクを追加。
PR #178 (issue#142) で実装された請求書PDF→仕訳変換機能への導線。

## 変更内容

- `clients/show.html.erb`: 請求書処理カードを追加（銀行明細処理と清掃マニュアルの間）
- `clients_spec.rb`: 「請求書処理」リンクの表示テストを追加

## テスト方法

```bash
make test ARGS="spec/requests/web/clients_spec.rb"
```

## チェックリスト

- [x] テスト追加
- [x] 既存テスト全パス

Closes #183