### PR TITLE
feat(platform): 証憑処理を別タブで実行しメインUIの操作性を確保 (issue#198)

### DIFF
--- a/rails/platform/app/controllers/statement_batches_controller.rb
+++ b/rails/platform/app/controllers/statement_batches_controller.rb
@@ -1,0 +1,15 @@
+class StatementBatchesController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  def show
+    @batch = StatementBatch.find(params[:id])
+    @client = @batch.client || raise(ActiveRecord::RecordNotFound)
+    @sidebar_client = @client
+  end
+
+  private
+
+  def record_not_found
+    redirect_to clients_path, alert: "処理バッチが見つかりません"
+  end
+end

--- a/rails/platform/app/javascript/controllers/bank_pdf_upload_controller.js
+++ b/rails/platform/app/javascript/controllers/bank_pdf_upload_controller.js
@@ -2,23 +2,5 @@ import BasePdfUploadController from "controllers/base_pdf_upload_controller"
 
 export default class extends BasePdfUploadController {
   get uploadUrl() { return "/api/v1/bank_statements/process_statement" }
-  get statusUrlPrefix() { return "/api/v1/bank_statements" }
   get sourceType() { return "bank" }
-
-  renderSummaryCards(summary, _data) {
-    let html = ""
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-blue-600">${this.escapeHTML(String(summary.total_transactions || 0))}</p>`
-    html += `<p class="text-sm text-gray-500">取引件数</p></div>`
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-red-600">${this.escapeHTML(String((summary.total_withdrawals || 0).toLocaleString()))}円</p>`
-    html += `<p class="text-sm text-gray-500">出金合計</p></div>`
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-green-600">${this.escapeHTML(String((summary.total_deposits || 0).toLocaleString()))}円</p>`
-    html += `<p class="text-sm text-gray-500">入金合計</p></div>`
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-yellow-600">${this.escapeHTML(String(summary.review_required_count || 0))}</p>`
-    html += `<p class="text-sm text-gray-500">要確認</p></div>`
-    return html
-  }
 }

--- a/rails/platform/app/javascript/controllers/base_pdf_upload_controller.js
+++ b/rails/platform/app/javascript/controllers/base_pdf_upload_controller.js
@@ -4,12 +4,11 @@ export default class extends Controller {
   static targets = [
     "form", "dropZone", "fileInput", "fileName",
     "submitButton", "loading", "error", "errorMessage",
-    "result", "resultContent", "clientCode"
+    "clientCode"
   ]
 
   // --- サブクラスでオーバーライド ---
   get uploadUrl() { throw new Error("implement uploadUrl in subclass") }
-  get statusUrlPrefix() { throw new Error("implement statusUrlPrefix in subclass") }
   get sourceType() { throw new Error("implement sourceType in subclass") }
   get documentLabel() { return "明細" }
 
@@ -86,9 +85,10 @@ export default class extends Controller {
     }
 
     this.hideError()
-    this.hideResult()
     this.showLoading()
     this.submitButtonTarget.disabled = true
+
+    const progressTab = window.open("about:blank", "_blank")
 
     const formData = new FormData()
     formData.append("pdf", this.file)
@@ -105,6 +105,7 @@ export default class extends Controller {
       const data = await response.json()
 
       if (response.status === 409 && data.duplicate) {
+        this.closeTab(progressTab)
         this.hideLoading()
         this.submitButtonTarget.disabled = false
         if (confirm(`この${this.documentLabel}は既に処理済みです。再処理しますか？`)) {
@@ -114,14 +115,17 @@ export default class extends Controller {
       }
 
       if (!response.ok) {
+        this.closeTab(progressTab)
         this.showError(data.error || `${this.documentLabel}の処理に失敗しました。`)
         this.hideLoading()
         this.submitButtonTarget.disabled = false
         return
       }
 
-      await this.pollStatus(data.id, clientCode)
+      this.openProgressTab(progressTab, data.id)
+      this.resetForm()
     } catch (error) {
+      this.closeTab(progressTab)
       this.showError(`通信エラー: ${error.message}`)
     } finally {
       this.hideLoading()
@@ -133,8 +137,8 @@ export default class extends Controller {
     this.showLoading()
     this.submitButtonTarget.disabled = true
 
+    const progressTab = window.open("about:blank", "_blank")
     formData.append("force", "true")
-    const clientCode = formData.get("client_code")
 
     try {
       const response = await fetch(this.uploadUrl, {
@@ -148,12 +152,15 @@ export default class extends Controller {
       const data = await response.json()
 
       if (!response.ok) {
+        this.closeTab(progressTab)
         this.showError(data.error || `${this.documentLabel}の処理に失敗しました。`)
         return
       }
 
-      await this.pollStatus(data.id, clientCode)
+      this.openProgressTab(progressTab, data.id)
+      this.resetForm()
     } catch (error) {
+      this.closeTab(progressTab)
       this.showError(`通信エラー: ${error.message}`)
     } finally {
       this.hideLoading()
@@ -161,34 +168,26 @@ export default class extends Controller {
     }
   }
 
-  async pollStatus(batchId, clientCode) {
-    const POLL_INTERVAL = 3000
-    const MAX_POLLS = 300
-
-    for (let i = 0; i < MAX_POLLS; i++) {
-      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL))
-
-      try {
-        const response = await fetch(
-          `${this.statusUrlPrefix}/${batchId}/status?client_code=${encodeURIComponent(clientCode)}`
-        )
-        const data = await response.json()
-
-        if (data.status === "completed") {
-          this.showResult(data, clientCode)
-          return
-        }
-
-        if (data.status === "failed") {
-          this.showError(data.error_message || `${this.documentLabel}の処理に失敗しました。`)
-          return
-        }
-      } catch (error) {
-        console.warn("Polling error:", error.message)
-      }
+  openProgressTab(tab, batchId) {
+    const url = `/statement_batches/${batchId}`
+    if (tab) {
+      tab.location.href = url
+    } else {
+      window.location.href = url
     }
+  }
 
-    this.showError("処理がタイムアウトしました。しばらく待ってからページを再読み込みしてください。")
+  closeTab(tab) {
+    if (tab) tab.close()
+  }
+
+  resetForm() {
+    this.file = null
+    this.fileInputTarget.value = ""
+    this.fileNameTarget.textContent = ""
+    this.fileNameTarget.classList.add("hidden")
+    this.submitButtonTarget.disabled = true
+    this.hideError()
   }
 
   showLoading() {
@@ -206,50 +205,5 @@ export default class extends Controller {
 
   hideError() {
     this.errorTarget.classList.add("hidden")
-  }
-
-  showResult(data, clientCode) {
-    this.resultTarget.classList.remove("hidden")
-    const summary = data.summary || {}
-
-    let html = `<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">`
-    html += this.renderSummaryCards(summary, data)
-    html += `</div>`
-
-    html += `<div class="flex gap-4">`
-    html += `<a href="/journal_entries?client_code=${encodeURIComponent(clientCode)}&source_type=${this.sourceType}" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors">仕訳一覧を確認</a>`
-    html += `<a href="/api/v1/journal_entries/export?client_code=${encodeURIComponent(clientCode)}&statement_batch_id=${data.id}" class="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 transition-colors">CSVダウンロード</a>`
-    html += `</div>`
-
-    this.resultContentTarget.innerHTML = html
-  }
-
-  renderSummaryCards(summary, data) {
-    let html = ""
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-blue-600">${this.escapeHTML(String(summary.total_transactions || 0))}</p>`
-    html += `<p class="text-sm text-gray-500">取引件数</p></div>`
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-blue-600">${this.escapeHTML(String((summary.total_amount || 0).toLocaleString()))}円</p>`
-    html += `<p class="text-sm text-gray-500">合計金額</p></div>`
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-yellow-600">${this.escapeHTML(String(summary.review_required_count || 0))}</p>`
-    html += `<p class="text-sm text-gray-500">要確認</p></div>`
-    html += `<div class="bg-white shadow rounded-lg p-4 text-center">`
-    html += `<p class="text-2xl font-bold text-green-600">${this.escapeHTML(String(data.journal_entries_count || 0))}</p>`
-    html += `<p class="text-sm text-gray-500">仕訳登録数</p></div>`
-    return html
-  }
-
-  hideResult() {
-    this.resultTarget.classList.add("hidden")
-    this.resultContentTarget.innerHTML = ""
-  }
-
-  escapeHTML(str) {
-    if (!str) return ""
-    const div = document.createElement("div")
-    div.textContent = str
-    return div.innerHTML
   }
 }

--- a/rails/platform/app/javascript/controllers/batch_progress_controller.js
+++ b/rails/platform/app/javascript/controllers/batch_progress_controller.js
@@ -1,0 +1,129 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["loading", "error", "errorMessage", "result", "resultContent"]
+  static values = {
+    batchId: Number,
+    sourceType: String,
+    clientCode: String,
+    statusUrl: String,
+    status: String
+  }
+
+  connect() {
+    this.pollCount = 0
+    this.maxPolls = 300
+    this.pollInterval = 3000
+
+    if (!this.statusUrlValue) return
+
+    if (this.statusValue === "completed") {
+      this.fetchAndShowResult()
+    } else if (this.statusValue === "processing") {
+      this.startPolling()
+    }
+  }
+
+  disconnect() {
+    this.stopPolling()
+  }
+
+  startPolling() {
+    this.timer = setInterval(() => this.poll(), this.pollInterval)
+  }
+
+  stopPolling() {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  async poll() {
+    this.pollCount++
+    if (this.pollCount > this.maxPolls) {
+      this.stopPolling()
+      this.showError("処理がタイムアウトしました。しばらく待ってからページを再読み込みしてください。")
+      return
+    }
+
+    try {
+      const response = await fetch(this.statusUrlValue)
+      const data = await response.json()
+
+      if (data.status === "completed") {
+        this.stopPolling()
+        this.showResult(data)
+        return
+      }
+
+      if (data.status === "failed") {
+        this.stopPolling()
+        this.showError(data.error_message || "処理に失敗しました。")
+        return
+      }
+    } catch (error) {
+      console.warn("Polling error:", error.message)
+    }
+  }
+
+  async fetchAndShowResult() {
+    try {
+      const response = await fetch(this.statusUrlValue)
+      const data = await response.json()
+      this.showResult(data)
+    } catch (error) {
+      console.warn("Fetch error:", error.message)
+    }
+  }
+
+  showError(message) {
+    this.loadingTarget.classList.add("hidden")
+    this.errorMessageTarget.textContent = message
+    this.errorTarget.classList.remove("hidden")
+  }
+
+  showResult(data) {
+    this.loadingTarget.classList.add("hidden")
+    this.resultTarget.classList.remove("hidden")
+
+    const summary = data.summary || {}
+    const clientCode = this.clientCodeValue
+    const sourceType = this.sourceTypeValue
+    let html = ""
+
+    html += `<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">`
+    html += this.statCard(String(summary.total_transactions || 0), "取引件数", "text-blue-600")
+
+    if (sourceType === "bank") {
+      html += this.statCard(String((summary.total_withdrawals || 0).toLocaleString()) + "円", "出金合計", "text-red-600")
+      html += this.statCard(String((summary.total_deposits || 0).toLocaleString()) + "円", "入金合計", "text-green-600")
+    } else {
+      html += this.statCard(String((summary.total_amount || 0).toLocaleString()) + "円", "合計金額", "text-blue-600")
+      html += this.statCard(String(data.journal_entries_count || 0), "仕訳登録数", "text-green-600")
+    }
+
+    html += this.statCard(String(summary.review_required_count || 0), "要確認", "text-yellow-600")
+    html += `</div>`
+
+    html += `<div class="flex gap-4">`
+    html += `<a href="/journal_entries?client_code=${encodeURIComponent(clientCode)}&source_type=${encodeURIComponent(sourceType)}" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors">仕訳一覧を確認</a>`
+    html += `<a href="/api/v1/journal_entries/export?client_code=${encodeURIComponent(clientCode)}&statement_batch_id=${data.id}" class="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 transition-colors">CSVダウンロード</a>`
+    html += `</div>`
+
+    this.resultContentTarget.innerHTML = html
+  }
+
+  statCard(value, label, colorClass) {
+    return `<div class="bg-white shadow rounded-lg p-4 text-center">` +
+      `<p class="text-2xl font-bold ${colorClass}">${this.escapeHTML(value)}</p>` +
+      `<p class="text-sm text-gray-500">${this.escapeHTML(label)}</p></div>`
+  }
+
+  escapeHTML(str) {
+    if (!str) return ""
+    const div = document.createElement("div")
+    div.textContent = str
+    return div.innerHTML
+  }
+}

--- a/rails/platform/app/javascript/controllers/invoice_pdf_upload_controller.js
+++ b/rails/platform/app/javascript/controllers/invoice_pdf_upload_controller.js
@@ -2,7 +2,6 @@ import BasePdfUploadController from "controllers/base_pdf_upload_controller"
 
 export default class extends BasePdfUploadController {
   get uploadUrl() { return "/api/v1/invoices/process_statement" }
-  get statusUrlPrefix() { return "/api/v1/invoices" }
   get sourceType() { return "invoice" }
   get documentLabel() { return "請求書" }
 }

--- a/rails/platform/app/javascript/controllers/pdf_upload_controller.js
+++ b/rails/platform/app/javascript/controllers/pdf_upload_controller.js
@@ -2,6 +2,5 @@ import BasePdfUploadController from "controllers/base_pdf_upload_controller"
 
 export default class extends BasePdfUploadController {
   get uploadUrl() { return "/api/v1/amex_statements/process_statement" }
-  get statusUrlPrefix() { return "/api/v1/amex_statements" }
   get sourceType() { return "amex" }
 }

--- a/rails/platform/app/views/amex_statements/new.html.erb
+++ b/rails/platform/app/views/amex_statements/new.html.erb
@@ -47,22 +47,11 @@
   <!-- ローディング -->
   <div data-pdf-upload-target="loading" class="hidden mt-8 text-center">
     <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    <p class="mt-2 text-gray-600">AIが明細PDFを解析し、仕訳データを生成しています...</p>
-    <p class="text-sm text-gray-400">PDF のページ数によっては数分かかることがあります</p>
+    <p class="mt-2 text-gray-600">アップロード中...</p>
   </div>
 
   <!-- エラー表示 -->
   <div data-pdf-upload-target="error" class="hidden mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
     <p class="text-red-800" data-pdf-upload-target="errorMessage"></p>
-  </div>
-
-  <!-- 結果表示 -->
-  <div data-pdf-upload-target="result" class="hidden mt-8 space-y-6">
-    <div class="bg-green-50 border border-green-200 rounded-lg p-4">
-      <p class="text-green-800 font-medium">明細の処理が完了しました</p>
-    </div>
-
-    <div data-pdf-upload-target="resultContent">
-    </div>
   </div>
 </div>

--- a/rails/platform/app/views/bank_statements/new.html.erb
+++ b/rails/platform/app/views/bank_statements/new.html.erb
@@ -47,22 +47,11 @@
   <!-- ローディング -->
   <div data-bank-pdf-upload-target="loading" class="hidden mt-8 text-center">
     <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    <p class="mt-2 text-gray-600">AIが銀行明細PDFを解析し、仕訳データを生成しています...</p>
-    <p class="text-sm text-gray-400">PDF のページ数によっては数分かかることがあります</p>
+    <p class="mt-2 text-gray-600">アップロード中...</p>
   </div>
 
   <!-- エラー表示 -->
   <div data-bank-pdf-upload-target="error" class="hidden mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
     <p class="text-red-800" data-bank-pdf-upload-target="errorMessage"></p>
-  </div>
-
-  <!-- 結果表示 -->
-  <div data-bank-pdf-upload-target="result" class="hidden mt-8 space-y-6">
-    <div class="bg-green-50 border border-green-200 rounded-lg p-4">
-      <p class="text-green-800 font-medium">明細の処理が完了しました</p>
-    </div>
-
-    <div data-bank-pdf-upload-target="resultContent">
-    </div>
   </div>
 </div>

--- a/rails/platform/app/views/invoices/new.html.erb
+++ b/rails/platform/app/views/invoices/new.html.erb
@@ -47,22 +47,11 @@
   <!-- ローディング -->
   <div data-invoice-pdf-upload-target="loading" class="hidden mt-8 text-center">
     <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    <p class="mt-2 text-gray-600">AIが請求書PDFを解析し、仕訳データを生成しています...</p>
-    <p class="text-sm text-gray-400">PDF のページ数によっては数分かかることがあります</p>
+    <p class="mt-2 text-gray-600">アップロード中...</p>
   </div>
 
   <!-- エラー表示 -->
   <div data-invoice-pdf-upload-target="error" class="hidden mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
     <p class="text-red-800" data-invoice-pdf-upload-target="errorMessage"></p>
-  </div>
-
-  <!-- 結果表示 -->
-  <div data-invoice-pdf-upload-target="result" class="hidden mt-8 space-y-6">
-    <div class="bg-green-50 border border-green-200 rounded-lg p-4">
-      <p class="text-green-800 font-medium">請求書の処理が完了しました</p>
-    </div>
-
-    <div data-invoice-pdf-upload-target="resultContent">
-    </div>
   </div>
 </div>

--- a/rails/platform/app/views/statement_batches/show.html.erb
+++ b/rails/platform/app/views/statement_batches/show.html.erb
@@ -1,0 +1,48 @@
+<% source_labels = { "bank" => "銀行明細", "amex" => "Amex明細", "invoice" => "請求書", "receipt" => "領収書" } %>
+<% source_label = source_labels[@batch.source_type] || @batch.source_type %>
+<% content_for(:title) { "#{source_label}処理状況" } %>
+
+<%
+  status_paths = {
+    "bank"    => "bank_statements",
+    "amex"    => "amex_statements",
+    "invoice" => "invoices",
+    "receipt" => "receipts"
+  }
+  api_resource = status_paths[@batch.source_type]
+  status_url = api_resource ?
+    "/api/v1/#{api_resource}/#{@batch.id}/status?client_code=#{ERB::Util.url_encode(@client.code)}" :
+    nil
+%>
+
+<div class="w-full max-w-4xl mx-auto"
+     data-controller="batch-progress"
+     data-batch-progress-batch-id-value="<%= @batch.id %>"
+     data-batch-progress-source-type-value="<%= @batch.source_type %>"
+     data-batch-progress-client-code-value="<%= @client.code %>"
+     data-batch-progress-status-url-value="<%= status_url %>"
+     data-batch-progress-status-value="<%= @batch.status %>">
+
+  <h1 class="text-2xl font-bold mb-6"><%= source_label %>処理状況</h1>
+
+  <%# ローディング（処理中のみ表示） %>
+  <div data-batch-progress-target="loading" class="<%= @batch.status == 'processing' ? '' : 'hidden' %> mt-8 text-center">
+    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+    <p class="mt-2 text-gray-600">AIが<%= source_label %>を解析し、仕訳データを生成しています...</p>
+    <p class="text-sm text-gray-400">PDFのページ数によっては数分かかることがあります</p>
+  </div>
+
+  <%# エラー表示 %>
+  <div data-batch-progress-target="error" class="<%= @batch.status == 'failed' ? '' : 'hidden' %> mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
+    <p class="text-red-800" data-batch-progress-target="errorMessage"><%= @batch.error_message if @batch.status == 'failed' %></p>
+  </div>
+
+  <%# 結果表示 %>
+  <div data-batch-progress-target="result" class="<%= @batch.status == 'completed' ? '' : 'hidden' %> mt-8 space-y-6">
+    <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+      <p class="text-green-800 font-medium"><%= source_label %>の処理が完了しました</p>
+    </div>
+    <div data-batch-progress-target="resultContent">
+    </div>
+  </div>
+</div>

--- a/rails/platform/config/routes.rb
+++ b/rails/platform/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
   resources :amex_statements, only: [ :new ]
   resources :bank_statements, only: [ :new ]
   resources :invoices, only: [ :new ]
+  resources :statement_batches, only: [ :show ]
   resources :journal_entries, only: [ :index, :show, :edit, :update ] do
     collection do
       get :export


### PR DESCRIPTION
## Summary
- 証憑アップロード後のAI処理（ポーリング・結果表示）を別タブの処理状況ページ（`/statement_batches/:id`）に分離
- 元タブではフォームリセットして連続アップロードを可能に
- 銀行明細・Amex明細・請求書の3ソースすべてに適用

## 主な変更
- `StatementBatchesController#show` + 進捗ビュー新設
- `batch_progress_controller.js` — 進捗ページ用Stimulusコントローラ（ポーリング・結果表示）
- 3つのアップロードコントローラからポーリング/結果表示を削除し、`window.open`で別タブ遷移に変更
- ポップアップブロッカー対策: fetch前に空タブを開き、成功時にURL設定
- `receipt` ソースタイプのガード追加

## Test plan
- [x] RSpec 442 examples, 0 failures
- [x] 銀行明細PDFアップロード → 別タブで処理状況が表示される
- [x] Amex明細PDFアップロード → 同上
- [x] 請求書PDFアップロード → 同上
- [x] 元タブでフォームがリセットされ、続けてアップロード可能
- [x] 処理完了後に結果カード・リンクが正しく表示される
- [x] 処理済みバッチのURLに直接アクセスして結果が表示される

Closes #198