### PR TITLE
fix(platform): クライアントステータスの日本語化統一 (issue#231)

### DIFF
--- a/rails/platform/app/models/client.rb
+++ b/rails/platform/app/models/client.rb
@@ -1,4 +1,11 @@
 class Client < ApplicationRecord
+  # === 定数 ===
+  STATUSES = {
+    "active" => "有効",
+    "trial" => "トライアル",
+    "inactive" => "無効"
+  }.freeze
+
   # === 関連 ===
   has_many :journal_entries, dependent: :restrict_with_error
   has_many :account_masters, dependent: :restrict_with_error
@@ -8,7 +15,7 @@ class Client < ApplicationRecord
   # === バリデーション ===
   validates :code, presence: true, uniqueness: true
   validates :name, presence: true
-  validates :status, inclusion: { in: %w[active trial inactive] }
+  validates :status, inclusion: { in: STATUSES.keys }
   validates :industry, inclusion: { in: %w[restaurant hotel tour] }, allow_nil: true
 
   # === スコープ ===
@@ -25,5 +32,9 @@ class Client < ApplicationRecord
 
   def to_param
     code
+  end
+
+  def status_label
+    STATUSES[status]
   end
 end

--- a/rails/platform/app/views/clients/_form.html.erb
+++ b/rails/platform/app/views/clients/_form.html.erb
@@ -38,7 +38,7 @@
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
         <%= f.select :status,
-              [["Active", "active"], ["Trial", "trial"], ["Inactive", "inactive"]],
+              Client::STATUSES.map { |value, label| [label, value] },
               {},
               class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
       </div>

--- a/rails/platform/app/views/clients/index.html.erb
+++ b/rails/platform/app/views/clients/index.html.erb
@@ -43,9 +43,9 @@
               <td class="px-6 py-4 text-sm text-gray-500"><%= client.industry.presence || "—" %></td>
               <td class="px-6 py-4">
                 <% if client.status == "active" %>
-                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"><%= client.status_label %></span>
                 <% elsif client.status == "trial" %>
-                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Trial</span>
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"><%= client.status_label %></span>
                 <% end %>
               </td>
             </tr>

--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -16,9 +16,9 @@
           <span class="text-sm text-gray-600"><%= @client.industry %></span>
         <% end %>
         <% if @client.status == "active" %>
-          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"><%= @client.status_label %></span>
         <% elsif @client.status == "trial" %>
-          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Trial</span>
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"><%= @client.status_label %></span>
         <% end %>
         <%= link_to "編集", edit_client_path(@client),
               class: "bg-gray-200 text-gray-700 px-3 py-1.5 rounded-md hover:bg-gray-300 transition-colors text-sm" %>

--- a/rails/platform/spec/models/client_spec.rb
+++ b/rails/platform/spec/models/client_spec.rb
@@ -74,6 +74,26 @@ RSpec.describe Client, type: :model do
     end
   end
 
+  describe "#status_label" do
+    it "activeは「有効」を返す" do
+      expect(build(:client, status: "active").status_label).to eq("有効")
+    end
+
+    it "trialは「トライアル」を返す" do
+      expect(build(:client, status: "trial").status_label).to eq("トライアル")
+    end
+
+    it "inactiveは「無効」を返す" do
+      expect(build(:client, status: "inactive").status_label).to eq("無効")
+    end
+  end
+
+  describe "STATUSES" do
+    it "全ステータスが定義されている" do
+      expect(Client::STATUSES.keys).to contain_exactly("active", "trial", "inactive")
+    end
+  end
+
   describe "スコープ" do
     describe ".active" do
       it "activeステータスのクライアントのみ取得する" do


### PR DESCRIPTION
## 概要
画面上で英語表示されていたクライアントステータス（Active/Trial）を日本語（有効/トライアル）に統一し、`Client::STATUSES`定数で一元管理。

## 変更内容
- `Client::STATUSES`定数追加、`status_label`メソッド追加
- バリデーションを`STATUSES.keys`参照に変更
- index/showのバッジ表示を日本語化
- フォームのセレクトボックスを定数から生成
- RSpec 4件追加（`status_label`、`STATUSES`）

## テスト方法
```bash
make test
```
- 413 examples, 0 failures

## チェックリスト
- [x] テスト合格
- [x] 全画面で日本語ラベル統一
- [x] 定数で一元管理

Closes #231