### PR TITLE
feat(platform): ヘッダーナビゲーション改善・ブレッドクラム統一 (issue#229)

### DIFF
--- a/rails/platform/app/controllers/invoices_controller.rb
+++ b/rails/platform/app/controllers/invoices_controller.rb
@@ -1,4 +1,5 @@
 class InvoicesController < ApplicationController
   def new
+    @client = Client.find_by(code: params[:client_code])
   end
 end

--- a/rails/platform/app/views/amex_statements/new.html.erb
+++ b/rails/platform/app/views/amex_statements/new.html.erb
@@ -1,15 +1,16 @@
 <% content_for(:title) { "Amex明細PDF処理" } %>
 
-<div class="w-full max-w-4xl mx-auto" data-controller="pdf-upload">
-  <% if @client %>
-    <div class="mb-4 text-sm text-gray-500">
-      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <span>Amex明細処理</span>
-    </div>
+<% if @client %>
+  <% content_for(:breadcrumb) do %>
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>Amex明細処理</span>
   <% end %>
+<% end %>
+
+<div class="w-full max-w-4xl mx-auto" data-controller="pdf-upload">
 
   <h1 class="text-2xl font-bold mb-6">Amex明細PDF → 仕訳台帳変換</h1>
 

--- a/rails/platform/app/views/amex_statements/new.html.erb
+++ b/rails/platform/app/views/amex_statements/new.html.erb
@@ -11,7 +11,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto" data-controller="pdf-upload">
-
   <h1 class="text-2xl font-bold mb-6">Amex明細PDF → 仕訳台帳変換</h1>
 
   <form data-pdf-upload-target="form" data-action="submit->pdf-upload#submit" class="space-y-6">

--- a/rails/platform/app/views/bank_statements/new.html.erb
+++ b/rails/platform/app/views/bank_statements/new.html.erb
@@ -11,7 +11,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto" data-controller="bank-pdf-upload">
-
   <h1 class="text-2xl font-bold mb-6">銀行明細PDF → 仕訳台帳変換</h1>
 
   <form data-bank-pdf-upload-target="form" data-action="submit->bank-pdf-upload#submit" class="space-y-6">

--- a/rails/platform/app/views/bank_statements/new.html.erb
+++ b/rails/platform/app/views/bank_statements/new.html.erb
@@ -1,15 +1,16 @@
 <% content_for(:title) { "銀行明細PDF処理" } %>
 
-<div class="w-full max-w-4xl mx-auto" data-controller="bank-pdf-upload">
-  <% if @client %>
-    <div class="mb-4 text-sm text-gray-500">
-      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <span>銀行明細処理</span>
-    </div>
+<% if @client %>
+  <% content_for(:breadcrumb) do %>
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>銀行明細処理</span>
   <% end %>
+<% end %>
+
+<div class="w-full max-w-4xl mx-auto" data-controller="bank-pdf-upload">
 
   <h1 class="text-2xl font-bold mb-6">銀行明細PDF → 仕訳台帳変換</h1>
 

--- a/rails/platform/app/views/cleaning_manuals/index.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/index.html.erb
@@ -11,7 +11,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto">
-
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">清掃マニュアル一覧</h1>
     <%= link_to "新規作成", new_cleaning_manual_path, class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors" %>

--- a/rails/platform/app/views/cleaning_manuals/index.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/index.html.erb
@@ -1,15 +1,16 @@
 <% content_for(:title) { "清掃マニュアル一覧" } %>
 
-<div class="w-full max-w-4xl mx-auto">
-  <% if @client %>
-    <div class="mb-4 text-sm text-gray-500">
-      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <span>清掃マニュアル</span>
-    </div>
+<% if @client %>
+  <% content_for(:breadcrumb) do %>
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>清掃マニュアル</span>
   <% end %>
+<% end %>
+
+<div class="w-full max-w-4xl mx-auto">
 
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">清掃マニュアル一覧</h1>

--- a/rails/platform/app/views/cleaning_manuals/new.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/new.html.erb
@@ -11,7 +11,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto" data-controller="image-upload">
-
   <h1 class="text-2xl font-bold mb-6">清掃マニュアル自動生成</h1>
 
   <form data-image-upload-target="form" data-action="submit->image-upload#submit" class="space-y-6">

--- a/rails/platform/app/views/cleaning_manuals/new.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/new.html.erb
@@ -1,15 +1,16 @@
 <% content_for(:title) { "清掃マニュアル生成" } %>
 
-<div class="w-full max-w-4xl mx-auto" data-controller="image-upload">
-  <% if @client %>
-    <div class="mb-4 text-sm text-gray-500">
-      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <span>清掃マニュアル生成</span>
-    </div>
+<% if @client %>
+  <% content_for(:breadcrumb) do %>
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>清掃マニュアル生成</span>
   <% end %>
+<% end %>
+
+<div class="w-full max-w-4xl mx-auto" data-controller="image-upload">
 
   <h1 class="text-2xl font-bold mb-6">清掃マニュアル自動生成</h1>
 

--- a/rails/platform/app/views/cleaning_manuals/show.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/show.html.erb
@@ -1,21 +1,26 @@
 <% content_for(:title) { "#{@manual.property_name} - 清掃マニュアル" } %>
 
-<div class="w-full max-w-4xl mx-auto">
-  <% if @client %>
-    <div class="mb-4 text-sm text-gray-500">
-      <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <%= link_to "清掃マニュアル", cleaning_manuals_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
-      <span class="mx-1">/</span>
-      <span><%= @manual.property_name %></span>
-    </div>
-  <% else %>
-    <div class="mb-6">
-      <%= link_to "← 一覧に戻る", cleaning_manuals_path(client_code: @manual.client.code), class: "text-blue-600 hover:text-blue-800 text-sm" %>
-    </div>
+<% if @client %>
+  <% content_for(:breadcrumb) do %>
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to "清掃マニュアル", cleaning_manuals_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span><%= @manual.property_name %></span>
   <% end %>
+<% else %>
+  <% content_for(:breadcrumb) do %>
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to "清掃マニュアル", cleaning_manuals_path(client_code: @manual.client.code), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span><%= @manual.property_name %></span>
+  <% end %>
+<% end %>
+
+<div class="w-full max-w-4xl mx-auto">
 
   <div class="flex items-center justify-between mb-6">
     <div>

--- a/rails/platform/app/views/cleaning_manuals/show.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/show.html.erb
@@ -21,7 +21,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto">
-
   <div class="flex items-center justify-between mb-6">
     <div>
       <h1 class="text-2xl font-bold"><%= @manual.property_name %></h1>

--- a/rails/platform/app/views/clients/edit.html.erb
+++ b/rails/platform/app/views/clients/edit.html.erb
@@ -1,13 +1,14 @@
 <% content_for(:title) { "#{@client.name} を編集" } %>
 
+<% content_for(:breadcrumb) do %>
+  <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <span>編集</span>
+<% end %>
+
 <div class="w-full max-w-4xl mx-auto px-4">
-  <div class="mb-4 text-sm text-gray-500">
-    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <span>編集</span>
-  </div>
 
   <h1 class="text-2xl font-bold mb-6"><%= @client.name %> を編集</h1>
 

--- a/rails/platform/app/views/clients/edit.html.erb
+++ b/rails/platform/app/views/clients/edit.html.erb
@@ -9,7 +9,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto px-4">
-
   <h1 class="text-2xl font-bold mb-6"><%= @client.name %> を編集</h1>
 
   <%= render "form" %>

--- a/rails/platform/app/views/clients/new.html.erb
+++ b/rails/platform/app/views/clients/new.html.erb
@@ -7,7 +7,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto px-4">
-
   <h1 class="text-2xl font-bold mb-6">新規クライアント作成</h1>
 
   <%= render "form" %>

--- a/rails/platform/app/views/clients/new.html.erb
+++ b/rails/platform/app/views/clients/new.html.erb
@@ -1,11 +1,12 @@
 <% content_for(:title) { "新規クライアント作成" } %>
 
+<% content_for(:breadcrumb) do %>
+  <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <span>新規作成</span>
+<% end %>
+
 <div class="w-full max-w-4xl mx-auto px-4">
-  <div class="mb-4 text-sm text-gray-500">
-    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <span>新規作成</span>
-  </div>
 
   <h1 class="text-2xl font-bold mb-6">新規クライアント作成</h1>
 

--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -1,9 +1,12 @@
 <% content_for(:title) { @client.name } %>
 
+<% content_for(:breadcrumb) do %>
+  <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <span><%= @client.name %></span>
+<% end %>
+
 <div class="w-full max-w-4xl mx-auto px-4">
-  <div class="mb-6">
-    <%= link_to "← クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800 text-sm" %>
-  </div>
 
   <div class="bg-white shadow rounded-lg p-6 mb-8">
     <div class="flex items-center justify-between">

--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -7,7 +7,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto px-4">
-
   <div class="bg-white shadow rounded-lg p-6 mb-8">
     <div class="flex items-center justify-between">
       <div>

--- a/rails/platform/app/views/invoices/new.html.erb
+++ b/rails/platform/app/views/invoices/new.html.erb
@@ -1,5 +1,15 @@
 <% content_for(:title) { "請求書PDF処理" } %>
 
+<% if @client %>
+  <% content_for(:breadcrumb) do %>
+    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+    <span class="mx-1">/</span>
+    <span>請求書処理</span>
+  <% end %>
+<% end %>
+
 <div class="w-full max-w-4xl mx-auto" data-controller="invoice-pdf-upload">
   <h1 class="text-2xl font-bold mb-6">請求書PDF → 仕訳台帳変換</h1>
 

--- a/rails/platform/app/views/journal_entries/edit.html.erb
+++ b/rails/platform/app/views/journal_entries/edit.html.erb
@@ -15,7 +15,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto">
-
   <h1 class="text-2xl font-bold mb-6">仕訳編集 #<%= @entry.transaction_no %></h1>
 
   <% if @entry.errors.any? %>

--- a/rails/platform/app/views/journal_entries/edit.html.erb
+++ b/rails/platform/app/views/journal_entries/edit.html.erb
@@ -2,18 +2,19 @@
 <% debit = @entry.debit_lines.first %>
 <% credit = @entry.credit_lines.first %>
 
+<% content_for(:breadcrumb) do %>
+  <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <%= link_to "仕訳一覧", journal_entries_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <%= link_to "##{@entry.transaction_no}", journal_entry_path(@entry, client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <span>編集</span>
+<% end %>
+
 <div class="w-full max-w-4xl mx-auto">
-  <div class="mb-4 text-sm text-gray-500">
-    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <%= link_to "仕訳一覧", journal_entries_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <%= link_to "##{@entry.transaction_no}", journal_entry_path(@entry, client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <span>編集</span>
-  </div>
 
   <h1 class="text-2xl font-bold mb-6">仕訳編集 #<%= @entry.transaction_no %></h1>
 

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -1,13 +1,14 @@
 <% content_for(:title) { "仕訳一覧 - #{@client.name}" } %>
 
+<% content_for(:breadcrumb) do %>
+  <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <span>仕訳一覧</span>
+<% end %>
+
 <div class="w-full mx-auto px-4">
-  <div class="mb-4 text-sm text-gray-500">
-    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <span>仕訳一覧</span>
-  </div>
 
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">仕訳一覧</h1>

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -9,7 +9,6 @@
 <% end %>
 
 <div class="w-full mx-auto px-4">
-
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">仕訳一覧</h1>
     <div class="flex gap-2">

--- a/rails/platform/app/views/journal_entries/show.html.erb
+++ b/rails/platform/app/views/journal_entries/show.html.erb
@@ -11,7 +11,6 @@
 <% end %>
 
 <div class="w-full max-w-4xl mx-auto">
-
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">仕訳詳細 #<%= @entry.transaction_no %></h1>
     <div class="flex items-center gap-3">

--- a/rails/platform/app/views/journal_entries/show.html.erb
+++ b/rails/platform/app/views/journal_entries/show.html.erb
@@ -1,15 +1,16 @@
 <% content_for(:title) { "仕訳詳細 ##{@entry.transaction_no}" } %>
 
+<% content_for(:breadcrumb) do %>
+  <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <%= link_to "仕訳一覧", journal_entries_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+  <span class="mx-1">/</span>
+  <span>#<%= @entry.transaction_no %></span>
+<% end %>
+
 <div class="w-full max-w-4xl mx-auto">
-  <div class="mb-4 text-sm text-gray-500">
-    <%= link_to "クライアント一覧", clients_path, class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <%= link_to @client.name, client_path(@client), class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <%= link_to "仕訳一覧", journal_entries_path(client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
-    <span class="mx-1">/</span>
-    <span>#<%= @entry.transaction_no %></span>
-  </div>
 
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">仕訳詳細 #<%= @entry.transaction_no %></h1>

--- a/rails/platform/app/views/layouts/application.html.erb
+++ b/rails/platform/app/views/layouts/application.html.erb
@@ -27,7 +27,10 @@
       <nav class="bg-white border-b border-gray-200 fixed w-full z-10 top-0">
         <div class="container mx-auto px-5 py-3 flex items-center justify-between">
           <%= link_to "LandBase Platform", root_path, class: "font-semibold text-gray-800 hover:text-gray-600 transition-colors" %>
-          <div class="flex items-center gap-4">
+          <div class="flex items-center gap-6">
+            <% nav_active = controller_name == "clients" && action_name == "index" %>
+            <%= link_to "クライアント一覧", clients_path,
+                  class: "text-sm transition-colors #{nav_active ? 'text-blue-600 font-semibold border-b-2 border-blue-600 pb-1' : 'text-gray-600 hover:text-gray-800'}" %>
             <span class="text-sm text-gray-600"><%= current_user.email %></span>
             <%= button_to "ログアウト", destroy_user_session_path, method: :delete,
                 class: "text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-1 rounded transition" %>
@@ -53,8 +56,15 @@
     <% end %>
 
     <% if user_signed_in? %>
-      <main class="container mx-auto mt-20 px-5 flex">
-        <%= yield %>
+      <main class="container mx-auto mt-20 px-5 flex flex-col">
+        <% if content_for?(:breadcrumb) %>
+          <nav class="mb-4 text-sm text-gray-500" aria-label="パンくずリスト">
+            <%= yield :breadcrumb %>
+          </nav>
+        <% end %>
+        <div class="flex">
+          <%= yield %>
+        </div>
       </main>
     <% else %>
       <%= yield %>

--- a/rails/platform/app/views/layouts/application.html.erb
+++ b/rails/platform/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
             <%= yield :breadcrumb %>
           </nav>
         <% end %>
-        <div class="flex">
+        <div class="flex w-full">
           <%= yield %>
         </div>
       </main>


### PR DESCRIPTION
## 概要
ヘッダーにクライアント一覧リンクを追加し、全ページのブレッドクラムを`content_for(:breadcrumb)`パターンで共通化。

## 変更内容
- ヘッダーに「クライアント一覧」ナビリンク追加（アクティブ表示対応）
- レイアウトに`content_for(:breadcrumb)`表示エリア追加（`aria-label`付き）
- 全11ビューのインラインブレッドクラムを`content_for`パターンに統一
- `invoices/new`の欠落していたブレッドクラムを追加（コントローラに`@client`セットも追加）

## 既知の問題（本PR対象外）
- `invoices/new.html.erb` のクライアントコード入力欄に `value="<%= params[:client_code] %>"` がなく、プリフィルされない（他のPDF処理画面では設定済み）。別issueで対応予定。

## テスト方法
```bash
make test
```
- 409 examples, 0 failures

## チェックリスト
- [x] テスト合格
- [x] 全ページにブレッドクラム表示
- [x] ブレッドクラム共通化
- [x] ヘッダーナビリンク追加

Closes #229