### PR TITLE
fix(platform): ダークテーマをTailwind標準パレットで適用 (issue#253)

### DIFF
--- a/rails/platform/app/assets/tailwind/application.css
+++ b/rails/platform/app/assets/tailwind/application.css
@@ -34,4 +34,9 @@
     background-color: var(--color-gray-950);
     color: var(--color-gray-100);
   }
+
+  input, select, textarea {
+    background-color: var(--color-gray-800);
+    color: var(--color-gray-100);
+  }
 }

--- a/rails/platform/app/assets/tailwind/application.css
+++ b/rails/platform/app/assets/tailwind/application.css
@@ -2,38 +2,18 @@
 @source "../../views/";
 
 @theme {
-  /* Surface layers — dark teal tint */
-  --color-bg-base: #0c1219;
-  --color-bg-surface: #131c25;
-  --color-bg-elevated: #1b2733;
-  --color-bg-hover: #243242;
-
-  /* Borders */
-  --color-border: #243242;
-  --color-border-subtle: #1b2733;
-
-  /* Text */
-  --color-text-primary: #f1f5f9;
-  --color-text-secondary: #cbd5e1;
-  --color-text-tertiary: #94a3b8;
-  --color-text-muted: #64748b;
-
-  /* Accent — teal (from ai-landbase.jp) */
-  --color-accent-300: #5eead4;
-  --color-accent-400: #2dd4bf;
-  --color-accent-500: #14b8a6;
-  --color-accent-600: #0d9488;
-
-  /* CTA — warm gold */
-  --color-cta-400: #fbbf24;
-  --color-cta-500: #f59e0b;
-  --color-cta-600: #d97706;
-
-  /* Status */
-  --color-success: #22c55e;
-  --color-warning: #f59e0b;
-  --color-error: #ef4444;
-  --color-info: #38bdf8;
+  /* Gray — teal-tinted dark palette (standard ordering preserved) */
+  --color-gray-50:  #f8fafc;
+  --color-gray-100: #f1f5f9;
+  --color-gray-200: #e2e8f0;
+  --color-gray-300: #cbd5e1;
+  --color-gray-400: #94a3b8;
+  --color-gray-500: #64748b;
+  --color-gray-600: #3a4f65;
+  --color-gray-700: #243242;
+  --color-gray-800: #1b2733;
+  --color-gray-900: #131c25;
+  --color-gray-950: #0c1219;
 
   /* Spacing scale aliases */
   --spacing-btn-x: 1rem;       /* px-4 */
@@ -47,4 +27,11 @@
   --spacing-badge-sm-y: 0.125rem;/* py-0.5 */
   --spacing-badge-md-x: 0.75rem; /* px-3 */
   --spacing-badge-md-y: 0.25rem; /* py-1 */
+}
+
+@layer base {
+  body {
+    background-color: var(--color-gray-950);
+    color: var(--color-gray-100);
+  }
 }

--- a/rails/platform/app/assets/tailwind/application.css
+++ b/rails/platform/app/assets/tailwind/application.css
@@ -35,7 +35,9 @@
     color: var(--color-gray-100);
   }
 
-  input, select, textarea {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]):not([type="file"]),
+  select,
+  textarea {
     background-color: var(--color-gray-800);
     color: var(--color-gray-100);
   }

--- a/rails/platform/app/views/amex_statements/new.html.erb
+++ b/rails/platform/app/views/amex_statements/new.html.erb
@@ -5,39 +5,39 @@
 
   <form data-pdf-upload-target="form" data-action="submit->pdf-upload#submit" class="space-y-6">
     <div>
-      <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
+      <label for="client_code" class="block text-sm font-medium text-gray-300 mb-1">クライアントコード <span class="text-red-400">*</span></label>
       <input type="text" name="client_code" id="client_code" required
              value="<%= params[:client_code] %>"
-             class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
+             class="w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border"
              data-pdf-upload-target="clientCode">
     </div>
 
     <!-- ドラッグ&ドロップエリア -->
-    <div class="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-blue-500 transition-colors"
+    <div class="border-2 border-dashed border-gray-600 rounded-lg p-8 text-center hover:border-teal-500 transition-colors"
          data-pdf-upload-target="dropZone"
          data-action="dragover->pdf-upload#dragOver dragenter->pdf-upload#dragEnter dragleave->pdf-upload#dragLeave drop->pdf-upload#drop">
       <input type="file" name="pdf" accept="application/pdf"
              class="hidden" data-pdf-upload-target="fileInput" data-action="change->pdf-upload#fileSelected">
       <div class="space-y-2">
-        <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+        <svg class="mx-auto h-12 w-12 text-gray-500" stroke="currentColor" fill="none" viewBox="0 0 48 48">
           <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="text-gray-600">
+        <p class="text-gray-400">
           PDFファイルをドラッグ&ドロップ、または
-          <button type="button" class="text-blue-600 hover:text-blue-500 font-medium" data-action="click->pdf-upload#openFileDialog">
+          <button type="button" class="text-teal-400 hover:text-teal-300 font-medium" data-action="click->pdf-upload#openFileDialog">
             ファイルを選択
           </button>
         </p>
-        <p class="text-xs text-gray-500">Amex利用明細PDF（20MB以下）</p>
+        <p class="text-xs text-gray-400">Amex利用明細PDF（20MB以下）</p>
       </div>
     </div>
 
     <!-- ファイル名表示 -->
-    <p class="text-sm text-gray-700 hidden" data-pdf-upload-target="fileName"></p>
+    <p class="text-sm text-gray-300 hidden" data-pdf-upload-target="fileName"></p>
 
     <div class="flex items-center justify-end">
       <button type="submit" data-pdf-upload-target="submitButton"
-              class="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+              class="bg-teal-600 text-white px-6 py-2 rounded-md hover:bg-teal-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
               disabled>
         仕訳変換を実行
       </button>
@@ -46,12 +46,12 @@
 
   <!-- ローディング -->
   <div data-pdf-upload-target="loading" class="hidden mt-8 text-center">
-    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    <p class="mt-2 text-gray-600">アップロード中...</p>
+    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-teal-600"></div>
+    <p class="mt-2 text-gray-400">アップロード中...</p>
   </div>
 
   <!-- エラー表示 -->
-  <div data-pdf-upload-target="error" class="hidden mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
-    <p class="text-red-800" data-pdf-upload-target="errorMessage"></p>
+  <div data-pdf-upload-target="error" class="hidden mt-6 bg-red-950 border border-red-700 rounded-lg p-4">
+    <p class="text-red-300" data-pdf-upload-target="errorMessage"></p>
   </div>
 </div>

--- a/rails/platform/app/views/bank_statements/new.html.erb
+++ b/rails/platform/app/views/bank_statements/new.html.erb
@@ -5,39 +5,39 @@
 
   <form data-bank-pdf-upload-target="form" data-action="submit->bank-pdf-upload#submit" class="space-y-6">
     <div>
-      <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
+      <label for="client_code" class="block text-sm font-medium text-gray-300 mb-1">クライアントコード <span class="text-red-400">*</span></label>
       <input type="text" name="client_code" id="client_code" required
              value="<%= params[:client_code] %>"
-             class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
+             class="w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border"
              data-bank-pdf-upload-target="clientCode">
     </div>
 
     <!-- ドラッグ&ドロップエリア -->
-    <div class="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-blue-500 transition-colors"
+    <div class="border-2 border-dashed border-gray-600 rounded-lg p-8 text-center hover:border-teal-500 transition-colors"
          data-bank-pdf-upload-target="dropZone"
          data-action="dragover->bank-pdf-upload#dragOver dragenter->bank-pdf-upload#dragEnter dragleave->bank-pdf-upload#dragLeave drop->bank-pdf-upload#drop">
       <input type="file" name="pdf" accept="application/pdf"
              class="hidden" data-bank-pdf-upload-target="fileInput" data-action="change->bank-pdf-upload#fileSelected">
       <div class="space-y-2">
-        <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+        <svg class="mx-auto h-12 w-12 text-gray-500" stroke="currentColor" fill="none" viewBox="0 0 48 48">
           <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="text-gray-600">
+        <p class="text-gray-400">
           PDFファイルをドラッグ&ドロップ、または
-          <button type="button" class="text-blue-600 hover:text-blue-500 font-medium" data-action="click->bank-pdf-upload#openFileDialog">
+          <button type="button" class="text-teal-400 hover:text-teal-300 font-medium" data-action="click->bank-pdf-upload#openFileDialog">
             ファイルを選択
           </button>
         </p>
-        <p class="text-xs text-gray-500">銀行入出金明細PDF（20MB以下）</p>
+        <p class="text-xs text-gray-400">銀行入出金明細PDF（20MB以下）</p>
       </div>
     </div>
 
     <!-- ファイル名表示 -->
-    <p class="text-sm text-gray-700 hidden" data-bank-pdf-upload-target="fileName"></p>
+    <p class="text-sm text-gray-300 hidden" data-bank-pdf-upload-target="fileName"></p>
 
     <div class="flex items-center justify-end">
       <button type="submit" data-bank-pdf-upload-target="submitButton"
-              class="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+              class="bg-teal-600 text-white px-6 py-2 rounded-md hover:bg-teal-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
               disabled>
         仕訳変換を実行
       </button>
@@ -46,12 +46,12 @@
 
   <!-- ローディング -->
   <div data-bank-pdf-upload-target="loading" class="hidden mt-8 text-center">
-    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    <p class="mt-2 text-gray-600">アップロード中...</p>
+    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-teal-600"></div>
+    <p class="mt-2 text-gray-400">アップロード中...</p>
   </div>
 
   <!-- エラー表示 -->
-  <div data-bank-pdf-upload-target="error" class="hidden mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
-    <p class="text-red-800" data-bank-pdf-upload-target="errorMessage"></p>
+  <div data-bank-pdf-upload-target="error" class="hidden mt-6 bg-red-950 border border-red-700 rounded-lg p-4">
+    <p class="text-red-300" data-bank-pdf-upload-target="errorMessage"></p>
   </div>
 </div>

--- a/rails/platform/app/views/cleaning_manuals/index.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/index.html.erb
@@ -8,24 +8,24 @@
 
   <form method="get" class="mb-6 flex gap-4 items-end">
     <div>
-      <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード</label>
+      <label for="client_code" class="block text-sm font-medium text-gray-300 mb-1">クライアントコード</label>
       <input type="text" name="client_code" id="client_code" value="<%= @client_code %>"
-             class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border">
+             class="rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border">
     </div>
     <%= render "shared/button", label: "検索", variant: :neutral, type: "submit" %>
   </form>
 
   <% if @client_code.blank? %>
-    <p class="text-gray-500">クライアントコードを入力して検索してください。</p>
+    <p class="text-gray-400">クライアントコードを入力して検索してください。</p>
   <% elsif @manuals.empty? %>
-    <p class="text-gray-500">マニュアルが見つかりません。</p>
+    <p class="text-gray-400">マニュアルが見つかりません。</p>
   <% else %>
     <%= render "shared/table", headers: ["ID", "施設名", "部屋タイプ", "ステータス", "作成日", ""] do %>
       <% @manuals.each do |manual| %>
-        <tr class="hover:bg-gray-50">
-          <td class="px-6 py-4 text-sm text-gray-900"><%= manual.id %></td>
-          <td class="px-6 py-4 text-sm text-gray-900"><%= manual.property_name %></td>
-          <td class="px-6 py-4 text-sm text-gray-900"><%= manual.room_type %></td>
+        <tr class="hover:bg-gray-800">
+          <td class="px-6 py-4 text-sm text-gray-100"><%= manual.id %></td>
+          <td class="px-6 py-4 text-sm text-gray-100"><%= manual.property_name %></td>
+          <td class="px-6 py-4 text-sm text-gray-100"><%= manual.room_type %></td>
           <td class="px-6 py-4 text-sm">
             <% if manual.status == "published" %>
               <%= render "shared/badge", label: "公開", variant: :success %>
@@ -33,9 +33,9 @@
               <%= render "shared/badge", label: "下書き", variant: :warning %>
             <% end %>
           </td>
-          <td class="px-6 py-4 text-sm text-gray-500"><%= l(manual.created_at, format: :short) rescue manual.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+          <td class="px-6 py-4 text-sm text-gray-400"><%= l(manual.created_at, format: :short) rescue manual.created_at.strftime("%Y/%m/%d %H:%M") %></td>
           <td class="px-6 py-4 text-sm text-right">
-            <%= link_to "詳細", cleaning_manual_path(manual, client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+            <%= link_to "詳細", cleaning_manual_path(manual, client_code: @client_code), class: "text-teal-400 hover:text-teal-300" %>
           </td>
         </tr>
       <% end %>

--- a/rails/platform/app/views/cleaning_manuals/new.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/new.html.erb
@@ -6,43 +6,43 @@
   <form data-image-upload-target="form" data-action="submit->image-upload#submit" class="space-y-6">
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div>
-        <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
+        <label for="client_code" class="block text-sm font-medium text-gray-300 mb-1">クライアントコード <span class="text-red-400">*</span></label>
         <input type="text" name="client_code" id="client_code" required
                value="<%= params[:client_code] %>"
-               class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
+               class="w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border"
                data-image-upload-target="clientCode">
       </div>
       <div>
-        <label for="property_name" class="block text-sm font-medium text-gray-700 mb-1">施設名 <span class="text-red-500">*</span></label>
+        <label for="property_name" class="block text-sm font-medium text-gray-300 mb-1">施設名 <span class="text-red-400">*</span></label>
         <input type="text" name="property_name" id="property_name" required
-               class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
+               class="w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border"
                data-image-upload-target="propertyName">
       </div>
       <div>
-        <label for="room_type" class="block text-sm font-medium text-gray-700 mb-1">部屋タイプ <span class="text-red-500">*</span></label>
+        <label for="room_type" class="block text-sm font-medium text-gray-300 mb-1">部屋タイプ <span class="text-red-400">*</span></label>
         <input type="text" name="room_type" id="room_type" required
-               class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
+               class="w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border"
                data-image-upload-target="roomType">
       </div>
     </div>
 
     <!-- ドラッグ&ドロップエリア -->
-    <div class="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-blue-500 transition-colors"
+    <div class="border-2 border-dashed border-gray-600 rounded-lg p-8 text-center hover:border-teal-500 transition-colors"
          data-image-upload-target="dropZone"
          data-action="dragover->image-upload#dragOver dragenter->image-upload#dragEnter dragleave->image-upload#dragLeave drop->image-upload#drop">
       <input type="file" name="images[]" multiple accept="image/jpeg,image/png,image/webp"
              class="hidden" data-image-upload-target="fileInput" data-action="change->image-upload#filesSelected">
       <div class="space-y-2">
-        <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+        <svg class="mx-auto h-12 w-12 text-gray-500" stroke="currentColor" fill="none" viewBox="0 0 48 48">
           <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="text-gray-600">
+        <p class="text-gray-400">
           画像をドラッグ&ドロップ、または
-          <button type="button" class="text-blue-600 hover:text-blue-500 font-medium" data-action="click->image-upload#openFileDialog">
+          <button type="button" class="text-teal-400 hover:text-teal-300 font-medium" data-action="click->image-upload#openFileDialog">
             ファイルを選択
           </button>
         </p>
-        <p class="text-xs text-gray-500">JPEG, PNG, WebP 対応</p>
+        <p class="text-xs text-gray-400">JPEG, PNG, WebP 対応</p>
       </div>
     </div>
 
@@ -51,9 +51,9 @@
     </div>
 
     <div class="flex items-center justify-between">
-      <p class="text-sm text-gray-500" data-image-upload-target="fileCount">画像が選択されていません</p>
+      <p class="text-sm text-gray-400" data-image-upload-target="fileCount">画像が選択されていません</p>
       <button type="submit" data-image-upload-target="submitButton"
-              class="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+              class="bg-teal-600 text-white px-6 py-2 rounded-md hover:bg-teal-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
               disabled>
         マニュアルを生成
       </button>
@@ -62,20 +62,20 @@
 
   <!-- ローディング -->
   <div data-image-upload-target="loading" class="hidden mt-8 text-center">
-    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    <p class="mt-2 text-gray-600">AI が清掃マニュアルを生成しています...</p>
-    <p class="text-sm text-gray-400">画像枚数によっては数分かかることがあります</p>
+    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-teal-600"></div>
+    <p class="mt-2 text-gray-400">AI が清掃マニュアルを生成しています...</p>
+    <p class="text-sm text-gray-500">画像枚数によっては数分かかることがあります</p>
   </div>
 
   <!-- エラー表示 -->
-  <div data-image-upload-target="error" class="hidden mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
-    <p class="text-red-800" data-image-upload-target="errorMessage"></p>
+  <div data-image-upload-target="error" class="hidden mt-6 bg-red-950 border border-red-700 rounded-lg p-4">
+    <p class="text-red-300" data-image-upload-target="errorMessage"></p>
   </div>
 
   <!-- 結果表示 -->
   <div data-image-upload-target="result" class="hidden mt-8 space-y-6">
-    <div class="bg-green-50 border border-green-200 rounded-lg p-4">
-      <p class="text-green-800 font-medium">マニュアルが正常に生成されました</p>
+    <div class="bg-green-950 border border-green-700 rounded-lg p-4">
+      <p class="text-green-300 font-medium">マニュアルが正常に生成されました</p>
     </div>
 
     <div data-image-upload-target="resultContent">

--- a/rails/platform/app/views/cleaning_manuals/show.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/show.html.erb
@@ -11,7 +11,7 @@
   <div class="flex items-center justify-between mb-6">
     <div>
       <h1 class="text-2xl font-bold"><%= @manual.property_name %></h1>
-      <p class="text-gray-500"><%= @manual.room_type %></p>
+      <p class="text-gray-400"><%= @manual.room_type %></p>
     </div>
     <% if @manual.status == "published" %>
       <%= render "shared/badge", label: "公開", variant: :success, size: :md %>
@@ -26,26 +26,26 @@
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
     <%= render "shared/card", padding: "p-4" do %>
       <div class="text-center">
-        <p class="text-2xl font-bold text-blue-600"><%= data[:areas]&.size || 0 %></p>
-        <p class="text-sm text-gray-500">エリア数</p>
+        <p class="text-2xl font-bold text-teal-400"><%= data[:areas]&.size || 0 %></p>
+        <p class="text-sm text-gray-400">エリア数</p>
       </div>
     <% end %>
     <%= render "shared/card", padding: "p-4" do %>
       <div class="text-center">
-        <p class="text-2xl font-bold text-blue-600"><%= data[:areas]&.sum { |a| a[:cleaning_steps]&.size || 0 } || 0 %></p>
-        <p class="text-sm text-gray-500">清掃ステップ数</p>
+        <p class="text-2xl font-bold text-teal-400"><%= data[:areas]&.sum { |a| a[:cleaning_steps]&.size || 0 } || 0 %></p>
+        <p class="text-sm text-gray-400">清掃ステップ数</p>
       </div>
     <% end %>
     <%= render "shared/card", padding: "p-4" do %>
       <div class="text-center">
-        <p class="text-2xl font-bold text-blue-600"><%= data[:total_estimated_minutes] || 0 %></p>
-        <p class="text-sm text-gray-500">推定所要時間（分）</p>
+        <p class="text-2xl font-bold text-teal-400"><%= data[:total_estimated_minutes] || 0 %></p>
+        <p class="text-sm text-gray-400">推定所要時間（分）</p>
       </div>
     <% end %>
     <%= render "shared/card", padding: "p-4" do %>
       <div class="text-center">
-        <p class="text-2xl font-bold text-blue-600"><%= data[:supplies_needed]&.size || 0 %></p>
-        <p class="text-sm text-gray-500">必要備品数</p>
+        <p class="text-2xl font-bold text-teal-400"><%= data[:supplies_needed]&.size || 0 %></p>
+        <p class="text-sm text-gray-400">必要備品数</p>
       </div>
     <% end %>
   </div>
@@ -54,8 +54,8 @@
   <% if data[:areas].present? %>
     <div class="space-y-6">
       <% data[:areas].each do |area| %>
-        <div class="bg-white shadow rounded-lg overflow-hidden">
-          <div class="bg-gray-50 px-6 py-4 border-b">
+        <div class="bg-gray-900 shadow rounded-lg overflow-hidden">
+          <div class="bg-gray-800 px-6 py-4 border-b">
             <h2 class="text-lg font-semibold"><%= area[:area_name] %></h2>
           </div>
           <div class="p-6">
@@ -64,14 +64,14 @@
               <ol class="space-y-4">
                 <% area[:cleaning_steps].each do |step| %>
                   <li class="flex gap-4">
-                    <span class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium">
+                    <span class="flex-shrink-0 w-8 h-8 bg-teal-900 text-teal-400 rounded-full flex items-center justify-center text-sm font-medium">
                       <%= step[:order] %>
                     </span>
                     <div class="flex-1">
                       <p class="font-medium"><%= step[:task] %></p>
-                      <p class="text-sm text-gray-600 mt-1"><%= step[:description] %></p>
+                      <p class="text-sm text-gray-400 mt-1"><%= step[:description] %></p>
                       <div class="flex items-center gap-4 mt-2">
-                        <span class="text-xs text-green-700 bg-green-50 px-2 py-1 rounded-full">✓ <%= step[:checkpoint] %></span>
+                        <span class="text-xs text-green-400 bg-green-950 px-2 py-1 rounded-full">✓ <%= step[:checkpoint] %></span>
                         <span class="text-xs text-gray-500">約<%= step[:estimated_minutes] %>分</span>
                       </div>
                     </div>
@@ -83,8 +83,8 @@
             <!-- 品質基準 -->
             <% if area[:quality_standards].present? %>
               <div class="mt-4 pt-4 border-t">
-                <h3 class="text-sm font-medium text-gray-700 mb-2">品質基準</h3>
-                <ul class="list-disc list-inside text-sm text-gray-600 space-y-1">
+                <h3 class="text-sm font-medium text-gray-300 mb-2">品質基準</h3>
+                <ul class="list-disc list-inside text-sm text-gray-400 space-y-1">
                   <% area[:quality_standards].each do |standard| %>
                     <li><%= standard %></li>
                   <% end %>

--- a/rails/platform/app/views/clients/_form.html.erb
+++ b/rails/platform/app/views/clients/_form.html.erb
@@ -6,35 +6,35 @@
   <%= render "shared/card" do %>
     <div class="space-y-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">コード</label>
+        <label class="block text-sm font-medium text-gray-300 mb-1">コード</label>
         <% if @client.persisted? %>
-          <p class="px-3 py-2 bg-gray-100 rounded-md text-sm font-mono text-gray-700"><%= @client.code %></p>
+          <p class="px-3 py-2 bg-gray-700 rounded-md text-sm font-mono text-gray-300"><%= @client.code %></p>
         <% else %>
           <%= f.text_field :code, placeholder: "例: ikigai_stay",
-                class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
         <% end %>
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">名前</label>
+        <label class="block text-sm font-medium text-gray-300 mb-1">名前</label>
         <%= f.text_field :name, placeholder: "例: イキガイステイ",
-              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+              class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">業種</label>
+        <label class="block text-sm font-medium text-gray-300 mb-1">業種</label>
         <%= f.select :industry,
               [["飲食業", "restaurant"], ["ホテル", "hotel"], ["ツアー", "tour"]],
               { include_blank: "-- 選択してください --" },
-              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+              class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
+        <label class="block text-sm font-medium text-gray-300 mb-1">ステータス</label>
         <%= f.select :status,
               Client::STATUSES.map { |value, label| [label, value] },
               {},
-              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+              class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
       </div>
     </div>
   <% end %>
@@ -42,6 +42,6 @@
   <div class="flex justify-end gap-4">
     <%= render "shared/button", label: "キャンセル", href: (@client.persisted? ? client_path(@client) : clients_path), variant: :secondary, size: :lg %>
     <%= f.submit (@client.persisted? ? "更新" : "作成"),
-          class: "bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 transition-colors cursor-pointer" %>
+          class: "bg-teal-600 text-white px-6 py-2 rounded-md hover:bg-teal-700 transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/rails/platform/app/views/clients/index.html.erb
+++ b/rails/platform/app/views/clients/index.html.erb
@@ -8,26 +8,26 @@
 
   <form method="get" class="mb-6 flex flex-wrap gap-4 items-end">
     <div>
-      <label for="query" class="block text-sm font-medium text-gray-700 mb-1">名前 / コードで検索</label>
+      <label for="query" class="block text-sm font-medium text-gray-300 mb-1">名前 / コードで検索</label>
       <input type="text" name="query" id="query" value="<%= params[:query] %>"
              placeholder="クライアント名またはコード"
-             class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border w-72">
+             class="rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border w-72">
     </div>
     <%= render "shared/button", label: "検索", variant: :neutral, type: "submit" %>
     <% if params[:query].present? %>
-      <%= link_to "クリア", clients_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-2" %>
+      <%= link_to "クリア", clients_path, class: "text-sm text-gray-400 hover:text-gray-300 px-2 py-2" %>
     <% end %>
   </form>
 
   <% if @clients.empty? %>
-    <p class="text-gray-500">クライアントが見つかりません。</p>
+    <p class="text-gray-400">クライアントが見つかりません。</p>
   <% else %>
     <%= render "shared/table", headers: ["コード", "名前", "業種", "ステータス"] do %>
       <% @clients.each do |client| %>
-        <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='<%= client_path(client) %>'">
-          <td class="px-6 py-4 text-sm font-mono text-gray-900"><%= client.code %></td>
-          <td class="px-6 py-4 text-sm font-medium text-gray-900"><%= client.name %></td>
-          <td class="px-6 py-4 text-sm text-gray-500"><%= client.industry.presence || "—" %></td>
+        <tr class="hover:bg-gray-800 cursor-pointer" onclick="window.location='<%= client_path(client) %>'">
+          <td class="px-6 py-4 text-sm font-mono text-gray-100"><%= client.code %></td>
+          <td class="px-6 py-4 text-sm font-medium text-gray-100"><%= client.name %></td>
+          <td class="px-6 py-4 text-sm text-gray-400"><%= client.industry.presence || "—" %></td>
           <td class="px-6 py-4">
             <% if client.status == "active" %>
               <%= render "shared/badge", label: client.status_label, variant: :success %>

--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -4,12 +4,12 @@
   <%= render "shared/card", class: "mb-8" do %>
     <div class="flex items-center justify-between">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900"><%= @client.name %></h1>
-        <p class="text-sm font-mono text-gray-500 mt-1"><%= @client.code %></p>
+        <h1 class="text-2xl font-bold text-gray-100"><%= @client.name %></h1>
+        <p class="text-sm font-mono text-gray-400 mt-1"><%= @client.code %></p>
       </div>
       <div class="flex items-center gap-3">
         <% if @client.industry.present? %>
-          <span class="text-sm text-gray-600"><%= @client.industry %></span>
+          <span class="text-sm text-gray-400"><%= @client.industry %></span>
         <% end %>
         <% if @client.status == "active" %>
           <%= render "shared/badge", label: @client.status_label, variant: :success, size: :md %>
@@ -28,29 +28,29 @@
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <%= render "shared/card", href: journal_entries_path(client_code: @client.code), hover: true do %>
-      <h2 class="text-lg font-semibold text-gray-900 mb-2">仕訳台帳</h2>
-      <p class="text-sm text-gray-500">仕訳データの一覧表示・編集・CSVエクスポート</p>
+      <h2 class="text-lg font-semibold text-gray-100 mb-2">仕訳台帳</h2>
+      <p class="text-sm text-gray-400">仕訳データの一覧表示・編集・CSVエクスポート</p>
     <% end %>
 
     <%= render "shared/card", href: new_amex_statement_path(client_code: @client.code), hover: true do %>
-      <h2 class="text-lg font-semibold text-gray-900 mb-2">Amex明細処理</h2>
-      <p class="text-sm text-gray-500">Amex利用明細PDFをAIで仕訳データに変換</p>
+      <h2 class="text-lg font-semibold text-gray-100 mb-2">Amex明細処理</h2>
+      <p class="text-sm text-gray-400">Amex利用明細PDFをAIで仕訳データに変換</p>
     <% end %>
 
     <%= render "shared/card", href: new_bank_statement_path(client_code: @client.code), hover: true do %>
-      <h2 class="text-lg font-semibold text-gray-900 mb-2">銀行明細処理</h2>
-      <p class="text-sm text-gray-500">銀行入出金明細PDFをAIで仕訳データに変換</p>
+      <h2 class="text-lg font-semibold text-gray-100 mb-2">銀行明細処理</h2>
+      <p class="text-sm text-gray-400">銀行入出金明細PDFをAIで仕訳データに変換</p>
     <% end %>
 
     <%= render "shared/card", href: new_invoice_path(client_code: @client.code), hover: true do %>
-      <h2 class="text-lg font-semibold text-gray-900 mb-2">請求書処理</h2>
-      <p class="text-sm text-gray-500">請求書PDFをAIで仕訳データに変換</p>
+      <h2 class="text-lg font-semibold text-gray-100 mb-2">請求書処理</h2>
+      <p class="text-sm text-gray-400">請求書PDFをAIで仕訳データに変換</p>
     <% end %>
 
     <% if @client.feature_available?(:cleaning_manuals) %>
     <%= render "shared/card", href: cleaning_manuals_path(client_code: @client.code), hover: true do %>
-      <h2 class="text-lg font-semibold text-gray-900 mb-2">清掃マニュアル</h2>
-      <p class="text-sm text-gray-500">AI生成の清掃基準マニュアル管理</p>
+      <h2 class="text-lg font-semibold text-gray-100 mb-2">清掃マニュアル</h2>
+      <p class="text-sm text-gray-400">AI生成の清掃基準マニュアル管理</p>
     <% end %>
     <% end %>
   </div>

--- a/rails/platform/app/views/devise/sessions/new.html.erb
+++ b/rails/platform/app/views/devise/sessions/new.html.erb
@@ -1,32 +1,32 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+<div class="min-h-screen flex items-center justify-center bg-gray-800 px-4">
   <div class="w-full max-w-sm">
     <div class="text-center mb-8">
-      <h1 class="text-2xl font-bold text-gray-900">AI Suite</h1>
-      <p class="text-sm text-gray-500 mt-1">サインインしてください</p>
+      <h1 class="text-2xl font-bold text-gray-100">AI Suite</h1>
+      <p class="text-sm text-gray-400 mt-1">サインインしてください</p>
     </div>
 
-    <div class="bg-white shadow rounded-lg p-8">
+    <div class="bg-gray-900 shadow rounded-lg p-8">
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <div class="mb-4">
-          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-300 mb-1" %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email",
-              class: "w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+              class: "w-full border border-gray-600 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500" %>
         </div>
 
         <div class="mb-6">
-          <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-300 mb-1" %>
           <%= f.password_field :password, autocomplete: "current-password",
-              class: "w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+              class: "w-full border border-gray-600 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500" %>
         </div>
 
         <% if devise_mapping.rememberable? %>
           <div class="mb-4 flex items-center">
             <%= f.check_box :remember_me, class: "mr-2" %>
-            <%= f.label :remember_me, "ログイン状態を保持する", class: "text-sm text-gray-600" %>
+            <%= f.label :remember_me, "ログイン状態を保持する", class: "text-sm text-gray-400" %>
           </div>
         <% end %>
 
-        <%= f.submit "サインイン", class: "w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded text-sm cursor-pointer transition" %>
+        <%= f.submit "サインイン", class: "w-full bg-teal-600 hover:bg-teal-700 text-white font-medium py-2 px-4 rounded text-sm cursor-pointer transition" %>
       <% end %>
 
       <%= render "devise/shared/links" %>

--- a/rails/platform/app/views/devise/sessions/new.html.erb
+++ b/rails/platform/app/views/devise/sessions/new.html.erb
@@ -1,11 +1,11 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-800 px-4">
+<div class="min-h-screen flex items-center justify-center bg-gray-950 px-4">
   <div class="w-full max-w-sm">
     <div class="text-center mb-8">
       <h1 class="text-2xl font-bold text-gray-100">AI Suite</h1>
       <p class="text-sm text-gray-400 mt-1">サインインしてください</p>
     </div>
 
-    <div class="bg-gray-900 shadow rounded-lg p-8">
+    <div class="bg-gray-800 shadow rounded-lg p-8">
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <div class="mb-4">
           <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-300 mb-1" %>

--- a/rails/platform/app/views/devise/shared/_links.html.erb
+++ b/rails/platform/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
   <div class="mt-4 text-center">
-    <%= link_to "サインイン", new_session_path(resource_name), class: "text-sm text-blue-600 hover:underline" %>
+    <%= link_to "サインイン", new_session_path(resource_name), class: "text-sm text-teal-400 hover:underline" %>
   </div>
 <% end %>

--- a/rails/platform/app/views/invoices/new.html.erb
+++ b/rails/platform/app/views/invoices/new.html.erb
@@ -5,39 +5,39 @@
 
   <form data-invoice-pdf-upload-target="form" data-action="submit->invoice-pdf-upload#submit" class="space-y-6">
     <div>
-      <label for="client_code" class="block text-sm font-medium text-gray-700 mb-1">クライアントコード <span class="text-red-500">*</span></label>
+      <label for="client_code" class="block text-sm font-medium text-gray-300 mb-1">クライアントコード <span class="text-red-400">*</span></label>
       <input type="text" name="client_code" id="client_code" required
              value="<%= params[:client_code] %>"
-             class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border"
+             class="w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border"
              data-invoice-pdf-upload-target="clientCode">
     </div>
 
     <!-- ドラッグ&ドロップエリア -->
-    <div class="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-blue-500 transition-colors"
+    <div class="border-2 border-dashed border-gray-600 rounded-lg p-8 text-center hover:border-teal-500 transition-colors"
          data-invoice-pdf-upload-target="dropZone"
          data-action="dragover->invoice-pdf-upload#dragOver dragenter->invoice-pdf-upload#dragEnter dragleave->invoice-pdf-upload#dragLeave drop->invoice-pdf-upload#drop">
       <input type="file" name="pdf" accept="application/pdf"
              class="hidden" data-invoice-pdf-upload-target="fileInput" data-action="change->invoice-pdf-upload#fileSelected">
       <div class="space-y-2">
-        <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+        <svg class="mx-auto h-12 w-12 text-gray-500" stroke="currentColor" fill="none" viewBox="0 0 48 48">
           <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="text-gray-600">
+        <p class="text-gray-400">
           PDFファイルをドラッグ&ドロップ、または
-          <button type="button" class="text-blue-600 hover:text-blue-500 font-medium" data-action="click->invoice-pdf-upload#openFileDialog">
+          <button type="button" class="text-teal-400 hover:text-teal-300 font-medium" data-action="click->invoice-pdf-upload#openFileDialog">
             ファイルを選択
           </button>
         </p>
-        <p class="text-xs text-gray-500">請求書PDF（20MB以下）</p>
+        <p class="text-xs text-gray-400">請求書PDF（20MB以下）</p>
       </div>
     </div>
 
     <!-- ファイル名表示 -->
-    <p class="text-sm text-gray-700 hidden" data-invoice-pdf-upload-target="fileName"></p>
+    <p class="text-sm text-gray-300 hidden" data-invoice-pdf-upload-target="fileName"></p>
 
     <div class="flex items-center justify-end">
       <button type="submit" data-invoice-pdf-upload-target="submitButton"
-              class="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+              class="bg-teal-600 text-white px-6 py-2 rounded-md hover:bg-teal-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
               disabled>
         仕訳変換を実行
       </button>
@@ -46,12 +46,12 @@
 
   <!-- ローディング -->
   <div data-invoice-pdf-upload-target="loading" class="hidden mt-8 text-center">
-    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    <p class="mt-2 text-gray-600">アップロード中...</p>
+    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-teal-600"></div>
+    <p class="mt-2 text-gray-400">アップロード中...</p>
   </div>
 
   <!-- エラー表示 -->
-  <div data-invoice-pdf-upload-target="error" class="hidden mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
-    <p class="text-red-800" data-invoice-pdf-upload-target="errorMessage"></p>
+  <div data-invoice-pdf-upload-target="error" class="hidden mt-6 bg-red-950 border border-red-700 rounded-lg p-4">
+    <p class="text-red-300" data-invoice-pdf-upload-target="errorMessage"></p>
   </div>
 </div>

--- a/rails/platform/app/views/journal_entries/edit.html.erb
+++ b/rails/platform/app/views/journal_entries/edit.html.erb
@@ -19,23 +19,23 @@
 
   <%= form_with(model: @entry, url: journal_entry_path(@entry, client_code: @client_code), method: :patch, class: "space-y-6") do |f| %>
     <!-- 基本情報（読み取り専用） -->
-    <div class="bg-gray-50 shadow rounded-lg p-6">
+    <div class="bg-gray-800 shadow rounded-lg p-6">
       <h2 class="text-lg font-semibold mb-4">基本情報（読み取り専用）</h2>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
         <div>
-          <span class="text-gray-500">取引日:</span>
+          <span class="text-gray-400">取引日:</span>
           <span class="font-medium ml-1"><%= @entry.date %></span>
         </div>
         <div>
-          <span class="text-gray-500">取引No:</span>
+          <span class="text-gray-400">取引No:</span>
           <span class="font-medium ml-1"><%= @entry.transaction_no %></span>
         </div>
         <div>
-          <span class="text-gray-500">ソース:</span>
+          <span class="text-gray-400">ソース:</span>
           <span class="font-medium ml-1"><%= @entry.source_type %></span>
         </div>
         <div>
-          <span class="text-gray-500">期間:</span>
+          <span class="text-gray-400">期間:</span>
           <span class="font-medium ml-1"><%= @entry.source_period %></span>
         </div>
       </div>
@@ -44,39 +44,39 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <!-- 借方 -->
       <%= render "shared/card" do %>
-        <h2 class="text-lg font-semibold mb-4 text-blue-700">借方</h2>
+        <h2 class="text-lg font-semibold mb-4 text-teal-400">借方</h2>
         <% if debit %>
           <%= f.fields_for :journal_entry_lines, debit do |lf| %>
             <%= lf.hidden_field :id %>
             <%= lf.hidden_field :side, value: "debit" %>
             <div class="space-y-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">勘定科目</label>
-                <%= lf.text_field :account, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">勘定科目</label>
+                <%= lf.text_field :account, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">補助科目</label>
-                <%= lf.text_field :sub_account, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">補助科目</label>
+                <%= lf.text_field :sub_account, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">部門</label>
-                <%= lf.text_field :department, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">部門</label>
+                <%= lf.text_field :department, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">取引先</label>
-                <%= lf.text_field :partner, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">取引先</label>
+                <%= lf.text_field :partner, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">税区分</label>
-                <%= lf.text_field :tax_category, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">税区分</label>
+                <%= lf.text_field :tax_category, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">インボイス</label>
-                <%= lf.text_field :invoice, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">インボイス</label>
+                <%= lf.text_field :invoice, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">金額</label>
-                <%= lf.number_field :amount, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">金額</label>
+                <%= lf.number_field :amount, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
             </div>
           <% end %>
@@ -92,32 +92,32 @@
             <%= lf.hidden_field :side, value: "credit" %>
             <div class="space-y-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">勘定科目</label>
-                <%= lf.text_field :account, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">勘定科目</label>
+                <%= lf.text_field :account, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">補助科目</label>
-                <%= lf.text_field :sub_account, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">補助科目</label>
+                <%= lf.text_field :sub_account, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">部門</label>
-                <%= lf.text_field :department, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">部門</label>
+                <%= lf.text_field :department, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">取引先</label>
-                <%= lf.text_field :partner, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">取引先</label>
+                <%= lf.text_field :partner, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">税区分</label>
-                <%= lf.text_field :tax_category, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">税区分</label>
+                <%= lf.text_field :tax_category, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">インボイス</label>
-                <%= lf.text_field :invoice, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">インボイス</label>
+                <%= lf.text_field :invoice, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">金額</label>
-                <%= lf.number_field :amount, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                <label class="block text-sm font-medium text-gray-300 mb-1">金額</label>
+                <%= lf.number_field :amount, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
               </div>
             </div>
           <% end %>
@@ -130,30 +130,30 @@
       <h2 class="text-lg font-semibold mb-4">その他</h2>
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">摘要</label>
-          <%= f.text_field :description, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+          <label class="block text-sm font-medium text-gray-300 mb-1">摘要</label>
+          <%= f.text_field :description, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">カード利用者</label>
-            <%= f.text_field :cardholder, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+            <label class="block text-sm font-medium text-gray-300 mb-1">カード利用者</label>
+            <%= f.text_field :cardholder, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
+            <label class="block text-sm font-medium text-gray-300 mb-1">ステータス</label>
             <%= f.select :status, [["OK", "ok"], ["要確認", "review_required"]],
-                  {}, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+                  {}, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
           </div>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">メモ</label>
-          <%= f.text_area :memo, rows: 3, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border" %>
+          <label class="block text-sm font-medium text-gray-300 mb-1">メモ</label>
+          <%= f.text_area :memo, rows: 3, class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
         </div>
       </div>
     <% end %>
 
     <div class="flex justify-end gap-4">
       <%= render "shared/button", label: "キャンセル", href: journal_entry_path(@entry, client_code: @client_code), variant: :secondary, size: :lg %>
-      <%= f.submit "保存", class: "bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 transition-colors cursor-pointer" %>
+      <%= f.submit "保存", class: "bg-teal-600 text-white px-6 py-2 rounded-md hover:bg-teal-700 transition-colors cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -13,9 +13,9 @@
   <form method="get" class="mb-6 flex flex-wrap gap-4 items-end">
     <input type="hidden" name="client_code" value="<%= @client_code %>">
     <div>
-      <label for="source_type" class="block text-sm font-medium text-gray-700 mb-1">ソースタイプ</label>
+      <label for="source_type" class="block text-sm font-medium text-gray-300 mb-1">ソースタイプ</label>
       <select name="source_type" id="source_type"
-              class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 px-3 py-2 border">
+              class="rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border">
         <option value="">全て</option>
         <option value="amex" <%= "selected" if @source_type == "amex" %>>Amex</option>
         <option value="bank" <%= "selected" if @source_type == "bank" %>>銀行</option>
@@ -29,99 +29,99 @@
         エクスポート
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
       </button>
-      <div data-dropdown-target="menu" class="hidden absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-30">
+      <div data-dropdown-target="menu" class="hidden absolute right-0 mt-1 w-56 bg-gray-900 border border-gray-700 rounded-md shadow-lg z-30">
         <%= link_to "CSV（従来形式）",
               export_journal_entries_path(client_code: @client_code, source_type: @source_type.presence, format_type: "csv"),
-              class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+              class: "block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700" %>
         <%= link_to "弥生会計（単一仕訳）",
               export_journal_entries_path(client_code: @client_code, source_type: @source_type.presence, format_type: "yayoi_single"),
-              class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+              class: "block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700" %>
       </div>
     </div>
   </form>
 
   <% if @entries.empty? %>
-    <p class="text-gray-500">仕訳が見つかりません。</p>
+    <p class="text-gray-400">仕訳が見つかりません。</p>
   <% else %>
-    <div class="bg-white shadow rounded-lg overflow-x-auto relative">
-      <table class="w-max min-w-full divide-y divide-gray-200 text-xs">
-        <thead class="bg-gray-50">
+    <div class="bg-gray-900 shadow rounded-lg overflow-x-auto relative">
+      <table class="w-max min-w-full divide-y divide-gray-700 text-xs">
+        <thead class="bg-gray-800">
           <tr>
             <%# 左端固定列 %>
-            <th class="sticky left-0 z-20 bg-gray-50 px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap w-[3.5rem] min-w-[3.5rem]">No</th>
-            <th class="sticky left-[3.5rem] z-20 bg-gray-50 px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap border-r border-gray-300">取引日</th>
+            <th class="sticky left-0 z-20 bg-gray-800 px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap w-[3.5rem] min-w-[3.5rem]">No</th>
+            <th class="sticky left-[3.5rem] z-20 bg-gray-800 px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap border-r border-gray-600">取引日</th>
             <%# 借方 %>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">借方勘定科目</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">借方補助科目</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">借方部門</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">借方取引先</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">借方税区分</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">借方インボイス</th>
-            <th class="px-3 py-3 text-right font-medium text-gray-500 uppercase whitespace-nowrap">借方金額(円)</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">借方勘定科目</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">借方補助科目</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">借方部門</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">借方取引先</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">借方税区分</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">借方インボイス</th>
+            <th class="px-3 py-3 text-right font-medium text-gray-400 uppercase whitespace-nowrap">借方金額(円)</th>
             <%# 貸方 %>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">貸方勘定科目</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">貸方補助科目</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">貸方部門</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">貸方取引先</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">貸方税区分</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">貸方インボイス</th>
-            <th class="px-3 py-3 text-right font-medium text-gray-500 uppercase whitespace-nowrap">貸方金額(円)</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">貸方勘定科目</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">貸方補助科目</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">貸方部門</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">貸方取引先</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">貸方税区分</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">貸方インボイス</th>
+            <th class="px-3 py-3 text-right font-medium text-gray-400 uppercase whitespace-nowrap">貸方金額(円)</th>
             <%# その他 %>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">摘要</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">タグ</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">メモ</th>
-            <th class="px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap">カード利用者</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">摘要</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">タグ</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">メモ</th>
+            <th class="px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap">カード利用者</th>
             <%# 右端固定列 %>
-            <th class="sticky right-[4rem] z-20 bg-gray-50 px-3 py-3 text-left font-medium text-gray-500 uppercase whitespace-nowrap border-l border-gray-300">ステータス</th>
-            <th class="sticky right-0 z-20 bg-gray-50 px-3 py-3 whitespace-nowrap border-l border-gray-300"></th>
+            <th class="sticky right-[4rem] z-20 bg-gray-800 px-3 py-3 text-left font-medium text-gray-400 uppercase whitespace-nowrap border-l border-gray-600">ステータス</th>
+            <th class="sticky right-0 z-20 bg-gray-800 px-3 py-3 whitespace-nowrap border-l border-gray-600"></th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-200">
+        <tbody class="divide-y divide-gray-700">
           <% @entries.each do |entry| %>
             <% debit = entry.debit_lines.first %>
             <% credit = entry.credit_lines.first %>
-            <tr class="hover:bg-gray-50 group">
+            <tr class="hover:bg-gray-800 group">
               <%# 左端固定列 %>
-              <td class="sticky left-0 z-10 bg-white group-hover:bg-gray-50 px-3 py-2 text-gray-900 whitespace-nowrap w-[3.5rem] min-w-[3.5rem]"><%= entry.transaction_no %></td>
-              <td class="sticky left-[3.5rem] z-10 bg-white group-hover:bg-gray-50 px-3 py-2 text-gray-900 whitespace-nowrap border-r border-gray-200"><%= entry.date %></td>
+              <td class="sticky left-0 z-10 bg-gray-900 group-hover:bg-gray-800 px-3 py-2 text-gray-100 whitespace-nowrap w-[3.5rem] min-w-[3.5rem]"><%= entry.transaction_no %></td>
+              <td class="sticky left-[3.5rem] z-10 bg-gray-900 group-hover:bg-gray-800 px-3 py-2 text-gray-100 whitespace-nowrap border-r border-gray-700"><%= entry.date %></td>
               <%# 借方 %>
-              <td class="px-3 py-2 text-gray-900 whitespace-nowrap"><%= debit&.account %></td>
-              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= debit&.sub_account.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= debit&.department.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-900 whitespace-nowrap max-w-[200px] truncate"><%= debit&.partner.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-900 whitespace-nowrap"><%= debit&.tax_category.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-900 whitespace-nowrap"><%= debit&.invoice.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-900 text-right whitespace-nowrap"><%= number_with_delimiter(debit&.amount) %></td>
+              <td class="px-3 py-2 text-gray-100 whitespace-nowrap"><%= debit&.account %></td>
+              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= debit&.sub_account.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= debit&.department.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-100 whitespace-nowrap max-w-[200px] truncate"><%= debit&.partner.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-100 whitespace-nowrap"><%= debit&.tax_category.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-100 whitespace-nowrap"><%= debit&.invoice.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-100 text-right whitespace-nowrap"><%= number_with_delimiter(debit&.amount) %></td>
               <%# 貸方 %>
-              <td class="px-3 py-2 text-gray-900 whitespace-nowrap"><%= credit&.account %></td>
-              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= credit&.sub_account.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= credit&.department.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-900 whitespace-nowrap max-w-[200px] truncate"><%= credit&.partner.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= credit&.tax_category.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= credit&.invoice.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-900 text-right whitespace-nowrap"><%= number_with_delimiter(credit&.amount) %></td>
+              <td class="px-3 py-2 text-gray-100 whitespace-nowrap"><%= credit&.account %></td>
+              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= credit&.sub_account.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= credit&.department.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-100 whitespace-nowrap max-w-[200px] truncate"><%= credit&.partner.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= credit&.tax_category.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= credit&.invoice.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-100 text-right whitespace-nowrap"><%= number_with_delimiter(credit&.amount) %></td>
               <%# その他 %>
-              <td class="px-3 py-2 text-gray-500 max-w-[250px] truncate">
+              <td class="px-3 py-2 text-gray-400 max-w-[250px] truncate">
                 <% unless entry.simple_entry? %>
-                  <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-100 text-purple-700 mr-1">複合</span>
+                  <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-900 text-purple-300 mr-1">複合</span>
                 <% end %>
                 <%= entry.description.presence || "—" %>
               </td>
-              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= entry.tag.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-500 max-w-[200px] truncate"><%= entry.memo.presence || "—" %></td>
-              <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= entry.cardholder.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= entry.tag.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-400 max-w-[200px] truncate"><%= entry.memo.presence || "—" %></td>
+              <td class="px-3 py-2 text-gray-400 whitespace-nowrap"><%= entry.cardholder.presence || "—" %></td>
               <%# 右端固定列 %>
-              <td class="sticky right-[4rem] z-10 bg-white group-hover:bg-gray-50 px-3 py-2 whitespace-nowrap border-l border-gray-200">
+              <td class="sticky right-[4rem] z-10 bg-gray-900 group-hover:bg-gray-800 px-3 py-2 whitespace-nowrap border-l border-gray-700">
                 <% if entry.status == "review_required" %>
                   <%= render "shared/badge", label: "要確認", variant: :warning %>
                 <% else %>
                   <%= render "shared/badge", label: "OK", variant: :success %>
                 <% end %>
               </td>
-              <td class="sticky right-0 z-10 bg-white group-hover:bg-gray-50 px-3 py-2 text-right whitespace-nowrap space-x-1 border-l border-gray-200">
-                <%= link_to "詳細", journal_entry_path(entry, client_code: @client_code), class: "text-blue-600 hover:text-blue-800" %>
+              <td class="sticky right-0 z-10 bg-gray-900 group-hover:bg-gray-800 px-3 py-2 text-right whitespace-nowrap space-x-1 border-l border-gray-700">
+                <%= link_to "詳細", journal_entry_path(entry, client_code: @client_code), class: "text-teal-400 hover:text-teal-300" %>
                 <% if entry.status == "review_required" %>
-                  <%= link_to "編集", edit_journal_entry_path(entry, client_code: @client_code), class: "text-orange-600 hover:text-orange-800" %>
+                  <%= link_to "編集", edit_journal_entry_path(entry, client_code: @client_code), class: "text-amber-500 hover:text-amber-400" %>
                 <% end %>
               </td>
             </tr>

--- a/rails/platform/app/views/journal_entries/show.html.erb
+++ b/rails/platform/app/views/journal_entries/show.html.erb
@@ -26,23 +26,23 @@
       <h2 class="text-lg font-semibold mb-4 border-b pb-2">基本情報</h2>
       <dl class="space-y-3">
         <div class="flex justify-between">
-          <dt class="text-sm text-gray-500">取引日</dt>
+          <dt class="text-sm text-gray-400">取引日</dt>
           <dd class="text-sm font-medium"><%= @entry.date %></dd>
         </div>
         <div class="flex justify-between">
-          <dt class="text-sm text-gray-500">ソースタイプ</dt>
+          <dt class="text-sm text-gray-400">ソースタイプ</dt>
           <dd class="text-sm font-medium"><%= @entry.source_type %></dd>
         </div>
         <div class="flex justify-between">
-          <dt class="text-sm text-gray-500">明細期間</dt>
+          <dt class="text-sm text-gray-400">明細期間</dt>
           <dd class="text-sm font-medium"><%= @entry.source_period %></dd>
         </div>
         <div class="flex justify-between">
-          <dt class="text-sm text-gray-500">カード利用者</dt>
+          <dt class="text-sm text-gray-400">カード利用者</dt>
           <dd class="text-sm font-medium"><%= @entry.cardholder.presence || "-" %></dd>
         </div>
         <div class="flex justify-between">
-          <dt class="text-sm text-gray-500">タグ</dt>
+          <dt class="text-sm text-gray-400">タグ</dt>
           <dd class="text-sm font-medium"><%= @entry.tag.presence || "-" %></dd>
         </div>
       </dl>
@@ -53,11 +53,11 @@
       <h2 class="text-lg font-semibold mb-4 border-b pb-2">摘要・メモ</h2>
       <dl class="space-y-3">
         <div>
-          <dt class="text-sm text-gray-500">摘要</dt>
+          <dt class="text-sm text-gray-400">摘要</dt>
           <dd class="text-sm font-medium mt-1"><%= @entry.description.presence || "-" %></dd>
         </div>
         <div>
-          <dt class="text-sm text-gray-500">メモ</dt>
+          <dt class="text-sm text-gray-400">メモ</dt>
           <dd class="text-sm font-medium mt-1"><%= @entry.memo.presence || "-" %></dd>
         </div>
       </dl>
@@ -65,39 +65,39 @@
 
     <!-- 借方 -->
     <%= render "shared/card" do %>
-      <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-blue-700">借方</h2>
+      <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-teal-400">借方</h2>
       <% @entry.debit_lines.each_with_index do |line, i| %>
         <% if i > 0 %>
-          <hr class="my-3 border-gray-200">
+          <hr class="my-3 border-gray-700">
         <% end %>
         <dl class="space-y-3">
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">勘定科目</dt>
+            <dt class="text-sm text-gray-400">勘定科目</dt>
             <dd class="text-sm font-medium"><%= line.account %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">補助科目</dt>
+            <dt class="text-sm text-gray-400">補助科目</dt>
             <dd class="text-sm font-medium"><%= line.sub_account.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">部門</dt>
+            <dt class="text-sm text-gray-400">部門</dt>
             <dd class="text-sm font-medium"><%= line.department.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">取引先</dt>
+            <dt class="text-sm text-gray-400">取引先</dt>
             <dd class="text-sm font-medium"><%= line.partner.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">税区分</dt>
+            <dt class="text-sm text-gray-400">税区分</dt>
             <dd class="text-sm font-medium"><%= line.tax_category.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">インボイス</dt>
+            <dt class="text-sm text-gray-400">インボイス</dt>
             <dd class="text-sm font-medium"><%= line.invoice.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">金額</dt>
-            <dd class="text-lg font-bold text-blue-700"><%= number_with_delimiter(line.amount) %>円</dd>
+            <dt class="text-sm text-gray-400">金額</dt>
+            <dd class="text-lg font-bold text-teal-400"><%= number_with_delimiter(line.amount) %>円</dd>
           </div>
         </dl>
       <% end %>
@@ -108,35 +108,35 @@
       <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-red-700">貸方</h2>
       <% @entry.credit_lines.each_with_index do |line, i| %>
         <% if i > 0 %>
-          <hr class="my-3 border-gray-200">
+          <hr class="my-3 border-gray-700">
         <% end %>
         <dl class="space-y-3">
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">勘定科目</dt>
+            <dt class="text-sm text-gray-400">勘定科目</dt>
             <dd class="text-sm font-medium"><%= line.account %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">補助科目</dt>
+            <dt class="text-sm text-gray-400">補助科目</dt>
             <dd class="text-sm font-medium"><%= line.sub_account.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">部門</dt>
+            <dt class="text-sm text-gray-400">部門</dt>
             <dd class="text-sm font-medium"><%= line.department.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">取引先</dt>
+            <dt class="text-sm text-gray-400">取引先</dt>
             <dd class="text-sm font-medium"><%= line.partner.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">税区分</dt>
+            <dt class="text-sm text-gray-400">税区分</dt>
             <dd class="text-sm font-medium"><%= line.tax_category.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">インボイス</dt>
+            <dt class="text-sm text-gray-400">インボイス</dt>
             <dd class="text-sm font-medium"><%= line.invoice.presence || "-" %></dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-sm text-gray-500">金額</dt>
+            <dt class="text-sm text-gray-400">金額</dt>
             <dd class="text-lg font-bold text-red-700"><%= number_with_delimiter(line.amount) %>円</dd>
           </div>
         </dl>

--- a/rails/platform/app/views/layouts/application.html.erb
+++ b/rails/platform/app/views/layouts/application.html.erb
@@ -25,28 +25,28 @@
   <body>
     <% if user_signed_in? %>
       <div <%= 'data-controller="sidebar"'.html_safe if @sidebar_client %>>
-      <nav class="bg-white border-b border-gray-200 fixed w-full z-10 top-0">
+      <nav class="bg-gray-900 border-b border-gray-700 fixed w-full z-10 top-0">
         <div class="container mx-auto px-5 py-3 flex items-center justify-between">
           <div class="flex items-center gap-3">
             <% if @sidebar_client %>
-              <button type="button" class="lg:hidden p-1 text-gray-600 hover:text-gray-900" data-action="click->sidebar#toggle">
+              <button type="button" class="lg:hidden p-1 text-gray-400 hover:text-gray-100" data-action="click->sidebar#toggle">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
               </button>
             <% end %>
-            <%= link_to "AI Suite", root_path, class: "font-semibold text-gray-800 hover:text-gray-600 transition-colors" %>
+            <%= link_to "AI Suite", root_path, class: "font-semibold text-gray-100 hover:text-gray-300 transition-colors" %>
             <% if @sidebar_client %>
               <span class="text-gray-400">/</span>
-              <%= link_to @sidebar_client.name, client_path(@sidebar_client), class: "text-sm text-gray-600 hover:text-gray-800 transition-colors" %>
+              <%= link_to @sidebar_client.name, client_path(@sidebar_client), class: "text-sm text-gray-400 hover:text-gray-100 transition-colors" %>
             <% else %>
               <% clients_active = current_page?(root_path) || current_page?(clients_path) || request.path.start_with?('/clients/') %>
               <%= link_to "クライアント一覧", clients_path,
-                    class: "text-sm #{clients_active ? 'text-blue-600 font-medium' : 'text-gray-500 hover:text-gray-700'} transition-colors" %>
+                    class: "text-sm #{clients_active ? 'text-teal-400 font-medium' : 'text-gray-400 hover:text-gray-300'} transition-colors" %>
             <% end %>
           </div>
           <div class="flex items-center gap-4">
-            <span class="text-sm text-gray-600"><%= current_user.email %></span>
+            <span class="text-sm text-gray-400"><%= current_user.email %></span>
             <%= button_to "ログアウト", destroy_user_session_path, method: :delete,
-                class: "text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-1 rounded transition" %>
+                class: "text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 px-3 py-1 rounded transition" %>
           </div>
         </div>
       </nav>
@@ -55,14 +55,14 @@
     <% flash_top = user_signed_in? ? "top-14" : "top-0" %>
     <% if notice %>
       <div class="fixed <%= flash_top %> left-0 right-0 z-20 flex justify-center px-5 pt-2">
-        <div class="bg-green-50 border border-green-300 text-green-800 text-sm px-4 py-2 rounded shadow max-w-xl w-full">
+        <div class="bg-green-950 border border-green-700 text-green-300 text-sm px-4 py-2 rounded shadow max-w-xl w-full">
           <%= notice %>
         </div>
       </div>
     <% end %>
     <% if alert %>
       <div class="fixed <%= flash_top %> left-0 right-0 z-20 flex justify-center px-5 pt-2">
-        <div class="bg-red-50 border border-red-300 text-red-800 text-sm px-4 py-2 rounded shadow max-w-xl w-full">
+        <div class="bg-red-950 border border-red-700 text-red-300 text-sm px-4 py-2 rounded shadow max-w-xl w-full">
           <%= alert %>
         </div>
       </div>

--- a/rails/platform/app/views/shared/_alert.html.erb
+++ b/rails/platform/app/views/shared/_alert.html.erb
@@ -9,10 +9,10 @@
   variant = local_assigns.fetch(:variant, :success).to_sym
 
   variant_classes = {
-    success: "bg-green-50 border-green-200 text-green-800",
-    error:   "bg-red-50 border-red-200 text-red-800",
-    warning: "bg-yellow-50 border-yellow-200 text-yellow-800",
-    info:    "bg-blue-50 border-blue-200 text-blue-800",
+    success: "bg-green-950 border-green-700 text-green-300",
+    error:   "bg-red-950 border-red-700 text-red-300",
+    warning: "bg-yellow-950 border-yellow-700 text-yellow-300",
+    info:    "bg-teal-950 border-teal-700 text-teal-300",
   }
 
   css = ["border rounded-lg p-4 text-sm", variant_classes[variant], local_assigns[:class]].compact.join(" ")

--- a/rails/platform/app/views/shared/_badge.html.erb
+++ b/rails/platform/app/views/shared/_badge.html.erb
@@ -10,12 +10,12 @@
   size    = local_assigns.fetch(:size, :sm).to_sym
 
   variant_classes = {
-    success: "bg-green-100 text-green-800",
-    info:    "bg-blue-100 text-blue-800",
-    warning: "bg-yellow-100 text-yellow-800",
-    danger:  "bg-red-100 text-red-800",
-    neutral: "bg-gray-100 text-gray-700",
-    purple:  "bg-purple-100 text-purple-700",
+    success: "bg-green-900 text-green-300",
+    info:    "bg-teal-900 text-teal-300",
+    warning: "bg-yellow-900 text-yellow-300",
+    danger:  "bg-red-900 text-red-300",
+    neutral: "bg-gray-700 text-gray-300",
+    purple:  "bg-purple-900 text-purple-300",
   }
 
   size_classes = {

--- a/rails/platform/app/views/shared/_breadcrumb.html.erb
+++ b/rails/platform/app/views/shared/_breadcrumb.html.erb
@@ -1,6 +1,6 @@
 <%# items: [{ label: "クライアント一覧", path: clients_path }, { label: "詳細" }] %>
 <%# 最後の要素はリンクなし（現在のページ） %>
-<nav aria-label="パンくずリスト" class="mb-4 text-sm text-gray-500">
+<nav aria-label="パンくずリスト" class="mb-4 text-sm text-gray-400">
   <ol class="flex items-center flex-wrap">
     <% items.each_with_index do |item, i| %>
       <li class="flex items-center">
@@ -8,7 +8,7 @@
           <span class="mx-1">/</span>
         <% end %>
         <% if item[:path].present? && i < items.size - 1 %>
-          <%= link_to item[:label], item[:path], class: "text-blue-600 hover:text-blue-800" %>
+          <%= link_to item[:label], item[:path], class: "text-teal-400 hover:text-teal-300" %>
         <% else %>
           <span><%= item[:label] %></span>
         <% end %>

--- a/rails/platform/app/views/shared/_button.html.erb
+++ b/rails/platform/app/views/shared/_button.html.erb
@@ -19,12 +19,12 @@
   disabled = local_assigns.fetch(:disabled, false)
 
   variant_classes = {
-    primary:   "bg-blue-600 text-white hover:bg-blue-700",
-    secondary: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+    primary:   "bg-teal-600 text-white hover:bg-teal-700",
+    secondary: "bg-gray-700 text-gray-300 hover:bg-gray-600",
     danger:    "bg-red-600 text-white hover:bg-red-700",
     success:   "bg-green-600 text-white hover:bg-green-700",
-    edit:      "bg-orange-600 text-white hover:bg-orange-700",
-    neutral:   "bg-gray-600 text-white hover:bg-gray-700",
+    edit:      "bg-amber-600 text-white hover:bg-amber-700",
+    neutral:   "bg-gray-600 text-white hover:bg-gray-500",
   }
 
   size_classes = {
@@ -34,7 +34,7 @@
   }
 
   base = "rounded-md transition-colors cursor-pointer"
-  base += " disabled:bg-gray-400 disabled:cursor-not-allowed" if disabled
+  base += " disabled:bg-gray-600 disabled:cursor-not-allowed" if disabled
   css = [base, variant_classes[variant], size_classes[size], local_assigns[:class]].compact.join(" ")
 %>
 <% if local_assigns[:href] %>

--- a/rails/platform/app/views/shared/_card.html.erb
+++ b/rails/platform/app/views/shared/_card.html.erb
@@ -9,7 +9,7 @@
   padding = local_assigns.fetch(:padding, "p-6")
   hover   = local_assigns.fetch(:hover, false)
 
-  base = "bg-white shadow rounded-lg #{padding}"
+  base = "bg-gray-900 shadow rounded-lg #{padding}"
   base += " hover:shadow-md transition-shadow" if hover
   css = [base, local_assigns[:class]].compact.join(" ")
 %>

--- a/rails/platform/app/views/shared/_sidebar.html.erb
+++ b/rails/platform/app/views/shared/_sidebar.html.erb
@@ -7,14 +7,14 @@
 
   <%# サイドバー本体 %>
   <aside data-sidebar-target="sidebar"
-         class="fixed top-14 left-0 bottom-0 w-56 bg-white border-r border-gray-200 z-30
+         class="fixed top-14 left-0 bottom-0 w-56 bg-gray-900 border-r border-gray-700 z-30
                 overflow-y-auto
                 -translate-x-full lg:translate-x-0 transition-transform duration-200">
     <nav class="py-4">
       <% sidebar_items(@sidebar_client).each do |item| %>
         <% active = current_sidebar_item?(item) %>
         <%= link_to item[:path],
-              class: "flex items-center gap-3 px-4 py-2.5 text-sm #{active ? 'bg-blue-50 text-blue-700 font-medium border-r-2 border-blue-700' : 'text-gray-700 hover:bg-gray-50'}" do %>
+              class: "flex items-center gap-3 px-4 py-2.5 text-sm #{active ? 'bg-teal-950 text-teal-400 font-medium border-r-2 border-teal-400' : 'text-gray-300 hover:bg-gray-800'}" do %>
           <%= render "shared/sidebar_icon", icon: item[:icon] %>
           <span><%= item[:label] %></span>
         <% end %>

--- a/rails/platform/app/views/shared/_table.html.erb
+++ b/rails/platform/app/views/shared/_table.html.erb
@@ -6,16 +6,16 @@
   Block:
     <tbody>の中身をyieldで受け取る
 %>
-<div class="bg-white shadow rounded-lg overflow-hidden <%= local_assigns[:class] %>">
-  <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50">
+<div class="bg-gray-900 shadow rounded-lg overflow-hidden <%= local_assigns[:class] %>">
+  <table class="min-w-full divide-y divide-gray-700">
+    <thead class="bg-gray-800">
       <tr>
         <% headers.each do |header| %>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase"><%= header %></th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase"><%= header %></th>
         <% end %>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-200">
+    <tbody class="divide-y divide-gray-700">
       <%= yield %>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- `@theme`のグレーパレットをティール系ダークにカスタマイズ（順序は標準通り: 低=明, 高=暗）
- ビュー全体のTailwindクラスをダークテーマ対応に移行（blue→teal, orange→amber, gray反転）
- 未使用のセマンティックトークン（accent, cta, status等）を削除し、Tailwind標準カラーを直接利用
- `@layer base`でbody背景色・フォーム入力フィールドの背景色を設定

## Test plan
- [x] ログイン画面の表示確認（ダーク背景、tealボタン）
- [x] ナビバー・サイドバーの表示確認（bg-gray-900、tealアクティブ状態）
- [x] クライアント一覧・詳細画面の表示確認
- [x] 仕訳一覧テーブルのスティッキーカラム・ホバー表示確認
- [x] フォーム入力フィールドの背景色・テキスト色確認（select, input, textarea）
- [x] バッジ・アラートの各バリアント表示確認
- [x] 仕訳詳細・編集画面の表示確認（借方teal/貸方red、パンくずリスト）

Closes #253