### PR TITLE
UIブランド表記をAI Suiteに変更 (issue#247)

### DIFF
--- a/rails/platform/app/views/devise/sessions/new.html.erb
+++ b/rails/platform/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen flex items-center justify-center bg-gray-50 px-4">
   <div class="w-full max-w-sm">
     <div class="text-center mb-8">
-      <h1 class="text-2xl font-bold text-gray-900">LandBase Platform</h1>
+      <h1 class="text-2xl font-bold text-gray-900">AI Suite</h1>
       <p class="text-sm text-gray-500 mt-1">サインインしてください</p>
     </div>
 

--- a/rails/platform/app/views/layouts/application.html.erb
+++ b/rails/platform/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
               </button>
             <% end %>
-            <%= link_to "LandBase Platform", root_path, class: "font-semibold text-gray-800 hover:text-gray-600 transition-colors" %>
+            <%= link_to "AI Suite", root_path, class: "font-semibold text-gray-800 hover:text-gray-600 transition-colors" %>
             <% if @sidebar_client %>
               <span class="text-gray-400">/</span>
               <%= link_to @sidebar_client.name, client_path(@sidebar_client), class: "text-sm text-gray-600 hover:text-gray-800 transition-colors" %>


### PR DESCRIPTION
## 概要

ログイン画面およびヘッダーナビゲーションのブランド表記を「LandBase Platform」から「AI Suite」に変更。

## 変更内容

- ログイン画面（`devise/sessions/new.html.erb`）のh1テキストを「AI Suite」に変更
- ヘッダーナビ（`layouts/application.html.erb`）のリンクテキストを「AI Suite」に変更

## テスト方法

```bash
make up
# ログイン画面とヘッダーで「AI Suite」表示を確認
```

## チェックリスト

- [x] UI上に「LandBase Platform」の表記が残っていないことを確認

Closes #247