### PR TITLE
fix(docs): 請求書HTMLの印刷用CSSをA4一枚に収まるよう調整 (issue#207)

### DIFF
--- a/docs/templates/invoice/template.html
+++ b/docs/templates/invoice/template.html
@@ -294,14 +294,119 @@
       }
 
       @media print {
+        @page {
+          size: A4;
+          margin: 10mm;
+        }
+
         body {
           background: white;
           padding: 0;
+          font-size: 11px;
         }
 
         .container {
           box-shadow: none;
-          padding: 0;
+          padding: 10px 20px;
+          line-height: 1.4;
+        }
+
+        .header {
+          margin-bottom: 20px;
+          padding-bottom: 10px;
+        }
+
+        .logo-section img {
+          max-width: 120px;
+        }
+
+        .title-section h1 {
+          font-size: 26px;
+        }
+
+        .content {
+          gap: 20px;
+          margin-bottom: 20px;
+        }
+
+        .section-title {
+          font-size: 11px;
+          margin-bottom: 6px;
+          padding-bottom: 4px;
+        }
+
+        .company-info,
+        .client-info {
+          font-size: 11px;
+          line-height: 1.5;
+        }
+
+        .client-name {
+          font-size: 15px;
+        }
+
+        .dates {
+          margin-bottom: 20px;
+          padding: 10px 16px;
+          gap: 10px;
+        }
+
+        .date-item {
+          font-size: 11px;
+        }
+
+        .items-table {
+          margin-bottom: 20px;
+        }
+
+        .items-table th {
+          padding: 6px 10px;
+          font-size: 11px;
+        }
+
+        .items-table td {
+          padding: 8px 10px;
+          font-size: 11px;
+        }
+
+        .subtotal-row td,
+        .tax-row td {
+          padding: 6px 10px;
+        }
+
+        .total-row td {
+          padding: 8px 10px;
+        }
+
+        .summary-section {
+          margin-bottom: 20px;
+          gap: 20px;
+        }
+
+        .bank-info {
+          font-size: 11px;
+          padding: 10px;
+        }
+
+        .terms {
+          font-size: 10px;
+          margin-top: 10px;
+        }
+
+        .total-amount {
+          font-size: 22px;
+          margin-bottom: 10px;
+        }
+
+        .contact-info {
+          font-size: 10px;
+          padding: 10px;
+          margin-top: 10px;
+        }
+
+        .footer {
+          padding-top: 10px;
+          font-size: 10px;
         }
 
         .print-button {


### PR DESCRIPTION
## 概要
請求書HTMLをブラウザで印刷/PDF保存した際に2ページになる問題を修正。`@media print` セクションを拡充しA4用紙1ページに収まるよう調整。

## 変更内容
- `@page` でA4サイズ・余白10mmを指定
- 印刷時のフォントサイズ・行間を縮小
- 各セクションのmargin/padding/gapを縮小
- 画面表示時のデザインには影響なし

## テスト方法
```bash
open docs/templates/invoice/template.html
# ブラウザで Cmd+P → 印刷プレビューでA4一枚に収まることを確認
```

## チェックリスト
- [x] 印刷時にA4用紙1ページに収まることを確認
- [x] 画面表示に影響がないことを確認

Closes #207