### PR TITLE
fix(platform): 請求書画面のクライアントコードプリフィルを追加 (issue#234)

### DIFF
--- a/rails/platform/app/views/invoices/new.html.erb
+++ b/rails/platform/app/views/invoices/new.html.erb
@@ -7,6 +7,7 @@
     <div>
       <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
       <input type="text" name="client_code" id="client_code" required
+             value="<%= params[:client_code] %>"
              class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
              data-invoice-pdf-upload-target="clientCode">
     </div>


### PR DESCRIPTION
## 概要
`invoices/new.html.erb` のクライアントコード入力欄に `value` 属性を追加し、クライアント詳細画面からの遷移時にプリフィルされるよう修正。

## 変更内容
- `invoices/new.html.erb` の `client_code` input に `value="<%= params[:client_code] %>"` を追加

## テスト方法
```bash
make test
```
- 409 examples, 0 failures

## チェックリスト
- [x] テスト合格
- [x] 他のPDF処理画面と挙動統一

Closes #234