### PR TITLE
chore(infra): Makefileからinclude .env.developmentを削除 (issue#190)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 # LandBase AI Suite Development Lifecycle Automation
 # Mattermost + n8n + Rails 8 + Next.js 15 + Flutter 3 + PostgreSQL
 
-include .env.development
-export
-
 # Colors for output
 YELLOW := \033[1;33m
 GREEN := \033[1;32m
@@ -34,7 +31,7 @@ logs: ## 全サービスのログ表示
 
 .PHONY: postgres-shell
 postgres-shell: ## PostgreSQLシェル接続
-	docker compose -f compose.development.yaml --env-file .env.development exec db-suite psql -U ${POSTGRES_USER} -d ${POSTGRES_DB}
+	docker compose -f compose.development.yaml --env-file .env.development exec db-suite bash -c 'psql -U $$POSTGRES_USER -d $$POSTGRES_DB'
 
 .PHONY: clean
 clean: ## クリーンアップ（コンテナ・ボリューム・プロジェクトイメージ削除）


### PR DESCRIPTION
## 概要
Makefileの `include .env.development` / `export` を削除し、環境変数ファイルへの暗黙的な依存を解消する。

## 変更内容
- `include .env.development` と `export` を削除
- `postgres-shell` ターゲットをコンテナ内環境変数参照方式に変更（`bash -c 'psql -U $$POSTGRES_USER -d $$POSTGRES_DB'`）

## テスト方法
```bash
make up
make postgres-shell  # PostgreSQLシェルに接続できることを確認
make down
```

## チェックリスト
- [x] `include .env.development` と `export` がMakefileから削除されている
- [x] `make postgres-shell` が修正前と同じくPostgreSQLシェルに接続できる
- [x] 他の全ターゲット（up, down, logs, clean, test等）に影響なし

Closes #190