### PR TITLE
fix(docs): Claude Codeスキルのディレクトリ構造をSKILL.md形式に修正 (issue#206)

### DIFF
--- a/.claude/skills/amex-statement-processor/SKILL.md
+++ b/.claude/skills/amex-statement-processor/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: amex-statement-processor
+description: Amex明細PDFを仕訳データに変換します
+---
+
 # Amex 明細 PDF → 仕訳台帳変換スキル
 
 ## メタデータ

--- a/.claude/skills/bank-statement-processor/SKILL.md
+++ b/.claude/skills/bank-statement-processor/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: bank-statement-processor
+description: 銀行明細PDFを仕訳データに変換します
+---
+
 # 銀行明細 PDF → 仕訳台帳変換スキル
 
 ## メタデータ

--- a/.claude/skills/cleaning-manual-generator/SKILL.md
+++ b/.claude/skills/cleaning-manual-generator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cleaning-manual-generator
+description: 客室写真から清掃マニュアルを生成します
+---
+
 # 清掃マニュアル自動生成スキル
 
 宿泊施設の室内完成画像から、清掃マニュアルを構造化JSONで自動生成します。

--- a/.claude/skills/invoice-generator/SKILL.md
+++ b/.claude/skills/invoice-generator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: invoice-generator
+description: クライアントへの請求書HTMLを生成します
+---
+
 # 請求書HTML生成スキル
 
 クライアントへの請求書HTMLを生成します。ブラウザの印刷機能でPDF化する運用です。

--- a/.claude/skills/invoice-processor/SKILL.md
+++ b/.claude/skills/invoice-processor/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: invoice-processor
+description: 請求書PDFを仕訳データに変換します
+---
+
 # 請求書 PDF → 仕訳台帳変換スキル
 
 ## メタデータ


### PR DESCRIPTION
## 概要
全5スキルをClaude Codeが認識する正しいディレクトリ構造（`<skill-name>/SKILL.md`）に修正し、YAML frontmatterを追加。

## 変更内容
- 5スキルのファイル構造を `*.md` → `*/SKILL.md` に変更
- 各 `SKILL.md` にYAML frontmatter（`name`, `description`）を追加
- スキル本文は変更なし

### 対象スキル
| スキル | コマンド |
|---|---|
| 請求書HTML生成 | `/invoice-generator` |
| 請求書PDF→仕訳変換 | `/invoice-processor` |
| Amex明細PDF→仕訳変換 | `/amex-statement-processor` |
| 銀行明細PDF→仕訳変換 | `/bank-statement-processor` |
| 清掃マニュアル生成 | `/cleaning-manual-generator` |

## テスト方法
```bash
# リポジトリで claude を起動し、スキルが認識されることを確認
claude
# /invoice-generator 等のコマンドが呼び出せることを確認
```

## チェックリスト
- [x] 全5スキルがディレクトリ + SKILL.md 構造になっている
- [x] 全スキルにYAML frontmatter定義済み
- [x] Claude Codeのsystem-reminderで全スキル認識を確認済み

Closes #206