### PR TITLE
feat(platform): クライアント管理CRUD機能を実装 (issue#187)

### DIFF
--- a/rails/platform/app/controllers/clients_controller.rb
+++ b/rails/platform/app/controllers/clients_controller.rb
@@ -9,7 +9,47 @@ class ClientsController < ApplicationController
     @client = Client.find_by!(code: params[:id])
   end
 
+  def new
+    @client = Client.new(status: "active")
+  end
+
+  def create
+    @client = Client.new(create_params)
+    if @client.save
+      redirect_to client_path(@client), notice: "クライアントを作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @client = Client.find_by!(code: params[:id])
+  end
+
+  def update
+    @client = Client.find_by!(code: params[:id])
+    if @client.update(update_params)
+      redirect_to client_path(@client), notice: "クライアントを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @client = Client.find_by!(code: params[:id])
+    @client.update!(status: "inactive")
+    redirect_to clients_path, notice: "クライアントを無効化しました"
+  end
+
   private
+
+  def create_params
+    params.require(:client).permit(:code, :name, :industry, :status)
+  end
+
+  def update_params
+    params.require(:client).permit(:name, :industry, :status)
+  end
 
   def record_not_found
     redirect_to clients_path, alert: "クライアントが見つかりません"

--- a/rails/platform/app/views/clients/_form.html.erb
+++ b/rails/platform/app/views/clients/_form.html.erb
@@ -1,0 +1,54 @@
+<% if @client.errors.any? %>
+  <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+    <ul class="list-disc list-inside text-red-800 text-sm">
+      <% @client.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with(model: @client, class: "space-y-6") do |f| %>
+  <div class="bg-white shadow rounded-lg p-6">
+    <div class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">コード</label>
+        <% if @client.persisted? %>
+          <p class="px-3 py-2 bg-gray-100 rounded-md text-sm font-mono text-gray-700"><%= @client.code %></p>
+        <% else %>
+          <%= f.text_field :code, placeholder: "例: ikigai_stay",
+                class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+        <% end %>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">名前</label>
+        <%= f.text_field :name, placeholder: "例: イキガイステイ",
+              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">業種</label>
+        <%= f.select :industry,
+              [["飲食業", "restaurant"], ["ホテル", "hotel"], ["ツアー", "tour"]],
+              { include_blank: "-- 選択してください --" },
+              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
+        <%= f.select :status,
+              [["Active", "active"], ["Trial", "trial"], ["Inactive", "inactive"]],
+              {},
+              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex justify-end gap-4">
+    <%= link_to "キャンセル", (@client.persisted? ? client_path(@client) : clients_path),
+          class: "bg-gray-200 text-gray-700 px-6 py-2 rounded-md hover:bg-gray-300 transition-colors" %>
+    <%= f.submit (@client.persisted? ? "更新" : "作成"),
+          class: "bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 transition-colors cursor-pointer" %>
+  </div>
+<% end %>

--- a/rails/platform/app/views/clients/edit.html.erb
+++ b/rails/platform/app/views/clients/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:title) { "#{@client.name} を編集" } %>
+
+<div class="w-full max-w-4xl mx-auto px-4">
+  <div class="mb-4 text-sm text-gray-500">
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>編集</span>
+  </div>
+
+  <h1 class="text-2xl font-bold mb-6"><%= @client.name %> を編集</h1>
+
+  <%= render "form" %>
+</div>

--- a/rails/platform/app/views/clients/index.html.erb
+++ b/rails/platform/app/views/clients/index.html.erb
@@ -1,7 +1,11 @@
 <% content_for(:title) { "クライアント一覧" } %>
 
 <div class="w-full mx-auto px-4">
-  <h1 class="text-2xl font-bold mb-6">クライアント一覧</h1>
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">クライアント一覧</h1>
+    <%= link_to "新規クライアント作成", new_client_path,
+          class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors text-sm" %>
+  </div>
 
   <form method="get" class="mb-6 flex flex-wrap gap-4 items-end">
     <div>

--- a/rails/platform/app/views/clients/new.html.erb
+++ b/rails/platform/app/views/clients/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for(:title) { "新規クライアント作成" } %>
+
+<div class="w-full max-w-4xl mx-auto px-4">
+  <div class="mb-4 text-sm text-gray-500">
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>新規作成</span>
+  </div>
+
+  <h1 class="text-2xl font-bold mb-6">新規クライアント作成</h1>
+
+  <%= render "form" %>
+</div>

--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -20,6 +20,13 @@
         <% elsif @client.status == "trial" %>
           <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Trial</span>
         <% end %>
+        <%= link_to "編集", edit_client_path(@client),
+              class: "bg-gray-200 text-gray-700 px-3 py-1.5 rounded-md hover:bg-gray-300 transition-colors text-sm" %>
+        <% if @client.status != "inactive" %>
+          <%= button_to "無効化", client_path(@client), method: :delete,
+                form: { data: { turbo_confirm: "「#{@client.name}」を無効化しますか？この操作によりクライアントは一覧から非表示になります。" } },
+                class: "bg-red-600 text-white px-3 py-1.5 rounded-md hover:bg-red-700 transition-colors text-sm" %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/rails/platform/config/routes.rb
+++ b/rails/platform/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
   end
 
   # Web UI
-  resources :clients, only: [ :index, :show ]
+  resources :clients
   resources :cleaning_manuals, only: [ :index, :show, :new ]
   resources :amex_statements, only: [ :new ]
   resources :bank_statements, only: [ :new ]

--- a/rails/platform/spec/requests/web/clients_spec.rb
+++ b/rails/platform/spec/requests/web/clients_spec.rb
@@ -87,6 +87,165 @@ RSpec.describe "Web::Clients", type: :request do
     end
   end
 
+  describe "GET /clients/new (new)" do
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        get new_client_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "200を返すこと" do
+        get new_client_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "フォームが表示されること" do
+        get new_client_path
+        expect(response.body).to include("新規クライアント作成")
+      end
+    end
+  end
+
+  describe "POST /clients (create)" do
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        post clients_path, params: { client: { code: "new_client", name: "新規社" } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "正常なパラメータで作成できること" do
+        expect {
+          post clients_path, params: { client: { code: "new_client", name: "新規社", industry: "hotel", status: "active" } }
+        }.to change(Client, :count).by(1)
+
+        client = Client.find_by(code: "new_client")
+        expect(response).to redirect_to(client_path(client))
+        expect(client.name).to eq("新規社")
+        expect(client.industry).to eq("hotel")
+        expect(client.status).to eq("active")
+      end
+
+      it "バリデーションエラー時にフォームが再表示されること" do
+        post clients_path, params: { client: { code: "", name: "" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("新規クライアント作成")
+      end
+
+      it "code重複時にエラーが表示されること" do
+        create(:client, code: "existing")
+        post clients_path, params: { client: { code: "existing", name: "重複社", status: "active" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "GET /clients/:code/edit (edit)" do
+    let!(:client) { create(:client, code: "edit_target", name: "編集対象社") }
+
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        get edit_client_path(client)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "200を返すこと" do
+        get edit_client_path(client)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "編集フォームが表示されること" do
+        get edit_client_path(client)
+        expect(response.body).to include("編集対象社")
+        expect(response.body).to include("を編集")
+      end
+
+      it "存在しないコードの場合リダイレクトすること" do
+        get edit_client_path(id: "nonexistent")
+        expect(response).to redirect_to(clients_path)
+      end
+    end
+  end
+
+  describe "PATCH /clients/:code (update)" do
+    let!(:client) { create(:client, code: "update_target", name: "更新前社") }
+
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        patch client_path(client), params: { client: { name: "更新後社" } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "正常に更新できること" do
+        patch client_path(client), params: { client: { name: "更新後社", industry: "tour" } }
+        expect(response).to redirect_to(client_path(client))
+        client.reload
+        expect(client.name).to eq("更新後社")
+        expect(client.industry).to eq("tour")
+      end
+
+      it "codeが変更されないこと" do
+        patch client_path(client), params: { client: { code: "hacked_code", name: "更新後社" } }
+        client.reload
+        expect(client.code).to eq("update_target")
+      end
+
+      it "バリデーションエラー時にフォームが再表示されること" do
+        patch client_path(client), params: { client: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("を編集")
+      end
+    end
+  end
+
+  describe "DELETE /clients/:code (destroy)" do
+    let!(:client) { create(:client, code: "delete_target", name: "削除対象社", status: "active") }
+
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        delete client_path(client)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "論理削除されること（statusがinactiveに変更）" do
+        delete client_path(client)
+        expect(response).to redirect_to(clients_path)
+        client.reload
+        expect(client.status).to eq("inactive")
+      end
+
+      it "物理削除されないこと" do
+        expect {
+          delete client_path(client)
+        }.not_to change(Client, :count)
+      end
+
+      it "フラッシュメッセージが表示されること" do
+        delete client_path(client)
+        expect(flash[:notice]).to eq("クライアントを無効化しました")
+      end
+    end
+  end
+
   describe "GET / (root)" do
     context "認証済みの場合" do
       before { sign_in user }


### PR DESCRIPTION
## 概要

issue#187 のクライアント管理CRUD機能を実装しました。Web UIからクライアントの作成・編集・無効化が可能になります。

## 変更内容

- `config/routes.rb`: `resources :clients` に変更（全アクション有効化）
- `clients_controller.rb`: `new`, `create`, `edit`, `update`, `destroy` アクション追加
- `_form.html.erb`: new/edit 共有フォームパーシャル（新規）
- `new.html.erb`: 新規作成ページ（新規）
- `edit.html.erb`: 編集ページ（新規）
- `index.html.erb`: 「新規クライアント作成」ボタン追加
- `show.html.erb`: 「編集」「無効化」ボタン追加
- `spec/requests/web/clients_spec.rb`: CRUDテスト19件追加

### 設計ポイント

- `code` は作成時のみ入力可、編集時は表示のみ（`update_params` で除外）
- `destroy` は物理削除ではなく `status: "inactive"` に変更（論理削除）
- 無効化ボタンは `turbo_confirm` で確認ダイアログ付き
- 既存の Tailwind CSS パターンに準拠（`journal_entries/edit.html.erb` 参考）

## テスト方法

```bash
make test ARGS="spec/requests/web/clients_spec.rb"
```

ブラウザ確認:
1. http://localhost:3000 → クライアント一覧 → 「新規クライアント作成」ボタン
2. フォームで新規クライアント作成 → show にリダイレクト
3. ダッシュボードから「編集」→ 更新確認
4. 「無効化」→ 確認ダイアログ → 一覧から非表示確認

## チェックリスト

- [x] テスト追加（19件、全347テストパス）
- [x] 既存の Tailwind CSS パターン準拠
- [x] Strong Parameters でマスアサインメント防止
- [x] code 編集不可（URLパラメータとして使用されるため）
- [x] セキュリティチェック（CSRF保護、認証必須）

Closes #187