### PR TITLE
fix(platform): YayoiExportServiceをjournal_entry_lines参照に修正

### DIFF
--- a/rails/platform/app/services/yayoi_export_service.rb
+++ b/rails/platform/app/services/yayoi_export_service.rb
@@ -5,6 +5,8 @@ class YayoiExportService
   SINGLE_TYPE = "0"
 
   def export_single_entry(entries)
+    entries = entries.includes(:journal_entry_lines) if entries.respond_to?(:includes)
+
     csv_string = CSV.generate do |csv|
       entries.each do |entry|
         csv << build_row(entry)
@@ -23,19 +25,19 @@ class YayoiExportService
     [
       SINGLE_ENTRY_FLAG,                       # 1: 識別フラグ
       entry.date.strftime("%Y/%m/%d"),         # 2: 取引日
-      debit&.account || "",                    # 3: 借方勘定科目
-      debit&.sub_account.presence || "",       # 4: 借方補助科目
-      debit&.department.presence || "",        # 5: 借方部門
-      debit&.partner.presence || "",           # 6: 借方取引先
-      debit&.tax_category.presence || "",      # 7: 借方税区分
-      debit&.invoice.presence || "",           # 8: 借方インボイス
+      debit&.account || "",                     # 3: 借方勘定科目
+      debit&.sub_account&.presence || "",      # 4: 借方補助科目
+      debit&.department&.presence || "",       # 5: 借方部門
+      debit&.partner&.presence || "",          # 6: 借方取引先
+      debit&.tax_category&.presence || "",     # 7: 借方税区分
+      debit&.invoice&.presence || "",          # 8: 借方インボイス
       debit&.amount || 0,                      # 9: 借方金額
       credit&.account || "",                   # 10: 貸方勘定科目
-      credit&.sub_account.presence || "",      # 11: 貸方補助科目
-      credit&.department.presence || "",       # 12: 貸方部門
-      credit&.partner.presence || "",          # 13: 貸方取引先
-      credit&.tax_category.presence || "",     # 14: 貸方税区分
-      credit&.invoice.presence || "",          # 15: 貸方インボイス
+      credit&.sub_account&.presence || "",     # 11: 貸方補助科目
+      credit&.department&.presence || "",      # 12: 貸方部門
+      credit&.partner&.presence || "",         # 13: 貸方取引先
+      credit&.tax_category&.presence || "",    # 14: 貸方税区分
+      credit&.invoice&.presence || "",         # 15: 貸方インボイス
       credit&.amount || 0,                     # 16: 貸方金額
       entry.description.presence || "",        # 17: 摘要
       entry.tag.presence || "",                # 18: タグ


### PR DESCRIPTION
Closes #223

## Summary
- `YayoiExportService#build_row` がレガシーカラム（`entry.debit_account` 等）を直接参照していたのを、`journal_entry_lines` 経由（`entry.debit_lines.first&.account` 等）に修正
- `JournalEntry#to_csv` や各Job（Amex/Bank/Invoice）と同じパターンに統一
- N+1クエリ防止のため `includes(:journal_entry_lines)` を追加
- safe navigation演算子を統一（`debit&.sub_account&.presence`）

## Test plan
- [x] `make test` 全381件パス（修正前は2件失敗していたYayoi関連テストも修正後はパス）