### PR TITLE
feat(platform): PDF処理バッチサイズ動的最適化・リトライ改善 (issue#251)

### DIFF
--- a/rails/platform/app/jobs/amex_statement_process_job.rb
+++ b/rails/platform/app/jobs/amex_statement_process_job.rb
@@ -1,15 +1,14 @@
 class AmexStatementProcessJob < ApplicationJob
+  class RetryableError < StandardError; end
+
   queue_as :default
 
-  retry_on StandardError, wait: 5.seconds, attempts: 2
+  retry_on RetryableError, wait: 5.seconds, attempts: 2 do |job, exception|
+    batch = StatementBatch.find_by(id: job.arguments.first)
+    batch&.update(status: "failed", error_message: "リトライ上限到達: #{exception.message}")
+  end
 
   discard_on ActiveRecord::RecordNotFound
-
-  after_discard do |job, exception|
-    batch_id = job.arguments.first
-    batch = StatementBatch.find_by(id: batch_id)
-    batch&.update(status: "failed", error_message: "ジョブ実行エラー: #{exception.message}")
-  end
 
   def perform(statement_batch_id)
     batch = StatementBatch.find(statement_batch_id)
@@ -30,6 +29,8 @@ class AmexStatementProcessJob < ApplicationJob
           error_message: nil
         )
       end
+    elsif result.retryable?
+      raise RetryableError, result.error
     else
       batch.update!(status: "failed", error_message: result.error)
     end

--- a/rails/platform/app/jobs/amex_statement_process_job.rb
+++ b/rails/platform/app/jobs/amex_statement_process_job.rb
@@ -21,13 +21,17 @@ class AmexStatementProcessJob < ApplicationJob
     result = service.call
 
     if result.success?
-      ActiveRecord::Base.transaction do
-        create_journal_entries(batch, result.data)
-        batch.update!(
-          status: "completed",
-          summary: result.data[:summary] || {},
-          error_message: nil
-        )
+      begin
+        ActiveRecord::Base.transaction do
+          create_journal_entries(batch, result.data)
+          batch.update!(
+            status: "completed",
+            summary: result.data[:summary] || {},
+            error_message: nil
+          )
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/jobs/amex_statement_process_job.rb
+++ b/rails/platform/app/jobs/amex_statement_process_job.rb
@@ -31,7 +31,7 @@ class AmexStatementProcessJob < ApplicationJob
           )
         end
       rescue ActiveRecord::RecordInvalid => e
-        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
+        batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/jobs/bank_statement_process_job.rb
+++ b/rails/platform/app/jobs/bank_statement_process_job.rb
@@ -1,15 +1,14 @@
 class BankStatementProcessJob < ApplicationJob
+  class RetryableError < StandardError; end
+
   queue_as :default
 
-  retry_on StandardError, wait: 5.seconds, attempts: 2
+  retry_on RetryableError, wait: 5.seconds, attempts: 2 do |job, exception|
+    batch = StatementBatch.find_by(id: job.arguments.first)
+    batch&.update(status: "failed", error_message: "リトライ上限到達: #{exception.message}")
+  end
 
   discard_on ActiveRecord::RecordNotFound
-
-  after_discard do |job, exception|
-    batch_id = job.arguments.first
-    batch = StatementBatch.find_by(id: batch_id)
-    batch&.update(status: "failed", error_message: "ジョブ実行エラー: #{exception.message}")
-  end
 
   def perform(statement_batch_id)
     batch = StatementBatch.find(statement_batch_id)
@@ -30,6 +29,8 @@ class BankStatementProcessJob < ApplicationJob
           error_message: nil
         )
       end
+    elsif result.retryable?
+      raise RetryableError, result.error
     else
       batch.update!(status: "failed", error_message: result.error)
     end

--- a/rails/platform/app/jobs/bank_statement_process_job.rb
+++ b/rails/platform/app/jobs/bank_statement_process_job.rb
@@ -21,13 +21,17 @@ class BankStatementProcessJob < ApplicationJob
     result = service.call
 
     if result.success?
-      ActiveRecord::Base.transaction do
-        create_journal_entries(batch, result.data)
-        batch.update!(
-          status: "completed",
-          summary: result.data[:summary] || {},
-          error_message: nil
-        )
+      begin
+        ActiveRecord::Base.transaction do
+          create_journal_entries(batch, result.data)
+          batch.update!(
+            status: "completed",
+            summary: result.data[:summary] || {},
+            error_message: nil
+          )
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/jobs/bank_statement_process_job.rb
+++ b/rails/platform/app/jobs/bank_statement_process_job.rb
@@ -31,7 +31,7 @@ class BankStatementProcessJob < ApplicationJob
           )
         end
       rescue ActiveRecord::RecordInvalid => e
-        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
+        batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/jobs/invoice_process_job.rb
+++ b/rails/platform/app/jobs/invoice_process_job.rb
@@ -1,15 +1,14 @@
 class InvoiceProcessJob < ApplicationJob
+  class RetryableError < StandardError; end
+
   queue_as :default
 
-  retry_on StandardError, wait: 5.seconds, attempts: 2
+  retry_on RetryableError, wait: 5.seconds, attempts: 2 do |job, exception|
+    batch = StatementBatch.find_by(id: job.arguments.first)
+    batch&.update(status: "failed", error_message: "リトライ上限到達: #{exception.message}")
+  end
 
   discard_on ActiveRecord::RecordNotFound
-
-  after_discard do |job, exception|
-    batch_id = job.arguments.first
-    batch = StatementBatch.find_by(id: batch_id)
-    batch&.update(status: "failed", error_message: "ジョブ実行エラー: #{exception.message}")
-  end
 
   def perform(statement_batch_id)
     batch = StatementBatch.find(statement_batch_id)
@@ -30,6 +29,8 @@ class InvoiceProcessJob < ApplicationJob
           error_message: nil
         )
       end
+    elsif result.retryable?
+      raise RetryableError, result.error
     else
       batch.update!(status: "failed", error_message: result.error)
     end

--- a/rails/platform/app/jobs/invoice_process_job.rb
+++ b/rails/platform/app/jobs/invoice_process_job.rb
@@ -21,13 +21,17 @@ class InvoiceProcessJob < ApplicationJob
     result = service.call
 
     if result.success?
-      ActiveRecord::Base.transaction do
-        create_journal_entries(batch, result.data)
-        batch.update!(
-          status: "completed",
-          summary: result.data[:summary] || {},
-          error_message: nil
-        )
+      begin
+        ActiveRecord::Base.transaction do
+          create_journal_entries(batch, result.data)
+          batch.update!(
+            status: "completed",
+            summary: result.data[:summary] || {},
+            error_message: nil
+          )
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/jobs/invoice_process_job.rb
+++ b/rails/platform/app/jobs/invoice_process_job.rb
@@ -31,7 +31,7 @@ class InvoiceProcessJob < ApplicationJob
           )
         end
       rescue ActiveRecord::RecordInvalid => e
-        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
+        batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/jobs/receipt_process_job.rb
+++ b/rails/platform/app/jobs/receipt_process_job.rb
@@ -23,13 +23,17 @@ class ReceiptProcessJob < ApplicationJob
     result = service.call
 
     if result.success?
-      ActiveRecord::Base.transaction do
-        create_journal_entries(batch, result.data)
-        batch.update!(
-          status: "completed",
-          summary: result.data[:summary] || {},
-          error_message: nil
-        )
+      begin
+        ActiveRecord::Base.transaction do
+          create_journal_entries(batch, result.data)
+          batch.update!(
+            status: "completed",
+            summary: result.data[:summary] || {},
+            error_message: nil
+          )
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/jobs/receipt_process_job.rb
+++ b/rails/platform/app/jobs/receipt_process_job.rb
@@ -33,7 +33,7 @@ class ReceiptProcessJob < ApplicationJob
           )
         end
       rescue ActiveRecord::RecordInvalid => e
-        batch.update!(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
+        batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end
     elsif result.retryable?
       raise RetryableError, result.error

--- a/rails/platform/app/services/amex_statement_processor_service.rb
+++ b/rails/platform/app/services/amex_statement_processor_service.rb
@@ -1,11 +1,15 @@
 require "combine_pdf"
 
 class AmexStatementProcessorService
-  Result = Data.define(:success, :data, :error) do
+  NON_RETRYABLE_REASONS = %i[config_error].freeze
+
+  Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
+    def retryable? = !success && !NON_RETRYABLE_REASONS.include?(reason)
   end
 
-  MAX_PAGES_PER_BATCH = 5
+  INITIAL_BATCH_SIZE = 20
+  MIN_BATCH_SIZE = 5
 
   SYSTEM_PROMPT = <<~PROMPT
     あなたは日本の経理・簿記の専門家です。以下のルールに厳密に従い、Amex 利用明細 PDF から抽出した取引データを仕訳台帳データに変換してください。
@@ -161,38 +165,21 @@ class AmexStatementProcessorService
 
   def call
     unless ENV["ANTHROPIC_API_KEY"].present?
-      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません")
+      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません", reason: :config_error)
     end
 
     pdf_binary = read_pdf_binary
     account_master_context = build_account_master_context
     user_prompt = build_user_prompt(account_master_context)
-    page_count = count_pages(pdf_binary)
+    pages = parse_pdf_pages(pdf_binary)
 
-    if page_count <= MAX_PAGES_PER_BATCH
-      pdf_data = Base64.strict_encode64(pdf_binary)
-      process_single_pdf(pdf_data, user_prompt)
-    else
-      batches = split_pdf(pdf_binary)
-      batch_results = []
-
-      batches.each_with_index do |batch_pdf_binary, index|
-        batch_pdf_data = Base64.strict_encode64(batch_pdf_binary)
-        previous_transaction_count = batch_results.sum { |r| r[:transactions]&.size || 0 }
-        result = process_batch(batch_pdf_data, index, batches.size, page_count, user_prompt, previous_transaction_count)
-        return result unless result.success?
-        batch_results << result.data
-      end
-
-      merged_data = merge_batch_results(batch_results)
-      Result.new(success: true, data: merged_data, error: nil)
-    end
+    process_with_adaptive_batch_size(pages, user_prompt)
   rescue Anthropic::Errors::APIError => e
-    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e
-    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}", reason: :parse_error)
   rescue StandardError => e
-    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}", reason: :unexpected_error)
   end
 
   private
@@ -208,54 +195,76 @@ class AmexStatementProcessorService
     end
   end
 
-  def count_pages(pdf_binary)
-    pdf = CombinePDF.parse(pdf_binary)
-    pdf.pages.size
+  def parse_pdf_pages(pdf_binary)
+    CombinePDF.parse(pdf_binary).pages
   end
 
-  def split_pdf(pdf_binary)
-    pdf = CombinePDF.parse(pdf_binary)
-    pages = pdf.pages
-
-    pages.each_slice(MAX_PAGES_PER_BATCH).map do |page_group|
+  def build_batch_pdfs(pages, batch_size)
+    pages.each_slice(batch_size).map do |page_group|
       batch_pdf = CombinePDF.new
       page_group.each { |page| batch_pdf << page }
       batch_pdf.to_pdf
     end
   end
 
-  def process_single_pdf(pdf_data, user_prompt)
-    response = call_api(pdf_data, user_prompt)
+  def process_with_adaptive_batch_size(pages, user_prompt)
+    batch_size = [ INITIAL_BATCH_SIZE, pages.size ].min
 
-    if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
-      raise JSON::ParserError, "APIの応答がmax_tokensで切り詰められました。PDFのページ数が多すぎる可能性があります"
+    loop do
+      batch_pdfs = build_batch_pdfs(pages, batch_size)
+      batch_results = []
+      max_tokens_hit = false
+
+      batch_pdfs.each_with_index do |batch_pdf_binary, index|
+        batch_pdf_data = Base64.strict_encode64(batch_pdf_binary)
+        previous_transaction_count = batch_results.sum { |r| r[:transactions]&.size || 0 }
+
+        start_page = index * batch_size + 1
+        end_page = [ start_page + batch_size - 1, pages.size ].min
+
+        prompt = if batch_pdfs.size == 1
+          user_prompt
+        else
+          <<~CONTEXT
+            #{user_prompt}
+
+            【バッチ処理情報】
+            このPDFは全#{pages.size}ページ中のページ#{start_page}〜#{end_page}です（バッチ#{index + 1}/#{batch_pdfs.size}）。
+            前のバッチまでに#{previous_transaction_count}件の取引を処理済みです。transaction_noは#{previous_transaction_count + 1}から開始してください。
+            前のページからのカード会員情報がある場合は引き継いでください。
+          CONTEXT
+        end
+
+        response = call_api(batch_pdf_data, prompt)
+
+        if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
+          max_tokens_hit = true
+          break
+        end
+
+        data = parse_response(response)
+        batch_results << data
+      end
+
+      if max_tokens_hit
+        new_batch_size = batch_size / 2
+        if new_batch_size < MIN_BATCH_SIZE
+          return Result.new(
+            success: false, data: {}, reason: :api_error,
+            error: "バッチサイズ#{batch_size}でもmax_tokensに達しました。PDFのページあたりの情報量が多すぎます"
+          )
+        end
+        batch_size = new_batch_size
+        next
+      end
+
+      if batch_results.size == 1
+        return Result.new(success: true, data: batch_results.first, error: nil, reason: nil)
+      else
+        merged_data = merge_batch_results(batch_results)
+        return Result.new(success: true, data: merged_data, error: nil, reason: nil)
+      end
     end
-
-    data = parse_response(response)
-    Result.new(success: true, data: data, error: nil)
-  end
-
-  def process_batch(batch_pdf_data, batch_index, total_batches, total_pages, user_prompt, previous_transaction_count)
-    start_page = batch_index * MAX_PAGES_PER_BATCH + 1
-    end_page = [ start_page + MAX_PAGES_PER_BATCH - 1, total_pages ].min
-
-    batch_context = <<~CONTEXT
-      #{user_prompt}
-
-      【バッチ処理情報】
-      このPDFは全#{total_pages}ページ中のページ#{start_page}〜#{end_page}です（バッチ#{batch_index + 1}/#{total_batches}）。
-      前のバッチまでに#{previous_transaction_count}件の取引を処理済みです。transaction_noは#{previous_transaction_count + 1}から開始してください。
-      前のページからのカード会員情報がある場合は引き継いでください。
-    CONTEXT
-
-    response = call_api(batch_pdf_data, batch_context)
-
-    if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
-      raise JSON::ParserError, "バッチ#{batch_index + 1}/#{total_batches}でAPIの応答がmax_tokensで切り詰められました"
-    end
-
-    data = parse_response(response)
-    Result.new(success: true, data: data, error: nil)
   end
 
   def merge_batch_results(batch_results)

--- a/rails/platform/app/services/bank_statement_processor_service.rb
+++ b/rails/platform/app/services/bank_statement_processor_service.rb
@@ -1,11 +1,15 @@
 require "combine_pdf"
 
 class BankStatementProcessorService
-  Result = Data.define(:success, :data, :error) do
+  NON_RETRYABLE_REASONS = %i[config_error].freeze
+
+  Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
+    def retryable? = !success && !NON_RETRYABLE_REASONS.include?(reason)
   end
 
-  MAX_PAGES_PER_BATCH = 5
+  INITIAL_BATCH_SIZE = 20
+  MIN_BATCH_SIZE = 5
 
   SYSTEM_PROMPT = <<~PROMPT
     あなたは日本の経理・簿記の専門家です。以下のルールに厳密に従い、銀行入出金明細 PDF から抽出した取引データを仕訳台帳データに変換してください。
@@ -166,38 +170,21 @@ class BankStatementProcessorService
 
   def call
     unless ENV["ANTHROPIC_API_KEY"].present?
-      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません")
+      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません", reason: :config_error)
     end
 
     pdf_binary = read_pdf_binary
     account_master_context = build_account_master_context
     user_prompt = build_user_prompt(account_master_context)
-    page_count = count_pages(pdf_binary)
+    pages = parse_pdf_pages(pdf_binary)
 
-    if page_count <= MAX_PAGES_PER_BATCH
-      pdf_data = Base64.strict_encode64(pdf_binary)
-      process_single_pdf(pdf_data, user_prompt)
-    else
-      batches = split_pdf(pdf_binary)
-      batch_results = []
-
-      batches.each_with_index do |batch_pdf_binary, index|
-        batch_pdf_data = Base64.strict_encode64(batch_pdf_binary)
-        previous_transaction_count = batch_results.sum { |r| r[:transactions]&.size || 0 }
-        result = process_batch(batch_pdf_data, index, batches.size, page_count, user_prompt, previous_transaction_count)
-        return result unless result.success?
-        batch_results << result.data
-      end
-
-      merged_data = merge_batch_results(batch_results)
-      Result.new(success: true, data: merged_data, error: nil)
-    end
+    process_with_adaptive_batch_size(pages, user_prompt)
   rescue Anthropic::Errors::APIError => e
-    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e
-    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}", reason: :parse_error)
   rescue StandardError => e
-    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}", reason: :unexpected_error)
   end
 
   private
@@ -213,54 +200,76 @@ class BankStatementProcessorService
     end
   end
 
-  def count_pages(pdf_binary)
-    pdf = CombinePDF.parse(pdf_binary)
-    pdf.pages.size
+  def parse_pdf_pages(pdf_binary)
+    CombinePDF.parse(pdf_binary).pages
   end
 
-  def split_pdf(pdf_binary)
-    pdf = CombinePDF.parse(pdf_binary)
-    pages = pdf.pages
-
-    pages.each_slice(MAX_PAGES_PER_BATCH).map do |page_group|
+  def build_batch_pdfs(pages, batch_size)
+    pages.each_slice(batch_size).map do |page_group|
       batch_pdf = CombinePDF.new
       page_group.each { |page| batch_pdf << page }
       batch_pdf.to_pdf
     end
   end
 
-  def process_single_pdf(pdf_data, user_prompt)
-    response = call_api(pdf_data, user_prompt)
+  def process_with_adaptive_batch_size(pages, user_prompt)
+    batch_size = [ INITIAL_BATCH_SIZE, pages.size ].min
 
-    if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
-      raise JSON::ParserError, "APIの応答がmax_tokensで切り詰められました。PDFのページ数が多すぎる可能性があります"
+    loop do
+      batch_pdfs = build_batch_pdfs(pages, batch_size)
+      batch_results = []
+      max_tokens_hit = false
+
+      batch_pdfs.each_with_index do |batch_pdf_binary, index|
+        batch_pdf_data = Base64.strict_encode64(batch_pdf_binary)
+        previous_transaction_count = batch_results.sum { |r| r[:transactions]&.size || 0 }
+
+        start_page = index * batch_size + 1
+        end_page = [ start_page + batch_size - 1, pages.size ].min
+
+        prompt = if batch_pdfs.size == 1
+          user_prompt
+        else
+          <<~CONTEXT
+            #{user_prompt}
+
+            【バッチ処理情報】
+            このPDFは全#{pages.size}ページ中のページ#{start_page}〜#{end_page}です（バッチ#{index + 1}/#{batch_pdfs.size}）。
+            前のバッチまでに#{previous_transaction_count}件の取引を処理済みです。transaction_noは#{previous_transaction_count + 1}から開始してください。
+            前のページからの銀行名・支店名情報がある場合は引き継いでください。
+          CONTEXT
+        end
+
+        response = call_api(batch_pdf_data, prompt)
+
+        if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
+          max_tokens_hit = true
+          break
+        end
+
+        data = parse_response(response)
+        batch_results << data
+      end
+
+      if max_tokens_hit
+        new_batch_size = batch_size / 2
+        if new_batch_size < MIN_BATCH_SIZE
+          return Result.new(
+            success: false, data: {}, reason: :api_error,
+            error: "バッチサイズ#{batch_size}でもmax_tokensに達しました。PDFのページあたりの情報量が多すぎます"
+          )
+        end
+        batch_size = new_batch_size
+        next
+      end
+
+      if batch_results.size == 1
+        return Result.new(success: true, data: batch_results.first, error: nil, reason: nil)
+      else
+        merged_data = merge_batch_results(batch_results)
+        return Result.new(success: true, data: merged_data, error: nil, reason: nil)
+      end
     end
-
-    data = parse_response(response)
-    Result.new(success: true, data: data, error: nil)
-  end
-
-  def process_batch(batch_pdf_data, batch_index, total_batches, total_pages, user_prompt, previous_transaction_count)
-    start_page = batch_index * MAX_PAGES_PER_BATCH + 1
-    end_page = [ start_page + MAX_PAGES_PER_BATCH - 1, total_pages ].min
-
-    batch_context = <<~CONTEXT
-      #{user_prompt}
-
-      【バッチ処理情報】
-      このPDFは全#{total_pages}ページ中のページ#{start_page}〜#{end_page}です（バッチ#{batch_index + 1}/#{total_batches}）。
-      前のバッチまでに#{previous_transaction_count}件の取引を処理済みです。transaction_noは#{previous_transaction_count + 1}から開始してください。
-      前のページからの銀行名・支店名情報がある場合は引き継いでください。
-    CONTEXT
-
-    response = call_api(batch_pdf_data, batch_context)
-
-    if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
-      raise JSON::ParserError, "バッチ#{batch_index + 1}/#{total_batches}でAPIの応答がmax_tokensで切り詰められました"
-    end
-
-    data = parse_response(response)
-    Result.new(success: true, data: data, error: nil)
   end
 
   def merge_batch_results(batch_results)

--- a/rails/platform/app/services/invoice_processor_service.rb
+++ b/rails/platform/app/services/invoice_processor_service.rb
@@ -1,11 +1,15 @@
 require "combine_pdf"
 
 class InvoiceProcessorService
-  Result = Data.define(:success, :data, :error) do
+  NON_RETRYABLE_REASONS = %i[config_error].freeze
+
+  Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
+    def retryable? = !success && !NON_RETRYABLE_REASONS.include?(reason)
   end
 
-  MAX_PAGES_PER_BATCH = 5
+  INITIAL_BATCH_SIZE = 20
+  MIN_BATCH_SIZE = 5
 
   SYSTEM_PROMPT = <<~PROMPT
     あなたは日本の経理・簿記の専門家です。以下のルールに厳密に従い、請求書 PDF から抽出したデータを仕訳台帳データに変換してください。
@@ -166,38 +170,21 @@ class InvoiceProcessorService
 
   def call
     unless ENV["ANTHROPIC_API_KEY"].present?
-      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません")
+      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません", reason: :config_error)
     end
 
     pdf_binary = read_pdf_binary
     account_master_context = build_account_master_context
     user_prompt = build_user_prompt(account_master_context)
-    page_count = count_pages(pdf_binary)
+    pages = parse_pdf_pages(pdf_binary)
 
-    if page_count <= MAX_PAGES_PER_BATCH
-      pdf_data = Base64.strict_encode64(pdf_binary)
-      process_single_pdf(pdf_data, user_prompt)
-    else
-      batches = split_pdf(pdf_binary)
-      batch_results = []
-
-      batches.each_with_index do |batch_pdf_binary, index|
-        batch_pdf_data = Base64.strict_encode64(batch_pdf_binary)
-        previous_transaction_count = batch_results.sum { |r| r[:transactions]&.size || 0 }
-        result = process_batch(batch_pdf_data, index, batches.size, page_count, user_prompt, previous_transaction_count)
-        return result unless result.success?
-        batch_results << result.data
-      end
-
-      merged_data = merge_batch_results(batch_results)
-      Result.new(success: true, data: merged_data, error: nil)
-    end
+    process_with_adaptive_batch_size(pages, user_prompt)
   rescue Anthropic::Errors::APIError => e
-    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e
-    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}", reason: :parse_error)
   rescue StandardError => e
-    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}", reason: :unexpected_error)
   end
 
   private
@@ -213,53 +200,75 @@ class InvoiceProcessorService
     end
   end
 
-  def count_pages(pdf_binary)
-    pdf = CombinePDF.parse(pdf_binary)
-    pdf.pages.size
+  def parse_pdf_pages(pdf_binary)
+    CombinePDF.parse(pdf_binary).pages
   end
 
-  def split_pdf(pdf_binary)
-    pdf = CombinePDF.parse(pdf_binary)
-    pages = pdf.pages
-
-    pages.each_slice(MAX_PAGES_PER_BATCH).map do |page_group|
+  def build_batch_pdfs(pages, batch_size)
+    pages.each_slice(batch_size).map do |page_group|
       batch_pdf = CombinePDF.new
       page_group.each { |page| batch_pdf << page }
       batch_pdf.to_pdf
     end
   end
 
-  def process_single_pdf(pdf_data, user_prompt)
-    response = call_api(pdf_data, user_prompt)
+  def process_with_adaptive_batch_size(pages, user_prompt)
+    batch_size = [ INITIAL_BATCH_SIZE, pages.size ].min
 
-    if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
-      raise JSON::ParserError, "APIの応答がmax_tokensで切り詰められました。PDFのページ数が多すぎる可能性があります"
+    loop do
+      batch_pdfs = build_batch_pdfs(pages, batch_size)
+      batch_results = []
+      max_tokens_hit = false
+
+      batch_pdfs.each_with_index do |batch_pdf_binary, index|
+        batch_pdf_data = Base64.strict_encode64(batch_pdf_binary)
+        previous_transaction_count = batch_results.sum { |r| r[:transactions]&.size || 0 }
+
+        start_page = index * batch_size + 1
+        end_page = [ start_page + batch_size - 1, pages.size ].min
+
+        prompt = if batch_pdfs.size == 1
+          user_prompt
+        else
+          <<~CONTEXT
+            #{user_prompt}
+
+            【バッチ処理情報】
+            このPDFは全#{pages.size}ページ中のページ#{start_page}〜#{end_page}です（バッチ#{index + 1}/#{batch_pdfs.size}）。
+            前のバッチまでに#{previous_transaction_count}件の取引を処理済みです。transaction_noは#{previous_transaction_count + 1}から開始してください。
+          CONTEXT
+        end
+
+        response = call_api(batch_pdf_data, prompt)
+
+        if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
+          max_tokens_hit = true
+          break
+        end
+
+        data = parse_response(response)
+        batch_results << data
+      end
+
+      if max_tokens_hit
+        new_batch_size = batch_size / 2
+        if new_batch_size < MIN_BATCH_SIZE
+          return Result.new(
+            success: false, data: {}, reason: :api_error,
+            error: "バッチサイズ#{batch_size}でもmax_tokensに達しました。PDFのページあたりの情報量が多すぎます"
+          )
+        end
+        batch_size = new_batch_size
+        next
+      end
+
+      if batch_results.size == 1
+        return Result.new(success: true, data: batch_results.first, error: nil, reason: nil)
+      else
+        merged_data = merge_batch_results(batch_results)
+        return Result.new(success: true, data: merged_data, error: nil, reason: nil)
+      end
     end
-
-    data = parse_response(response)
-    Result.new(success: true, data: data, error: nil)
-  end
-
-  def process_batch(batch_pdf_data, batch_index, total_batches, total_pages, user_prompt, previous_transaction_count)
-    start_page = batch_index * MAX_PAGES_PER_BATCH + 1
-    end_page = [ start_page + MAX_PAGES_PER_BATCH - 1, total_pages ].min
-
-    batch_context = <<~CONTEXT
-      #{user_prompt}
-
-      【バッチ処理情報】
-      このPDFは全#{total_pages}ページ中のページ#{start_page}〜#{end_page}です（バッチ#{batch_index + 1}/#{total_batches}）。
-      前のバッチまでに#{previous_transaction_count}件の取引を処理済みです。transaction_noは#{previous_transaction_count + 1}から開始してください。
-    CONTEXT
-
-    response = call_api(batch_pdf_data, batch_context)
-
-    if response.respond_to?(:stop_reason) && response.stop_reason == "max_tokens"
-      raise JSON::ParserError, "バッチ#{batch_index + 1}/#{total_batches}でAPIの応答がmax_tokensで切り詰められました"
-    end
-
-    data = parse_response(response)
-    Result.new(success: true, data: data, error: nil)
   end
 
   def merge_batch_results(batch_results)

--- a/rails/platform/app/services/receipt_processor_service.rb
+++ b/rails/platform/app/services/receipt_processor_service.rb
@@ -1,5 +1,5 @@
 class ReceiptProcessorService
-  NON_RETRYABLE_REASONS = %i[non_receipt unsupported_format].freeze
+  NON_RETRYABLE_REASONS = %i[config_error non_receipt unsupported_format].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success

--- a/rails/platform/spec/jobs/amex_statement_process_job_spec.rb
+++ b/rails/platform/spec/jobs/amex_statement_process_job_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe AmexStatementProcessJob, type: :job do
     AmexStatementProcessorService::Result.new(
       success: true,
       data: mock_result_data,
-      error: nil
+      error: nil,
+      reason: nil
     )
   end
 
@@ -92,10 +93,32 @@ RSpec.describe AmexStatementProcessJob, type: :job do
     expect(credit.amount).to eq(3280)
   end
 
-  context "サービスが失敗した場合" do
+  context "retryableなエラーの場合" do
     let(:mock_result) do
       AmexStatementProcessorService::Result.new(
-        success: false, data: {}, error: "Anthropic API エラー: API key invalid"
+        success: false, data: {}, error: "Anthropic API エラー: timeout", reason: :api_error
+      )
+    end
+
+    it "RetryableErrorをraiseすること" do
+      job = described_class.new(batch.id)
+
+      expect { job.perform(batch.id) }.to raise_error(AmexStatementProcessJob::RetryableError, "Anthropic API エラー: timeout")
+    end
+
+    it "JournalEntryを作成しないこと" do
+      job = described_class.new(batch.id)
+
+      expect {
+        job.perform(batch.id) rescue nil
+      }.not_to change(JournalEntry, :count)
+    end
+  end
+
+  context "non-retryableなエラーの場合" do
+    let(:mock_result) do
+      AmexStatementProcessorService::Result.new(
+        success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません", reason: :config_error
       )
     end
 
@@ -104,7 +127,7 @@ RSpec.describe AmexStatementProcessJob, type: :job do
 
       batch.reload
       expect(batch.status).to eq("failed")
-      expect(batch.error_message).to eq("Anthropic API エラー: API key invalid")
+      expect(batch.error_message).to eq("ANTHROPIC_API_KEY が設定されていません")
     end
 
     it "JournalEntryを作成しないこと" do

--- a/rails/platform/spec/jobs/amex_statement_process_job_spec.rb
+++ b/rails/platform/spec/jobs/amex_statement_process_job_spec.rb
@@ -137,6 +137,40 @@ RSpec.describe AmexStatementProcessJob, type: :job do
     end
   end
 
+  context "仕訳データのバリデーションエラーの場合" do
+    let(:mock_result_data) do
+      {
+        statement_period: "2026年1月",
+        transactions: [
+          {
+            transaction_no: 1,
+            date: nil,
+            debit_account: nil,
+            debit_amount: 100,
+            credit_account: nil,
+            credit_amount: 100,
+            description: "テスト"
+          }
+        ],
+        summary: {}
+      }
+    end
+
+    it "ステータスをfailedに更新すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("failed")
+      expect(batch.error_message).to include("仕訳データの保存に失敗")
+    end
+
+    it "JournalEntryを作成しないこと" do
+      expect {
+        described_class.perform_now(batch.id)
+      }.not_to change(JournalEntry, :count)
+    end
+  end
+
   it "レコードが存在しない場合は静かに終了すること" do
     expect {
       described_class.perform_now(-1)

--- a/rails/platform/spec/jobs/bank_statement_process_job_spec.rb
+++ b/rails/platform/spec/jobs/bank_statement_process_job_spec.rb
@@ -138,6 +138,40 @@ RSpec.describe BankStatementProcessJob, type: :job do
     end
   end
 
+  context "仕訳データのバリデーションエラーの場合" do
+    let(:mock_result_data) do
+      {
+        statement_period: "2026年1月",
+        transactions: [
+          {
+            transaction_no: 1,
+            date: nil,
+            debit_account: nil,
+            debit_amount: 100,
+            credit_account: nil,
+            credit_amount: 100,
+            description: "テスト"
+          }
+        ],
+        summary: {}
+      }
+    end
+
+    it "ステータスをfailedに更新すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("failed")
+      expect(batch.error_message).to include("仕訳データの保存に失敗")
+    end
+
+    it "JournalEntryを作成しないこと" do
+      expect {
+        described_class.perform_now(batch.id)
+      }.not_to change(JournalEntry, :count)
+    end
+  end
+
   it "レコードが存在しない場合は静かに終了すること" do
     expect {
       described_class.perform_now(-1)

--- a/rails/platform/spec/jobs/bank_statement_process_job_spec.rb
+++ b/rails/platform/spec/jobs/bank_statement_process_job_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe BankStatementProcessJob, type: :job do
     BankStatementProcessorService::Result.new(
       success: true,
       data: mock_result_data,
-      error: nil
+      error: nil,
+      reason: nil
     )
   end
 
@@ -93,10 +94,32 @@ RSpec.describe BankStatementProcessJob, type: :job do
     expect(credit.amount).to eq(45000)
   end
 
-  context "サービスが失敗した場合" do
+  context "retryableなエラーの場合" do
     let(:mock_result) do
       BankStatementProcessorService::Result.new(
-        success: false, data: {}, error: "Anthropic API エラー: API key invalid"
+        success: false, data: {}, error: "Anthropic API エラー: timeout", reason: :api_error
+      )
+    end
+
+    it "RetryableErrorをraiseすること" do
+      job = described_class.new(batch.id)
+
+      expect { job.perform(batch.id) }.to raise_error(BankStatementProcessJob::RetryableError, "Anthropic API エラー: timeout")
+    end
+
+    it "JournalEntryを作成しないこと" do
+      job = described_class.new(batch.id)
+
+      expect {
+        job.perform(batch.id) rescue nil
+      }.not_to change(JournalEntry, :count)
+    end
+  end
+
+  context "non-retryableなエラーの場合" do
+    let(:mock_result) do
+      BankStatementProcessorService::Result.new(
+        success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません", reason: :config_error
       )
     end
 
@@ -105,7 +128,7 @@ RSpec.describe BankStatementProcessJob, type: :job do
 
       batch.reload
       expect(batch.status).to eq("failed")
-      expect(batch.error_message).to eq("Anthropic API エラー: API key invalid")
+      expect(batch.error_message).to eq("ANTHROPIC_API_KEY が設定されていません")
     end
 
     it "JournalEntryを作成しないこと" do

--- a/rails/platform/spec/jobs/invoice_process_job_spec.rb
+++ b/rails/platform/spec/jobs/invoice_process_job_spec.rb
@@ -147,6 +147,40 @@ RSpec.describe InvoiceProcessJob, type: :job do
     end
   end
 
+  context "仕訳データのバリデーションエラーの場合" do
+    let(:mock_result_data) do
+      {
+        invoice_date: "2026-02-01",
+        transactions: [
+          {
+            transaction_no: 1,
+            date: nil,
+            debit_account: nil,
+            debit_amount: 100,
+            credit_account: nil,
+            credit_amount: 100,
+            description: "テスト"
+          }
+        ],
+        summary: {}
+      }
+    end
+
+    it "ステータスをfailedに更新すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("failed")
+      expect(batch.error_message).to include("仕訳データの保存に失敗")
+    end
+
+    it "JournalEntryを作成しないこと" do
+      expect {
+        described_class.perform_now(batch.id)
+      }.not_to change(JournalEntry, :count)
+    end
+  end
+
   it "レコードが存在しない場合は静かに終了すること" do
     expect {
       described_class.perform_now(-1)

--- a/rails/platform/spec/jobs/invoice_process_job_spec.rb
+++ b/rails/platform/spec/jobs/invoice_process_job_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe InvoiceProcessJob, type: :job do
     InvoiceProcessorService::Result.new(
       success: true,
       data: mock_result_data,
-      error: nil
+      error: nil,
+      reason: nil
     )
   end
 
@@ -102,10 +103,32 @@ RSpec.describe InvoiceProcessJob, type: :job do
     expect(entry.source_period).to eq("2026年2月")
   end
 
-  context "サービスが失敗した場合" do
+  context "retryableなエラーの場合" do
     let(:mock_result) do
       InvoiceProcessorService::Result.new(
-        success: false, data: {}, error: "Anthropic API エラー: API key invalid"
+        success: false, data: {}, error: "Anthropic API エラー: timeout", reason: :api_error
+      )
+    end
+
+    it "RetryableErrorをraiseすること" do
+      job = described_class.new(batch.id)
+
+      expect { job.perform(batch.id) }.to raise_error(InvoiceProcessJob::RetryableError, "Anthropic API エラー: timeout")
+    end
+
+    it "JournalEntryを作成しないこと" do
+      job = described_class.new(batch.id)
+
+      expect {
+        job.perform(batch.id) rescue nil
+      }.not_to change(JournalEntry, :count)
+    end
+  end
+
+  context "non-retryableなエラーの場合" do
+    let(:mock_result) do
+      InvoiceProcessorService::Result.new(
+        success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません", reason: :config_error
       )
     end
 
@@ -114,7 +137,7 @@ RSpec.describe InvoiceProcessJob, type: :job do
 
       batch.reload
       expect(batch.status).to eq("failed")
-      expect(batch.error_message).to eq("Anthropic API エラー: API key invalid")
+      expect(batch.error_message).to eq("ANTHROPIC_API_KEY が設定されていません")
     end
 
     it "JournalEntryを作成しないこと" do

--- a/rails/platform/spec/jobs/receipt_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_process_job_spec.rb
@@ -191,6 +191,41 @@ RSpec.describe ReceiptProcessJob, type: :job do
     end
   end
 
+  context "仕訳データのバリデーションエラーの場合" do
+    let(:mock_result_data) do
+      {
+        is_receipt: true,
+        receipt_date: "2026-03-01",
+        transactions: [
+          {
+            transaction_no: 1,
+            date: nil,
+            debit_account: nil,
+            debit_amount: 100,
+            credit_account: nil,
+            credit_amount: 100,
+            description: "テスト"
+          }
+        ],
+        summary: {}
+      }
+    end
+
+    it "ステータスをfailedに更新すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("failed")
+      expect(batch.error_message).to include("仕訳データの保存に失敗")
+    end
+
+    it "JournalEntryを作成しないこと" do
+      expect {
+        described_class.perform_now(batch.id)
+      }.not_to change(JournalEntry, :count)
+    end
+  end
+
   it "レコードが存在しない場合は静かに終了すること" do
     expect {
       described_class.perform_now(-1)

--- a/rails/platform/spec/services/amex_statement_processor_service_spec.rb
+++ b/rails/platform/spec/services/amex_statement_processor_service_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe AmexStatementProcessorService do
 
   let(:mock_response) do
     double("Response",
+      stop_reason: "end_turn",
       content: [
         double("Content", type: "text", text: valid_response_json)
       ]
@@ -113,6 +114,7 @@ RSpec.describe AmexStatementProcessorService do
     context "JSONがコードブロックで囲まれている場合" do
       let(:mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: "```json\n#{valid_response_json}\n```")
           ]
@@ -150,12 +152,15 @@ RSpec.describe AmexStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("Anthropic API エラー")
+        expect(result.reason).to eq(:api_error)
+        expect(result.retryable?).to be true
       end
     end
 
     context "不正なJSONが返された場合" do
       let(:mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: "invalid json {{{")
           ]
@@ -168,6 +173,8 @@ RSpec.describe AmexStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("JSON パースエラー")
+        expect(result.reason).to eq(:parse_error)
+        expect(result.retryable?).to be true
       end
     end
 
@@ -184,11 +191,17 @@ RSpec.describe AmexStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("ANTHROPIC_API_KEY")
+        expect(result.reason).to eq(:config_error)
+        expect(result.retryable?).to be false
       end
     end
 
-    context "5ページ以下の場合" do
+    context "INITIAL_BATCH_SIZE以下の場合" do
       let(:mock_pdf_pages) { Array.new(3) { |i| double("Page#{i + 1}") } }
+
+      before do
+        stub_const("AmexStatementProcessorService::INITIAL_BATCH_SIZE", 5)
+      end
 
       it "バッチ分割しないこと" do
         service = described_class.new(pdf: pdf_file, client_code: client.code)
@@ -201,7 +214,7 @@ RSpec.describe AmexStatementProcessorService do
       end
     end
 
-    context "6ページ以上の場合" do
+    context "INITIAL_BATCH_SIZEを超える場合" do
       let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
 
       let(:batch1_response_json) do
@@ -284,6 +297,7 @@ RSpec.describe AmexStatementProcessorService do
 
       let(:batch1_mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: batch1_response_json)
           ]
@@ -292,6 +306,7 @@ RSpec.describe AmexStatementProcessorService do
 
       let(:batch2_mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: batch2_response_json)
           ]
@@ -299,6 +314,8 @@ RSpec.describe AmexStatementProcessorService do
       end
 
       before do
+        stub_const("AmexStatementProcessorService::INITIAL_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -355,6 +372,8 @@ RSpec.describe AmexStatementProcessorService do
       let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
 
       before do
+        stub_const("AmexStatementProcessorService::INITIAL_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -379,11 +398,56 @@ RSpec.describe AmexStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("Anthropic API エラー")
+        expect(result.reason).to eq(:api_error)
       end
     end
 
-    context "バッチ処理中にmax_tokensで切り詰められた場合" do
-      let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
+    context "max_tokensで動的にバッチサイズを縮小するケース" do
+      let(:mock_pdf_pages) { Array.new(12) { |i| double("Page#{i + 1}") } }
+
+      let(:max_tokens_response) do
+        double("Response",
+          stop_reason: "max_tokens",
+          content: [
+            double("Content", type: "text", text: '{"incomplete": true}')
+          ]
+        )
+      end
+
+      let(:success_response) do
+        double("Response",
+          stop_reason: "end_turn",
+          content: [
+            double("Content", type: "text", text: valid_response_json)
+          ]
+        )
+      end
+
+      before do
+        stub_const("AmexStatementProcessorService::INITIAL_BATCH_SIZE", 12)
+        stub_const("AmexStatementProcessorService::MIN_BATCH_SIZE", 5)
+
+        batch_pdf = CombinePDF.new
+        allow(CombinePDF).to receive(:new).and_return(batch_pdf)
+        allow(batch_pdf).to receive(:<<)
+        allow(batch_pdf).to receive(:to_pdf).and_return("fake_pdf_binary")
+      end
+
+      it "バッチサイズを半分にしてリトライし成功すること" do
+        messages = mock_client.messages
+        allow(messages).to receive(:create)
+          .and_return(max_tokens_response, success_response, success_response)
+
+        service = described_class.new(pdf: pdf_file, client_code: client.code)
+        result = service.call
+
+        expect(result.success?).to be true
+        expect(messages).to have_received(:create).exactly(3).times
+      end
+    end
+
+    context "最小バッチサイズでもmax_tokensに達する場合" do
+      let(:mock_pdf_pages) { Array.new(10) { |i| double("Page#{i + 1}") } }
 
       let(:max_tokens_response) do
         double("Response",
@@ -395,6 +459,9 @@ RSpec.describe AmexStatementProcessorService do
       end
 
       before do
+        stub_const("AmexStatementProcessorService::INITIAL_BATCH_SIZE", 10)
+        stub_const("AmexStatementProcessorService::MIN_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -404,13 +471,26 @@ RSpec.describe AmexStatementProcessorService do
         allow(messages).to receive(:create).and_return(max_tokens_response)
       end
 
-      it "バッチ番号付きのエラーメッセージを返すこと" do
+      it "エラーを返すこと" do
         service = described_class.new(pdf: pdf_file, client_code: client.code)
 
         result = service.call
         expect(result.success?).to be false
-        expect(result.error).to include("バッチ1/2")
         expect(result.error).to include("max_tokens")
+        expect(result.reason).to eq(:api_error)
+        expect(result.retryable?).to be true
+      end
+    end
+
+    describe "Result#retryable?" do
+      it "api_errorはretryableであること" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :api_error)
+        expect(result.retryable?).to be true
+      end
+
+      it "config_errorはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :config_error)
+        expect(result.retryable?).to be false
       end
     end
   end

--- a/rails/platform/spec/services/bank_statement_processor_service_spec.rb
+++ b/rails/platform/spec/services/bank_statement_processor_service_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe BankStatementProcessorService do
 
   let(:mock_response) do
     double("Response",
+      stop_reason: "end_turn",
       content: [
         double("Content", type: "text", text: valid_response_json)
       ]
@@ -118,6 +119,7 @@ RSpec.describe BankStatementProcessorService do
     context "JSONがコードブロックで囲まれている場合" do
       let(:mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: "```json\n#{valid_response_json}\n```")
           ]
@@ -155,12 +157,15 @@ RSpec.describe BankStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("Anthropic API エラー")
+        expect(result.reason).to eq(:api_error)
+        expect(result.retryable?).to be true
       end
     end
 
     context "不正なJSONが返された場合" do
       let(:mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: "invalid json {{{")
           ]
@@ -173,6 +178,8 @@ RSpec.describe BankStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("JSON パースエラー")
+        expect(result.reason).to eq(:parse_error)
+        expect(result.retryable?).to be true
       end
     end
 
@@ -189,11 +196,17 @@ RSpec.describe BankStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("ANTHROPIC_API_KEY")
+        expect(result.reason).to eq(:config_error)
+        expect(result.retryable?).to be false
       end
     end
 
-    context "5ページ以下の場合" do
+    context "INITIAL_BATCH_SIZE以下の場合" do
       let(:mock_pdf_pages) { Array.new(3) { |i| double("Page#{i + 1}") } }
+
+      before do
+        stub_const("BankStatementProcessorService::INITIAL_BATCH_SIZE", 5)
+      end
 
       it "バッチ分割しないこと" do
         service = described_class.new(pdf: pdf_file, client_code: client.code)
@@ -206,7 +219,7 @@ RSpec.describe BankStatementProcessorService do
       end
     end
 
-    context "6ページ以上の場合" do
+    context "INITIAL_BATCH_SIZEを超える場合" do
       let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
 
       let(:batch1_response_json) do
@@ -291,6 +304,7 @@ RSpec.describe BankStatementProcessorService do
 
       let(:batch1_mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: batch1_response_json)
           ]
@@ -299,6 +313,7 @@ RSpec.describe BankStatementProcessorService do
 
       let(:batch2_mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: batch2_response_json)
           ]
@@ -306,6 +321,8 @@ RSpec.describe BankStatementProcessorService do
       end
 
       before do
+        stub_const("BankStatementProcessorService::INITIAL_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -364,6 +381,8 @@ RSpec.describe BankStatementProcessorService do
       let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
 
       before do
+        stub_const("BankStatementProcessorService::INITIAL_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -388,11 +407,56 @@ RSpec.describe BankStatementProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("Anthropic API エラー")
+        expect(result.reason).to eq(:api_error)
       end
     end
 
-    context "バッチ処理中にmax_tokensで切り詰められた場合" do
-      let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
+    context "max_tokensで動的にバッチサイズを縮小するケース" do
+      let(:mock_pdf_pages) { Array.new(12) { |i| double("Page#{i + 1}") } }
+
+      let(:max_tokens_response) do
+        double("Response",
+          stop_reason: "max_tokens",
+          content: [
+            double("Content", type: "text", text: '{"incomplete": true}')
+          ]
+        )
+      end
+
+      let(:success_response) do
+        double("Response",
+          stop_reason: "end_turn",
+          content: [
+            double("Content", type: "text", text: valid_response_json)
+          ]
+        )
+      end
+
+      before do
+        stub_const("BankStatementProcessorService::INITIAL_BATCH_SIZE", 12)
+        stub_const("BankStatementProcessorService::MIN_BATCH_SIZE", 5)
+
+        batch_pdf = CombinePDF.new
+        allow(CombinePDF).to receive(:new).and_return(batch_pdf)
+        allow(batch_pdf).to receive(:<<)
+        allow(batch_pdf).to receive(:to_pdf).and_return("fake_pdf_binary")
+      end
+
+      it "バッチサイズを半分にしてリトライし成功すること" do
+        messages = mock_client.messages
+        allow(messages).to receive(:create)
+          .and_return(max_tokens_response, success_response, success_response)
+
+        service = described_class.new(pdf: pdf_file, client_code: client.code)
+        result = service.call
+
+        expect(result.success?).to be true
+        expect(messages).to have_received(:create).exactly(3).times
+      end
+    end
+
+    context "最小バッチサイズでもmax_tokensに達する場合" do
+      let(:mock_pdf_pages) { Array.new(10) { |i| double("Page#{i + 1}") } }
 
       let(:max_tokens_response) do
         double("Response",
@@ -404,6 +468,9 @@ RSpec.describe BankStatementProcessorService do
       end
 
       before do
+        stub_const("BankStatementProcessorService::INITIAL_BATCH_SIZE", 10)
+        stub_const("BankStatementProcessorService::MIN_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -413,13 +480,26 @@ RSpec.describe BankStatementProcessorService do
         allow(messages).to receive(:create).and_return(max_tokens_response)
       end
 
-      it "バッチ番号付きのエラーメッセージを返すこと" do
+      it "エラーを返すこと" do
         service = described_class.new(pdf: pdf_file, client_code: client.code)
 
         result = service.call
         expect(result.success?).to be false
-        expect(result.error).to include("バッチ1/2")
         expect(result.error).to include("max_tokens")
+        expect(result.reason).to eq(:api_error)
+        expect(result.retryable?).to be true
+      end
+    end
+
+    describe "Result#retryable?" do
+      it "api_errorはretryableであること" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :api_error)
+        expect(result.retryable?).to be true
+      end
+
+      it "config_errorはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :config_error)
+        expect(result.retryable?).to be false
       end
     end
   end

--- a/rails/platform/spec/services/invoice_processor_service_spec.rb
+++ b/rails/platform/spec/services/invoice_processor_service_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe InvoiceProcessorService do
 
   let(:mock_response) do
     double("Response",
+      stop_reason: "end_turn",
       content: [
         double("Content", type: "text", text: valid_response_json)
       ]
@@ -117,6 +118,7 @@ RSpec.describe InvoiceProcessorService do
     context "JSONがコードブロックで囲まれている場合" do
       let(:mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: "```json\n#{valid_response_json}\n```")
           ]
@@ -154,12 +156,15 @@ RSpec.describe InvoiceProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("Anthropic API エラー")
+        expect(result.reason).to eq(:api_error)
+        expect(result.retryable?).to be true
       end
     end
 
     context "不正なJSONが返された場合" do
       let(:mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: "invalid json {{{")
           ]
@@ -172,6 +177,8 @@ RSpec.describe InvoiceProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("JSON パースエラー")
+        expect(result.reason).to eq(:parse_error)
+        expect(result.retryable?).to be true
       end
     end
 
@@ -188,11 +195,17 @@ RSpec.describe InvoiceProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("ANTHROPIC_API_KEY")
+        expect(result.reason).to eq(:config_error)
+        expect(result.retryable?).to be false
       end
     end
 
-    context "5ページ以下の場合" do
+    context "INITIAL_BATCH_SIZE以下の場合" do
       let(:mock_pdf_pages) { Array.new(3) { |i| double("Page#{i + 1}") } }
+
+      before do
+        stub_const("InvoiceProcessorService::INITIAL_BATCH_SIZE", 5)
+      end
 
       it "バッチ分割しないこと" do
         service = described_class.new(pdf: pdf_file, client_code: client.code)
@@ -205,7 +218,7 @@ RSpec.describe InvoiceProcessorService do
       end
     end
 
-    context "6ページ以上の場合" do
+    context "INITIAL_BATCH_SIZEを超える場合" do
       let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
 
       let(:batch1_response_json) do
@@ -292,6 +305,7 @@ RSpec.describe InvoiceProcessorService do
 
       let(:batch1_mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: batch1_response_json)
           ]
@@ -300,6 +314,7 @@ RSpec.describe InvoiceProcessorService do
 
       let(:batch2_mock_response) do
         double("Response",
+          stop_reason: "end_turn",
           content: [
             double("Content", type: "text", text: batch2_response_json)
           ]
@@ -307,6 +322,8 @@ RSpec.describe InvoiceProcessorService do
       end
 
       before do
+        stub_const("InvoiceProcessorService::INITIAL_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -366,6 +383,8 @@ RSpec.describe InvoiceProcessorService do
       let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
 
       before do
+        stub_const("InvoiceProcessorService::INITIAL_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -390,11 +409,58 @@ RSpec.describe InvoiceProcessorService do
         result = service.call
         expect(result.success?).to be false
         expect(result.error).to include("Anthropic API エラー")
+        expect(result.reason).to eq(:api_error)
       end
     end
 
-    context "バッチ処理中にmax_tokensで切り詰められた場合" do
-      let(:mock_pdf_pages) { Array.new(8) { |i| double("Page#{i + 1}") } }
+    context "max_tokensで動的にバッチサイズを縮小するケース" do
+      let(:mock_pdf_pages) { Array.new(12) { |i| double("Page#{i + 1}") } }
+
+      let(:max_tokens_response) do
+        double("Response",
+          stop_reason: "max_tokens",
+          content: [
+            double("Content", type: "text", text: '{"incomplete": true}')
+          ]
+        )
+      end
+
+      let(:success_response) do
+        double("Response",
+          stop_reason: "end_turn",
+          content: [
+            double("Content", type: "text", text: valid_response_json)
+          ]
+        )
+      end
+
+      before do
+        stub_const("InvoiceProcessorService::INITIAL_BATCH_SIZE", 12)
+        stub_const("InvoiceProcessorService::MIN_BATCH_SIZE", 5)
+
+        batch_pdf = CombinePDF.new
+        allow(CombinePDF).to receive(:new).and_return(batch_pdf)
+        allow(batch_pdf).to receive(:<<)
+        allow(batch_pdf).to receive(:to_pdf).and_return("fake_pdf_binary")
+      end
+
+      it "バッチサイズを半分にしてリトライし成功すること" do
+        messages = mock_client.messages
+        # 1回目: 12ページ一括 → max_tokens
+        # 2回目以降: 6ページ×2バッチ → 成功
+        allow(messages).to receive(:create)
+          .and_return(max_tokens_response, success_response, success_response)
+
+        service = described_class.new(pdf: pdf_file, client_code: client.code)
+        result = service.call
+
+        expect(result.success?).to be true
+        expect(messages).to have_received(:create).exactly(3).times
+      end
+    end
+
+    context "最小バッチサイズでもmax_tokensに達する場合" do
+      let(:mock_pdf_pages) { Array.new(10) { |i| double("Page#{i + 1}") } }
 
       let(:max_tokens_response) do
         double("Response",
@@ -406,6 +472,9 @@ RSpec.describe InvoiceProcessorService do
       end
 
       before do
+        stub_const("InvoiceProcessorService::INITIAL_BATCH_SIZE", 10)
+        stub_const("InvoiceProcessorService::MIN_BATCH_SIZE", 5)
+
         batch_pdf = CombinePDF.new
         allow(CombinePDF).to receive(:new).and_return(batch_pdf)
         allow(batch_pdf).to receive(:<<)
@@ -415,13 +484,36 @@ RSpec.describe InvoiceProcessorService do
         allow(messages).to receive(:create).and_return(max_tokens_response)
       end
 
-      it "バッチ番号付きのエラーメッセージを返すこと" do
+      it "エラーを返すこと" do
         service = described_class.new(pdf: pdf_file, client_code: client.code)
 
         result = service.call
         expect(result.success?).to be false
-        expect(result.error).to include("バッチ1/2")
         expect(result.error).to include("max_tokens")
+        expect(result.reason).to eq(:api_error)
+        expect(result.retryable?).to be true
+      end
+    end
+
+    describe "Result#retryable?" do
+      it "api_errorはretryableであること" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :api_error)
+        expect(result.retryable?).to be true
+      end
+
+      it "parse_errorはretryableであること" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :parse_error)
+        expect(result.retryable?).to be true
+      end
+
+      it "config_errorはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :config_error)
+        expect(result.retryable?).to be false
+      end
+
+      it "成功時はretryableでないこと" do
+        result = described_class::Result.new(success: true, data: {}, error: nil, reason: nil)
+        expect(result.retryable?).to be false
       end
     end
   end


### PR DESCRIPTION
## Summary

- PDF処理の`MAX_PAGES_PER_BATCH=5`固定を`INITIAL_BATCH_SIZE=20`に変更し、max_tokens超過時にバッチサイズを半分にして全ページを再分割するアダプティブリトライを実装（20→10→5の順に縮小）
- 3サービス（Invoice/Bank/Amex）の`Result`に`reason`/`retryable?`を追加し、ReceiptProcessorServiceとインターフェースを統一
- 3ジョブの`retry_on StandardError`+`after_discard`を`RetryableError`パターンに統一し、non-retryableエラー（config_error等）で無駄なリトライを防止

## Test plan

- [x] `make test` — 全476テストパス
- [x] 5ページ以下のPDFが1回のAPI呼び出しで処理されること（3サービスspec「INITIAL_BATCH_SIZE以下の場合」で検証）
- [x] 20ページ超のPDFが適切にバッチ分割されること（3サービスspec「INITIAL_BATCH_SIZEを超える場合」で検証）
- [x] max_tokens発生時にバッチサイズが動的に縮小されること（3サービスspec「max_tokensで動的にバッチサイズを縮小するケース」で検証）
- [x] config_errorはリトライされずに即failedになること（3ジョブspec「non-retryableなエラーの場合」で検証）