### PR TITLE
feat(platform): 清掃マニュアルのインタラクティブ実行モード (issue#212)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,8 +113,11 @@ PostgreSQL 16
     ├── journal_entry_lines  # 仕訳行（借方/貸方の明細行）
     ├── account_masters      # 勘定科目マッピングルール
     ├── statement_batches    # PDF 処理バッチ管理
-    ├── cleaning_manuals     # 清掃マニュアル（OperationAI）
-    └── active_storage_*     # ファイルストレージ（画像・PDF）
+    ├── cleaning_manuals           # 清掃マニュアル（OperationAI）
+    ├── cleaning_sessions          # 清掃セッション（OperationAI）
+    ├── cleaning_session_steps     # セッション内ステップ
+    ├── cleaning_session_attempts  # ステップ判定試行（AI判定結果）
+    └── active_storage_*           # ファイルストレージ（画像・PDF）
 ```
 
 ---
@@ -139,6 +142,16 @@ POST   /api/v1/cleaning_manuals/generate             # 画像から AI 生成
 GET    /api/v1/cleaning_manuals                      # マニュアル一覧
 GET    /api/v1/cleaning_manuals/:id                  # マニュアル詳細
 GET    /api/v1/cleaning_manuals/:id/status           # 生成状況確認
+
+# OperationAI — 清掃セッション（インタラクティブ実行）
+POST   /api/v1/cleaning_manuals/:id/cleaning_sessions  # セッション作成
+GET    /api/v1/cleaning_sessions/:id                    # セッション詳細
+GET    /api/v1/cleaning_sessions/:id/current_step       # 現在ステップ取得
+POST   /api/v1/cleaning_sessions/:id/judge              # AI 写真判定
+PATCH  /api/v1/cleaning_sessions/:id/skip               # ステップスキップ
+PATCH  /api/v1/cleaning_sessions/:id/suspend            # セッション中断
+PATCH  /api/v1/cleaning_sessions/:id/resume             # セッション再開
+GET    /api/v1/cleaning_sessions/:id/report             # 完了レポート
 ```
 
 ### リクエスト例
@@ -201,6 +214,8 @@ GET /api/v1/journal_entries?client_code=ikigai_stay&source_type=amex&status=revi
 | サービス | 責務 |
 |---|---|
 | `CleaningManualGeneratorService` | Claude Vision API で客室写真から清掃マニュアル生成 |
+| `CleaningSessionService` | 清掃セッションの状態管理（開始・判定・スキップ・中断/再開・完了・レポート） |
+| `CleaningPhotoJudgeService` | Claude Vision API で清掃写真の OK/NG 同期判定 |
 | `AmexStatementProcessorService` | Claude API で Amex PDF を仕訳データに変換 |
 | `BankStatementProcessorService` | Claude API で銀行明細 PDF を仕訳データに変換 |
 | `InvoiceProcessorService` | Claude API で請求書 PDF を仕訳データに変換 |

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -50,12 +50,6 @@ module Api
         step = @session.current_step
         return render_error("判定するステップがありません") unless step
 
-        # 同時リクエストでの重複判定を防止
-        step = @session.cleaning_session_steps.lock.find(step.id)
-        unless step.status.in?(%w[pending failed])
-          return render_error("このステップは既に処理済みです")
-        end
-
         photos = params[:photos] || []
         return render_error("写真を1枚以上送信してください") if photos.empty?
         return render_error("写真は#{MAX_IMAGE_COUNT}枚以下にしてください") if photos.size > MAX_IMAGE_COUNT
@@ -66,20 +60,33 @@ module Api
         oversized = photos.select { |img| img.size > MAX_IMAGE_SIZE }
         return render_error("画像は1枚あたり10MB以下にしてください。") if oversized.any?
 
-        result = CleaningSessionService.judge(
-          session: @session,
-          step: step,
-          photos: photos
-        )
+        # トランザクション内でロック取得→判定→更新を一括実行（重複判定防止）
+        result = ActiveRecord::Base.transaction do
+          locked_step = @session.cleaning_session_steps.lock.find(step.id)
+          unless locked_step.status.in?(%w[pending failed])
+            raise ActiveRecord::Rollback
+          end
+
+          CleaningSessionService.judge(
+            session: @session,
+            step: locked_step,
+            photos: photos
+          )
+        end
+
+        unless result
+          return render_error("このステップは既に処理済みです")
+        end
 
         if result[:success]
+          @session.reload
           auto_complete_if_done
 
           render json: {
             result: result[:result],
             feedback: result[:feedback],
             attempt_number: result[:attempt_number],
-            next_step: CleaningSessionService.current_step_data(@session.reload),
+            next_step: CleaningSessionService.current_step_data(@session),
             session_status: @session.status,
             completed_steps: @session.completed_steps_count,
             total_steps: @session.total_steps_count

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -1,0 +1,160 @@
+module Api
+  module V1
+    class CleaningSessionsController < BaseController
+      ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/webp].freeze
+      MAX_IMAGE_SIZE = 10.megabytes
+      MAX_IMAGE_COUNT = 5
+
+      before_action :require_feature!
+      before_action :set_session, except: [:create]
+
+      # POST /api/v1/cleaning_manuals/:cleaning_manual_id/cleaning_sessions
+      def create
+        manual = @current_client.cleaning_manuals.published.find_by(id: params[:cleaning_manual_id])
+        return render_not_found unless manual
+
+        staff_name = params[:staff_name]
+        return render_error("staff_name は必須です") if staff_name.blank?
+
+        session = CleaningSessionService.start(
+          cleaning_manual: manual,
+          staff_name: staff_name,
+          client: @current_client
+        )
+
+        render json: session_json(session), status: :created
+      rescue ActiveRecord::RecordInvalid => e
+        render_error(e.record.errors.full_messages.join(", "))
+      end
+
+      # GET /api/v1/cleaning_sessions/:id
+      def show
+        render json: session_json(@session)
+      end
+
+      # GET /api/v1/cleaning_sessions/:id/current_step
+      def current_step
+        step_data = CleaningSessionService.current_step_data(@session)
+
+        if step_data
+          render json: step_data
+        else
+          render json: { message: "すべてのステップが完了しています" }
+        end
+      end
+
+      # POST /api/v1/cleaning_sessions/:id/judge
+      def judge
+        return render_error("セッションは進行中ではありません") unless @session.in_progress?
+
+        step = @session.current_step
+        return render_error("判定するステップがありません") unless step
+
+        photos = params[:photos] || []
+        return render_error("写真を1枚以上送信してください") if photos.empty?
+        return render_error("写真は#{MAX_IMAGE_COUNT}枚以下にしてください") if photos.size > MAX_IMAGE_COUNT
+
+        invalid = photos.reject { |img| Marcel::MimeType.for(img.tempfile, name: img.original_filename).in?(ALLOWED_CONTENT_TYPES) }
+        return render_error("対応していない画像形式です。JPEG, PNG, WebP のみ対応しています。") if invalid.any?
+
+        oversized = photos.select { |img| img.size > MAX_IMAGE_SIZE }
+        return render_error("画像は1枚あたり10MB以下にしてください。") if oversized.any?
+
+        result = CleaningSessionService.judge(
+          session: @session,
+          step: step,
+          photos: photos
+        )
+
+        if result[:success]
+          auto_complete_if_done
+
+          render json: {
+            result: result[:result],
+            feedback: result[:feedback],
+            attempt_number: result[:attempt_number],
+            next_step: CleaningSessionService.current_step_data(@session.reload),
+            session_status: @session.status,
+            completed_steps: @session.completed_steps_count,
+            total_steps: @session.total_steps_count
+          }
+        else
+          render_error(result[:error])
+        end
+      end
+
+      # PATCH /api/v1/cleaning_sessions/:id/skip
+      def skip
+        return render_error("セッションは進行中ではありません") unless @session.in_progress?
+
+        step = CleaningSessionService.skip_step(@session)
+        return render_error("スキップするステップがありません") unless step
+
+        auto_complete_if_done
+
+        render json: {
+          skipped_step: { task: step.task, area_name: step.area_name },
+          next_step: CleaningSessionService.current_step_data(@session.reload),
+          session_status: @session.status,
+          completed_steps: @session.completed_steps_count,
+          total_steps: @session.total_steps_count
+        }
+      end
+
+      # PATCH /api/v1/cleaning_sessions/:id/suspend
+      def suspend
+        return render_error("セッションは進行中ではありません") unless @session.in_progress?
+
+        CleaningSessionService.suspend(@session)
+        render json: { status: @session.status }
+      end
+
+      # PATCH /api/v1/cleaning_sessions/:id/resume
+      def resume
+        return render_error("セッションは中断中ではありません") unless @session.suspended?
+
+        CleaningSessionService.resume(@session)
+        render json: session_json(@session.reload)
+      end
+
+      # GET /api/v1/cleaning_sessions/:id/report
+      def report
+        render json: CleaningSessionService.build_report(@session)
+      end
+
+      private
+
+      def set_session
+        @session = @current_client.cleaning_sessions.find_by(id: params[:id])
+        render_not_found unless @session
+      end
+
+      def require_feature!
+        return if @current_client&.feature_available?(:cleaning_manuals)
+
+        render json: { error: "この機能はご利用いただけません" }, status: :forbidden
+      end
+
+      def session_json(session)
+        {
+          id: session.id,
+          cleaning_manual_id: session.cleaning_manual_id,
+          staff_name: session.staff_name,
+          status: session.status,
+          started_at: session.started_at,
+          completed_at: session.completed_at,
+          total_steps: session.total_steps_count,
+          completed_steps: session.completed_steps_count
+        }
+      end
+
+      def auto_complete_if_done
+        return unless @session.in_progress?
+
+        if @session.current_step.nil?
+          CleaningSessionService.complete(@session)
+        end
+      end
+    end
+  end
+end

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -4,6 +4,7 @@ module Api
       ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/webp].freeze
       MAX_IMAGE_SIZE = 10.megabytes
       MAX_IMAGE_COUNT = 5
+      MAX_ATTEMPTS_PER_STEP = 10
 
       before_action :require_feature!
       before_action :set_session, except: [ :create ]
@@ -49,6 +50,7 @@ module Api
 
         step = @session.current_step
         return render_error("判定するステップがありません") unless step
+        return render_error("このステップの判定回数上限（#{MAX_ATTEMPTS_PER_STEP}回）に達しました。スキップしてください。") if step.attempts_count >= MAX_ATTEMPTS_PER_STEP
 
         photos = Array.wrap(params[:photos]).select { |p| p.respond_to?(:tempfile) }
         return render_error("写真を1枚以上送信してください") if photos.empty?
@@ -68,7 +70,7 @@ module Api
 
         if result[:success]
           @session.reload
-          auto_complete_if_done
+          CleaningSessionService.auto_complete_if_done(@session)
 
           render json: {
             result: result[:result],
@@ -92,7 +94,7 @@ module Api
         return render_error("スキップするステップがありません") unless step
 
         @session.reload
-        auto_complete_if_done
+        CleaningSessionService.auto_complete_if_done(@session)
 
         response = {
           skipped_step: { task: step.task, area_name: step.area_name },
@@ -103,7 +105,7 @@ module Api
         }
 
         if @session.suspended?
-          response[:error] = "すべてのステップがスキップされました。清掃を最初からやり直してください。"
+          response[:warning] = "すべてのステップがスキップされました。清掃を最初からやり直してください。"
         end
 
         render json: response
@@ -156,16 +158,6 @@ module Api
         }
       end
 
-      def auto_complete_if_done
-        return unless @session.in_progress?
-        return if @session.current_step
-
-        if @session.step_counts.fetch("passed", 0).zero?
-          CleaningSessionService.suspend(@session)
-        else
-          CleaningSessionService.complete(@session)
-        end
-      end
     end
   end
 end

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -160,7 +160,6 @@ module Api
         return unless @session.in_progress?
         return if @session.current_step
 
-        @session.reload
         if @session.step_counts.fetch("passed", 0).zero?
           CleaningSessionService.suspend(@session)
         else

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -91,15 +91,22 @@ module Api
         step = CleaningSessionService.skip_step(@session)
         return render_error("スキップするステップがありません") unless step
 
+        @session.reload
         auto_complete_if_done
 
-        render json: {
+        response = {
           skipped_step: { task: step.task, area_name: step.area_name },
-          next_step: CleaningSessionService.current_step_data(@session.reload),
+          next_step: CleaningSessionService.current_step_data(@session),
           session_status: @session.status,
           completed_steps: @session.completed_steps_count,
           total_steps: @session.total_steps_count
         }
+
+        if @session.suspended?
+          response[:error] = "すべてのステップがスキップされました。清掃を最初からやり直してください。"
+        end
+
+        render json: response
       end
 
       # PATCH /api/v1/cleaning_sessions/:id/suspend
@@ -151,8 +158,12 @@ module Api
 
       def auto_complete_if_done
         return unless @session.in_progress?
+        return if @session.current_step
 
-        if @session.current_step.nil?
+        @session.reload
+        if @session.step_counts.fetch("passed", 0).zero?
+          CleaningSessionService.suspend(@session)
+        else
           CleaningSessionService.complete(@session)
         end
       end

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -50,7 +50,7 @@ module Api
 
         step = @session.current_step
         return render_error("判定するステップがありません") unless step
-        return render_error("このステップの判定回数上限（#{MAX_ATTEMPTS_PER_STEP}回）に達しました。スキップしてください。") if step.attempts_count >= MAX_ATTEMPTS_PER_STEP
+        return render_error("このステップの判定回数上限に達しました。スキップしてください。") if step.attempts_count >= MAX_ATTEMPTS_PER_STEP
 
         photos = Array.wrap(params[:photos]).select { |p| p.respond_to?(:tempfile) }
         return render_error("写真を1枚以上送信してください") if photos.empty?

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -60,29 +60,11 @@ module Api
         oversized = photos.select { |img| img.size > MAX_IMAGE_SIZE }
         return render_error("画像は1枚あたり10MB以下にしてください。") if oversized.any?
 
-        # トランザクション内でロック取得→判定→更新を一括実行（重複判定防止）
-        already_processed = false
-        result = ActiveRecord::Base.transaction do
-          locked_step = @session.cleaning_session_steps.lock.find(step.id)
-          unless locked_step.status.in?(%w[pending failed])
-            already_processed = true
-            raise ActiveRecord::Rollback
-          end
-
-          CleaningSessionService.judge(
-            session: @session,
-            step: locked_step,
-            photos: photos
-          )
-        end
-
-        if already_processed
-          return render_error("このステップは既に処理済みです")
-        end
-
-        unless result
-          return render_error("判定処理中にエラーが発生しました")
-        end
+        result = CleaningSessionService.judge(
+          session: @session,
+          step: step,
+          photos: photos
+        )
 
         if result[:success]
           @session.reload

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -50,6 +50,12 @@ module Api
         step = @session.current_step
         return render_error("判定するステップがありません") unless step
 
+        # 同時リクエストでの重複判定を防止
+        step = @session.cleaning_session_steps.lock.find(step.id)
+        unless step.status.in?(%w[pending failed])
+          return render_error("このステップは既に処理済みです")
+        end
+
         photos = params[:photos] || []
         return render_error("写真を1枚以上送信してください") if photos.empty?
         return render_error("写真は#{MAX_IMAGE_COUNT}枚以下にしてください") if photos.size > MAX_IMAGE_COUNT

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -4,7 +4,7 @@ module Api
       ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/webp].freeze
       MAX_IMAGE_SIZE = 10.megabytes
       MAX_IMAGE_COUNT = 5
-      MAX_ATTEMPTS_PER_STEP = 10
+      MAX_ATTEMPTS_PER_STEP = CleaningSessionService::MAX_ATTEMPTS_PER_STEP
 
       before_action :require_feature!
       before_action :set_session, except: [ :create ]

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -6,7 +6,7 @@ module Api
       MAX_IMAGE_COUNT = 5
 
       before_action :require_feature!
-      before_action :set_session, except: [:create]
+      before_action :set_session, except: [ :create ]
 
       # POST /api/v1/cleaning_manuals/:cleaning_manual_id/cleaning_sessions
       def create

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -157,7 +157,6 @@ module Api
           completed_steps: session.completed_steps_count
         }
       end
-
     end
   end
 end

--- a/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_sessions_controller.rb
@@ -50,7 +50,7 @@ module Api
         step = @session.current_step
         return render_error("判定するステップがありません") unless step
 
-        photos = params[:photos] || []
+        photos = Array.wrap(params[:photos]).select { |p| p.respond_to?(:tempfile) }
         return render_error("写真を1枚以上送信してください") if photos.empty?
         return render_error("写真は#{MAX_IMAGE_COUNT}枚以下にしてください") if photos.size > MAX_IMAGE_COUNT
 
@@ -61,9 +61,11 @@ module Api
         return render_error("画像は1枚あたり10MB以下にしてください。") if oversized.any?
 
         # トランザクション内でロック取得→判定→更新を一括実行（重複判定防止）
+        already_processed = false
         result = ActiveRecord::Base.transaction do
           locked_step = @session.cleaning_session_steps.lock.find(step.id)
           unless locked_step.status.in?(%w[pending failed])
+            already_processed = true
             raise ActiveRecord::Rollback
           end
 
@@ -74,8 +76,12 @@ module Api
           )
         end
 
-        unless result
+        if already_processed
           return render_error("このステップは既に処理済みです")
+        end
+
+        unless result
+          return render_error("判定処理中にエラーが発生しました")
         end
 
         if result[:success]
@@ -119,7 +125,7 @@ module Api
         return render_error("セッションは進行中ではありません") unless @session.in_progress?
 
         CleaningSessionService.suspend(@session)
-        render json: { status: @session.status }
+        render json: { status: @session.reload.status }
       end
 
       # PATCH /api/v1/cleaning_sessions/:id/resume

--- a/rails/platform/app/controllers/cleaning_manuals_controller.rb
+++ b/rails/platform/app/controllers/cleaning_manuals_controller.rb
@@ -14,6 +14,7 @@ class CleaningManualsController < ApplicationController
 
   def show
     @manual = CleaningManual.for_client(@client_code).find(params[:id])
+    @suspended_session = @manual.cleaning_sessions.where(status: "suspended").order(updated_at: :desc).first
   end
 
   def new

--- a/rails/platform/app/controllers/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/cleaning_sessions_controller.rb
@@ -23,8 +23,8 @@ class CleaningSessionsController < ApplicationController
   private
 
   def set_client
-    @client_code = params[:client_code].presence || ""
-    @client = Client.find_by(code: @client_code) if @client_code.present?
+    @client_code = params[:client_code].presence
+    @client = Client.find_by(code: @client_code) if @client_code
   end
 
   def require_feature!

--- a/rails/platform/app/controllers/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/cleaning_sessions_controller.rb
@@ -23,8 +23,8 @@ class CleaningSessionsController < ApplicationController
   private
 
   def set_client
-    @client_code = params[:client_code] || ""
-    @client = Client.find_by(code: @client_code)
+    @client_code = params[:client_code].presence || ""
+    @client = Client.find_by(code: @client_code) if @client_code.present?
   end
 
   def require_feature!

--- a/rails/platform/app/controllers/cleaning_sessions_controller.rb
+++ b/rails/platform/app/controllers/cleaning_sessions_controller.rb
@@ -1,0 +1,43 @@
+class CleaningSessionsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  before_action :set_client
+  before_action :require_feature!
+
+  def new
+    @manual = CleaningManual.for_client(@client_code).published.find(params[:cleaning_manual_id])
+    @manual_data = @manual.manual_data.deep_symbolize_keys
+  end
+
+  def show
+    @session = CleaningSession.for_client(@client_code).find(params[:id])
+    @manual = @session.cleaning_manual
+  end
+
+  def report
+    @session = CleaningSession.for_client(@client_code).find(params[:id])
+    @manual = @session.cleaning_manual
+    @report = CleaningSessionService.build_report(@session)
+  end
+
+  private
+
+  def set_client
+    @client_code = params[:client_code] || ""
+    @client = Client.find_by(code: @client_code)
+  end
+
+  def require_feature!
+    return if @client&.feature_available?(:cleaning_manuals)
+
+    if @client
+      redirect_to client_path(@client), alert: "この機能はご利用いただけません"
+    else
+      redirect_to clients_path, alert: "クライアントを選択してください"
+    end
+  end
+
+  def record_not_found
+    redirect_to cleaning_manuals_path(client_code: @client_code), alert: "セッションが見つかりません"
+  end
+end

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -158,21 +158,17 @@ export default class extends Controller {
     this.setButtonsEnabled(false)
 
     const formData = new FormData()
-    formData.append("client_code", this.clientCodeValue)
     this.files.forEach(file => formData.append("photos[]", file))
 
     this.abortController = new AbortController()
     const timeoutId = setTimeout(() => this.abortController.abort(), 60000)
 
     try {
-      const response = await fetch(
-        `/api/v1/cleaning_sessions/${this.sessionIdValue}/judge?client_code=${encodeURIComponent(this.clientCodeValue)}`,
+      const response = await this.apiFetch(
+        `/api/v1/cleaning_sessions/${this.sessionIdValue}/judge`,
         {
           method: "POST",
           body: formData,
-          headers: {
-            "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content
-          },
           signal: this.abortController.signal
         }
       )

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -28,6 +28,22 @@ export default class extends Controller {
 
   async loadCurrentStep() {
     try {
+      // 中断中セッションの場合は自動再開
+      const sessionRes = await this.apiFetch(`/api/v1/cleaning_sessions/${this.sessionIdValue}`)
+      const session = await sessionRes.json()
+
+      if (session.status === "suspended") {
+        const resumeRes = await this.apiFetch(
+          `/api/v1/cleaning_sessions/${this.sessionIdValue}/resume`,
+          { method: "PATCH" }
+        )
+        if (!resumeRes.ok) {
+          const err = await resumeRes.json()
+          this.showError(err.error || "再開に失敗しました。")
+          return
+        }
+      }
+
       const response = await this.apiFetch(`/api/v1/cleaning_sessions/${this.sessionIdValue}/current_step`)
       const data = await response.json()
 

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -17,7 +17,6 @@ export default class extends Controller {
     this.files = []
     this.objectURLs = []
     this.abortController = null
-    this.lastFormData = null
     this.loadCurrentStep()
   }
 
@@ -157,7 +156,6 @@ export default class extends Controller {
     const formData = new FormData()
     formData.append("client_code", this.clientCodeValue)
     this.files.forEach(file => formData.append("photos[]", file))
-    this.lastFormData = formData
 
     this.abortController = new AbortController()
     const timeoutId = setTimeout(() => this.abortController.abort(), 60000)
@@ -192,6 +190,8 @@ export default class extends Controller {
         setTimeout(() => this.showCompleted(), 2000)
       } else if (data.result === "ok" && data.next_step) {
         setTimeout(() => this.updateStepDisplay(data.next_step), 2000)
+      } else if (data.result === "ng") {
+        setTimeout(() => this.resetPhotoState(), 2000)
       }
     } catch (error) {
       clearTimeout(timeoutId)

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -144,7 +144,7 @@ export default class extends Controller {
     this.lastFormData = formData
 
     this.abortController = new AbortController()
-    const timeoutId = setTimeout(() => this.abortController.abort(), 30000)
+    const timeoutId = setTimeout(() => this.abortController.abort(), 60000)
 
     try {
       const response = await fetch(

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -32,6 +32,10 @@ export default class extends Controller {
       const session = await sessionRes.json()
 
       if (session.status === "suspended") {
+        if (!confirm("中断中のセッションがあります。再開しますか？")) {
+          window.location.href = `/cleaning_manuals?client_code=${encodeURIComponent(this.clientCodeValue)}`
+          return
+        }
         const resumeRes = await this.apiFetch(
           `/api/v1/cleaning_sessions/${this.sessionIdValue}/resume`,
           { method: "PATCH" }
@@ -173,7 +177,6 @@ export default class extends Controller {
         }
       )
 
-      clearTimeout(timeoutId)
       const data = await response.json()
 
       if (!response.ok) {
@@ -194,7 +197,6 @@ export default class extends Controller {
         setTimeout(() => this.resetPhotoState(), 2000)
       }
     } catch (error) {
-      clearTimeout(timeoutId)
       if (error.name === "AbortError") {
         this.showError("判定がタイムアウトしました。再試行してください。")
       } else {
@@ -202,6 +204,7 @@ export default class extends Controller {
       }
       this.showRetryButton()
     } finally {
+      clearTimeout(timeoutId)
       this.hideLoading()
       this.setButtonsEnabled(true)
       this.abortController = null

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -1,0 +1,332 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "progressBar", "progressText", "progressPercent",
+    "stepArea", "areaName", "stepTask", "stepDescription", "stepCheckpoint", "stepTime",
+    "cameraInput", "cameraButton", "photoPreview", "photoGrid",
+    "judgeButton", "skipButton", "suspendButton",
+    "loading", "judgeResult", "judgeResultCard", "judgeResultBadge", "judgeResultLabel", "judgeResultFeedback",
+    "completedArea", "reportLink",
+    "error", "errorMessage", "retryButton"
+  ]
+
+  static values = { sessionId: Number, clientCode: String, manualName: String }
+
+  connect() {
+    this.files = []
+    this.objectURLs = []
+    this.abortController = null
+    this.lastFormData = null
+    this.loadCurrentStep()
+  }
+
+  disconnect() {
+    this.revokeObjectURLs()
+    if (this.abortController) this.abortController.abort()
+  }
+
+  async loadCurrentStep() {
+    try {
+      const response = await this.apiFetch(`/api/v1/cleaning_sessions/${this.sessionIdValue}/current_step`)
+      const data = await response.json()
+
+      if (data.message) {
+        this.showCompleted()
+        return
+      }
+
+      this.updateStepDisplay(data)
+      this.updateProgress(data.completed_steps, data.total_steps)
+    } catch (error) {
+      this.showError(`読み込みエラー: ${error.message}`)
+    }
+  }
+
+  updateStepDisplay(step) {
+    this.areaNameTarget.textContent = step.area_name
+    this.stepTaskTarget.textContent = step.task
+    this.stepDescriptionTarget.textContent = step.description || ""
+    this.stepCheckpointTarget.textContent = step.checkpoint || ""
+    this.stepTimeTarget.textContent = step.estimated_minutes ? `推定 ${step.estimated_minutes}分` : ""
+
+    this.resetPhotoState()
+    this.hideJudgeResult()
+    this.hideError()
+    this.stepAreaTarget.classList.remove("hidden")
+    this.completedAreaTarget.classList.add("hidden")
+  }
+
+  updateProgress(completed, total) {
+    const percent = total > 0 ? Math.round((completed / total) * 100) : 0
+    this.progressTextTarget.textContent = `${completed} / ${total} ステップ完了`
+    this.progressPercentTarget.textContent = `${percent}%`
+    this.progressBarTarget.style.width = `${percent}%`
+  }
+
+  openCamera() {
+    this.cameraInputTarget.click()
+  }
+
+  photosSelected(event) {
+    const newFiles = Array.from(event.target.files)
+    if (newFiles.length === 0) return
+
+    this.files = [...this.files, ...newFiles]
+    this.updatePhotoPreview()
+    this.judgeButtonTarget.disabled = false
+    this.cameraInputTarget.value = ""
+  }
+
+  updatePhotoPreview() {
+    if (this.files.length === 0) {
+      this.photoPreviewTarget.classList.add("hidden")
+      return
+    }
+
+    this.photoPreviewTarget.classList.remove("hidden")
+    this.revokeObjectURLs()
+    this.photoGridTarget.innerHTML = ""
+
+    this.files.forEach((file, index) => {
+      const div = document.createElement("div")
+      div.className = "relative group"
+
+      const img = document.createElement("img")
+      img.className = "w-full h-20 object-cover rounded-lg"
+      const url = URL.createObjectURL(file)
+      this.objectURLs.push(url)
+      img.src = url
+
+      const removeBtn = document.createElement("button")
+      removeBtn.type = "button"
+      removeBtn.className = "absolute top-0.5 right-0.5 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+      removeBtn.textContent = "\u00d7"
+      removeBtn.addEventListener("click", () => this.removePhoto(index))
+
+      div.appendChild(img)
+      div.appendChild(removeBtn)
+      this.photoGridTarget.appendChild(div)
+    })
+  }
+
+  removePhoto(index) {
+    this.files.splice(index, 1)
+    this.updatePhotoPreview()
+    this.judgeButtonTarget.disabled = this.files.length === 0
+  }
+
+  resetPhotoState() {
+    this.files = []
+    this.revokeObjectURLs()
+    this.photoPreviewTarget.classList.add("hidden")
+    this.photoGridTarget.innerHTML = ""
+    this.judgeButtonTarget.disabled = true
+    this.cameraInputTarget.value = ""
+  }
+
+  revokeObjectURLs() {
+    this.objectURLs.forEach(url => URL.revokeObjectURL(url))
+    this.objectURLs = []
+  }
+
+  async judgeStep() {
+    if (this.files.length === 0) return
+
+    this.hideError()
+    this.hideJudgeResult()
+    this.showLoading()
+    this.setButtonsEnabled(false)
+
+    const formData = new FormData()
+    formData.append("client_code", this.clientCodeValue)
+    this.files.forEach(file => formData.append("photos[]", file))
+    this.lastFormData = formData
+
+    this.abortController = new AbortController()
+    const timeoutId = setTimeout(() => this.abortController.abort(), 30000)
+
+    try {
+      const response = await fetch(
+        `/api/v1/cleaning_sessions/${this.sessionIdValue}/judge?client_code=${encodeURIComponent(this.clientCodeValue)}`,
+        {
+          method: "POST",
+          body: formData,
+          headers: {
+            "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content
+          },
+          signal: this.abortController.signal
+        }
+      )
+
+      clearTimeout(timeoutId)
+      const data = await response.json()
+
+      if (!response.ok) {
+        this.showError(data.error || "判定に失敗しました。")
+        this.showRetryButton()
+        this.setButtonsEnabled(true)
+        return
+      }
+
+      this.showJudgeResult(data)
+      this.updateProgress(data.completed_steps, data.total_steps)
+
+      if (data.session_status === "completed") {
+        setTimeout(() => this.showCompleted(), 2000)
+      } else if (data.result === "ok" && data.next_step) {
+        setTimeout(() => this.updateStepDisplay(data.next_step), 2000)
+      }
+    } catch (error) {
+      clearTimeout(timeoutId)
+      if (error.name === "AbortError") {
+        this.showError("判定がタイムアウトしました。再試行してください。")
+      } else {
+        this.showError(`通信エラー: ${error.message}`)
+      }
+      this.showRetryButton()
+    } finally {
+      this.hideLoading()
+      this.setButtonsEnabled(true)
+      this.abortController = null
+    }
+  }
+
+  cancelJudge() {
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+  }
+
+  retryJudge() {
+    this.hideError()
+    this.judgeStep()
+  }
+
+  async skipStep() {
+    this.hideError()
+    this.setButtonsEnabled(false)
+
+    try {
+      const response = await this.apiFetch(
+        `/api/v1/cleaning_sessions/${this.sessionIdValue}/skip`,
+        { method: "PATCH" }
+      )
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        this.showError(data.error || "スキップに失敗しました。")
+        return
+      }
+
+      this.updateProgress(data.completed_steps, data.total_steps)
+
+      if (data.session_status === "completed") {
+        this.showCompleted()
+      } else if (data.next_step) {
+        this.updateStepDisplay(data.next_step)
+      } else {
+        this.showCompleted()
+      }
+    } catch (error) {
+      this.showError(`通信エラー: ${error.message}`)
+    } finally {
+      this.setButtonsEnabled(true)
+    }
+  }
+
+  async suspend() {
+    if (!confirm("清掃を中断しますか？後で再開できます。")) return
+
+    try {
+      const response = await this.apiFetch(
+        `/api/v1/cleaning_sessions/${this.sessionIdValue}/suspend`,
+        { method: "PATCH" }
+      )
+
+      if (response.ok) {
+        window.location.href = `/cleaning_manuals?client_code=${encodeURIComponent(this.clientCodeValue)}`
+      } else {
+        const data = await response.json()
+        this.showError(data.error || "中断に失敗しました。")
+      }
+    } catch (error) {
+      this.showError(`通信エラー: ${error.message}`)
+    }
+  }
+
+  showLoading() {
+    this.loadingTarget.classList.remove("hidden")
+  }
+
+  hideLoading() {
+    this.loadingTarget.classList.add("hidden")
+  }
+
+  showJudgeResult(data) {
+    this.judgeResultTarget.classList.remove("hidden")
+
+    if (data.result === "ok") {
+      this.judgeResultCardTarget.className = "bg-green-950 border border-green-700 shadow rounded-lg p-4"
+      this.judgeResultBadgeTarget.className = "text-sm font-medium px-2.5 py-0.5 rounded-full bg-green-900 text-green-400"
+      this.judgeResultBadgeTarget.textContent = "OK"
+      this.judgeResultLabelTarget.className = "text-sm font-medium text-green-400"
+      this.judgeResultLabelTarget.textContent = "合格"
+      this.judgeResultFeedbackTarget.className = "text-sm text-green-300"
+    } else {
+      this.judgeResultCardTarget.className = "bg-red-950 border border-red-700 shadow rounded-lg p-4"
+      this.judgeResultBadgeTarget.className = "text-sm font-medium px-2.5 py-0.5 rounded-full bg-red-900 text-red-400"
+      this.judgeResultBadgeTarget.textContent = "NG"
+      this.judgeResultLabelTarget.className = "text-sm font-medium text-red-400"
+      this.judgeResultLabelTarget.textContent = "修正が必要です"
+      this.judgeResultFeedbackTarget.className = "text-sm text-red-300"
+    }
+
+    this.judgeResultFeedbackTarget.textContent = data.feedback || ""
+  }
+
+  hideJudgeResult() {
+    this.judgeResultTarget.classList.add("hidden")
+  }
+
+  showCompleted() {
+    this.stepAreaTarget.classList.add("hidden")
+    this.completedAreaTarget.classList.remove("hidden")
+    this.reportLinkTarget.href = `/cleaning_sessions/${this.sessionIdValue}/report?client_code=${encodeURIComponent(this.clientCodeValue)}`
+  }
+
+  showError(message) {
+    this.errorMessageTarget.textContent = message
+    this.errorTarget.classList.remove("hidden")
+  }
+
+  hideError() {
+    this.errorTarget.classList.add("hidden")
+    this.retryButtonTarget.classList.add("hidden")
+  }
+
+  showRetryButton() {
+    this.retryButtonTarget.classList.remove("hidden")
+  }
+
+  setButtonsEnabled(enabled) {
+    this.judgeButtonTarget.disabled = !enabled || this.files.length === 0
+    this.skipButtonTarget.disabled = !enabled
+    this.cameraButtonTarget.disabled = !enabled
+    this.suspendButtonTarget.disabled = !enabled
+  }
+
+  async apiFetch(url, options = {}) {
+    const separator = url.includes("?") ? "&" : "?"
+    const fullUrl = `${url}${separator}client_code=${encodeURIComponent(this.clientCodeValue)}`
+
+    return fetch(fullUrl, {
+      ...options,
+      headers: {
+        "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content,
+        ...(options.headers || {})
+      }
+    })
+  }
+}

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -199,6 +199,10 @@ export default class extends Controller {
   }
 
   retryJudge() {
+    if (this.files.length === 0) {
+      this.showError("写真を撮影してから再試行してください。")
+      return
+    }
     this.hideError()
     this.judgeStep()
   }

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -242,8 +242,8 @@ export default class extends Controller {
 
       this.updateProgress(data.completed_steps, data.total_steps)
 
-      if (data.error) {
-        this.showError(data.error)
+      if (data.warning) {
+        this.showError(data.warning)
       } else if (data.session_status === "completed") {
         this.showCompleted()
       } else if (data.next_step) {

--- a/rails/platform/app/javascript/controllers/cleaning_session_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_controller.js
@@ -226,7 +226,9 @@ export default class extends Controller {
 
       this.updateProgress(data.completed_steps, data.total_steps)
 
-      if (data.session_status === "completed") {
+      if (data.error) {
+        this.showError(data.error)
+      } else if (data.session_status === "completed") {
         this.showCompleted()
       } else if (data.next_step) {
         this.updateStepDisplay(data.next_step)

--- a/rails/platform/app/javascript/controllers/cleaning_session_start_controller.js
+++ b/rails/platform/app/javascript/controllers/cleaning_session_start_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["staffName", "submitButton", "error", "errorMessage"]
+  static values = { clientCode: String, manualId: Number }
+
+  async start() {
+    const staffName = this.staffNameTarget.value.trim()
+    if (!staffName) {
+      this.showError("担当者名を入力してください。")
+      return
+    }
+
+    this.hideError()
+    this.submitButtonTarget.disabled = true
+    this.submitButtonTarget.textContent = "開始中..."
+
+    try {
+      const formData = new FormData()
+      formData.append("staff_name", staffName)
+      formData.append("client_code", this.clientCodeValue)
+
+      const response = await fetch(
+        `/api/v1/cleaning_manuals/${this.manualIdValue}/cleaning_sessions?client_code=${encodeURIComponent(this.clientCodeValue)}`,
+        {
+          method: "POST",
+          body: formData,
+          headers: {
+            "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content
+          }
+        }
+      )
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        this.showError(data.error || "セッションの開始に失敗しました。")
+        return
+      }
+
+      window.location.href = `/cleaning_sessions/${data.id}?client_code=${encodeURIComponent(this.clientCodeValue)}`
+    } catch (error) {
+      this.showError(`通信エラー: ${error.message}`)
+    } finally {
+      this.submitButtonTarget.disabled = false
+      this.submitButtonTarget.textContent = "清掃を開始する"
+    }
+  }
+
+  showError(message) {
+    this.errorMessageTarget.textContent = message
+    this.errorTarget.classList.remove("hidden")
+  }
+
+  hideError() {
+    this.errorTarget.classList.add("hidden")
+  }
+}

--- a/rails/platform/app/models/cleaning_manual.rb
+++ b/rails/platform/app/models/cleaning_manual.rb
@@ -2,6 +2,7 @@ class CleaningManual < ApplicationRecord
   STATUSES = %w[processing draft published failed].freeze
 
   belongs_to :client
+  has_many :cleaning_sessions, dependent: :restrict_with_error
   has_many_attached :images
 
   validates :property_name, presence: true

--- a/rails/platform/app/models/cleaning_session.rb
+++ b/rails/platform/app/models/cleaning_session.rb
@@ -14,9 +14,9 @@ class CleaningSession < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
 
   def current_step
-    cleaning_session_steps.ordered
+    cleaning_session_steps
       .where(status: %w[failed pending])
-      .order(Arel.sql("CASE status WHEN 'failed' THEN 0 ELSE 1 END"))
+      .reorder(Arel.sql("CASE status WHEN 'failed' THEN 0 ELSE 1 END"), :area_index, :step_index)
       .first
   end
 

--- a/rails/platform/app/models/cleaning_session.rb
+++ b/rails/platform/app/models/cleaning_session.rb
@@ -1,0 +1,40 @@
+class CleaningSession < ApplicationRecord
+  STATUSES = %w[in_progress completed suspended].freeze
+
+  belongs_to :cleaning_manual
+  belongs_to :client
+  has_many :cleaning_session_steps, -> { ordered }, dependent: :destroy
+
+  validates :staff_name, presence: true
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :started_at, presence: true
+
+  scope :for_client, ->(code) { where(client: Client.where(code: code)) }
+  scope :active, -> { where(status: "in_progress") }
+  scope :recent, -> { order(created_at: :desc) }
+
+  def current_step
+    cleaning_session_steps.ordered.find_by(status: "pending") ||
+      cleaning_session_steps.ordered.find_by(status: "failed")
+  end
+
+  def total_steps_count
+    cleaning_session_steps.size
+  end
+
+  def completed_steps_count
+    cleaning_session_steps.where(status: %w[passed skipped]).count
+  end
+
+  def in_progress?
+    status == "in_progress"
+  end
+
+  def completed?
+    status == "completed"
+  end
+
+  def suspended?
+    status == "suspended"
+  end
+end

--- a/rails/platform/app/models/cleaning_session.rb
+++ b/rails/platform/app/models/cleaning_session.rb
@@ -5,6 +5,8 @@ class CleaningSession < ApplicationRecord
   belongs_to :client
   has_many :cleaning_session_steps, -> { ordered }, dependent: :destroy
 
+  before_validation :strip_staff_name
+
   validates :staff_name, presence: true, length: { maximum: 100 }
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :started_at, presence: true
@@ -47,5 +49,11 @@ class CleaningSession < ApplicationRecord
 
   def suspended?
     status == "suspended"
+  end
+
+  private
+
+  def strip_staff_name
+    self.staff_name = staff_name&.strip
   end
 end

--- a/rails/platform/app/models/cleaning_session.rb
+++ b/rails/platform/app/models/cleaning_session.rb
@@ -14,8 +14,10 @@ class CleaningSession < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
 
   def current_step
-    cleaning_session_steps.ordered.find_by(status: "failed") ||
-      cleaning_session_steps.ordered.find_by(status: "pending")
+    cleaning_session_steps.ordered
+      .where(status: %w[failed pending])
+      .order(Arel.sql("CASE status WHEN 'failed' THEN 0 ELSE 1 END"))
+      .first
   end
 
   def step_counts

--- a/rails/platform/app/models/cleaning_session.rb
+++ b/rails/platform/app/models/cleaning_session.rb
@@ -14,16 +14,25 @@ class CleaningSession < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
 
   def current_step
-    cleaning_session_steps.ordered.find_by(status: "pending") ||
-      cleaning_session_steps.ordered.find_by(status: "failed")
+    cleaning_session_steps.ordered.find_by(status: "failed") ||
+      cleaning_session_steps.ordered.find_by(status: "pending")
+  end
+
+  def step_counts
+    @step_counts ||= cleaning_session_steps.reorder(nil).group(:status).count
   end
 
   def total_steps_count
-    cleaning_session_steps.size
+    step_counts.values.sum
   end
 
   def completed_steps_count
-    cleaning_session_steps.where(status: %w[passed skipped]).count
+    step_counts.fetch("passed", 0) + step_counts.fetch("skipped", 0)
+  end
+
+  def reload(*)
+    @step_counts = nil
+    super
   end
 
   def in_progress?

--- a/rails/platform/app/models/cleaning_session.rb
+++ b/rails/platform/app/models/cleaning_session.rb
@@ -5,7 +5,7 @@ class CleaningSession < ApplicationRecord
   belongs_to :client
   has_many :cleaning_session_steps, -> { ordered }, dependent: :destroy
 
-  validates :staff_name, presence: true
+  validates :staff_name, presence: true, length: { maximum: 100 }
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :started_at, presence: true
 

--- a/rails/platform/app/models/cleaning_session_attempt.rb
+++ b/rails/platform/app/models/cleaning_session_attempt.rb
@@ -1,0 +1,10 @@
+class CleaningSessionAttempt < ApplicationRecord
+  RESULTS = %w[ok ng].freeze
+
+  belongs_to :cleaning_session_step
+  has_many_attached :photos
+
+  validates :attempt_number, presence: true
+  validates :result, presence: true, inclusion: { in: RESULTS }
+  validates :judged_at, presence: true
+end

--- a/rails/platform/app/models/cleaning_session_attempt.rb
+++ b/rails/platform/app/models/cleaning_session_attempt.rb
@@ -4,7 +4,7 @@ class CleaningSessionAttempt < ApplicationRecord
   belongs_to :cleaning_session_step
   has_many_attached :photos
 
-  validates :attempt_number, presence: true
+  validates :attempt_number, presence: true, uniqueness: { scope: :cleaning_session_step_id }
   validates :result, presence: true, inclusion: { in: RESULTS }
   validates :judged_at, presence: true
 end

--- a/rails/platform/app/models/cleaning_session_step.rb
+++ b/rails/platform/app/models/cleaning_session_step.rb
@@ -1,0 +1,12 @@
+class CleaningSessionStep < ApplicationRecord
+  STATUSES = %w[pending passed failed skipped].freeze
+
+  belongs_to :cleaning_session
+  has_many :cleaning_session_attempts, -> { order(:attempt_number) }, dependent: :destroy
+
+  validates :area_name, presence: true
+  validates :task, presence: true
+  validates :status, presence: true, inclusion: { in: STATUSES }
+
+  scope :ordered, -> { order(area_index: :asc, step_index: :asc) }
+end

--- a/rails/platform/app/models/client.rb
+++ b/rails/platform/app/models/client.rb
@@ -16,6 +16,7 @@ class Client < ApplicationRecord
   has_many :journal_entries, dependent: :restrict_with_error
   has_many :account_masters, dependent: :restrict_with_error
   has_many :cleaning_manuals, dependent: :restrict_with_error
+  has_many :cleaning_sessions, dependent: :restrict_with_error
   has_many :statement_batches, dependent: :restrict_with_error
 
   # === バリデーション ===

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -6,6 +6,7 @@ class CleaningPhotoJudgeService
   end
 
   MAX_IMAGE_LONG_EDGE = 1568
+  VALID_RESULTS = %w[ok ng].freeze
 
   SYSTEM_PROMPT = <<~PROMPT
     あなたは宿泊施設の清掃品質を検査する専門家です。
@@ -50,9 +51,15 @@ class CleaningPhotoJudgeService
     json_str = extract_json(text)
     data = JSON.parse(json_str, symbolize_names: true)
 
+    normalized_result = data[:result].to_s.downcase.strip
+    unless VALID_RESULTS.include?(normalized_result)
+      return Result.new(success: false, result: nil, feedback: nil,
+                        error: "AIの判定結果が不正です: #{data[:result]}")
+    end
+
     Result.new(
       success: true,
-      result: data[:result],
+      result: normalized_result,
       feedback: data[:feedback],
       error: nil
     )

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -124,11 +124,7 @@ class CleaningPhotoJudgeService
                       .call
     { data: File.binread(result.path), media_type: "image/jpeg" }
   ensure
-    if result
-      result_path = result.path if result.respond_to?(:path)
-      result.close! if result.respond_to?(:close!)
-      File.delete(result_path) if result_path && File.exist?(result_path)
-    end
+    result.close! if result.respond_to?(:close!)
     photo.rewind if photo.respond_to?(:rewind)
   end
 

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -67,8 +67,8 @@ class CleaningPhotoJudgeService
     Result.new(success: false, result: nil, feedback: nil, error: "Anthropic API エラー: #{e.message}")
   rescue JSON::ParserError => e
     Result.new(success: false, result: nil, feedback: nil, error: "JSON パースエラー: #{e.message}")
-  rescue StandardError => e
-    Result.new(success: false, result: nil, feedback: nil, error: "予期しないエラー: #{e.message}")
+  rescue IOError, Vips::Error => e
+    Result.new(success: false, result: nil, feedback: nil, error: "画像処理エラー: #{e.message}")
   end
 
   private

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -41,7 +41,7 @@ class CleaningPhotoJudgeService
       model: ENV.fetch("ANTHROPIC_MODEL", "claude-sonnet-4-6"),
       max_tokens: 1024,
       system: SYSTEM_PROMPT,
-      messages: [{ role: "user", content: content }]
+      messages: [ { role: "user", content: content } ]
     )
 
     text_block = response.content.find { |c| c.respond_to?(:type) && c.type.to_s == "text" }
@@ -111,11 +111,11 @@ class CleaningPhotoJudgeService
   def resize_image(photo)
     source = if photo.respond_to?(:tempfile)
                photo.tempfile.path
-             elsif photo.respond_to?(:path)
+    elsif photo.respond_to?(:path)
                photo.path
-             else
+    else
                photo.to_s
-             end
+    end
 
     processor = ImageProcessing::Vips.source(source)
     result = processor.resize_to_limit(MAX_IMAGE_LONG_EDGE, MAX_IMAGE_LONG_EDGE)

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -1,0 +1,138 @@
+require "image_processing/vips"
+
+class CleaningPhotoJudgeService
+  Result = Data.define(:success, :result, :feedback, :error) do
+    alias_method :success?, :success
+  end
+
+  MAX_IMAGE_LONG_EDGE = 1568
+
+  SYSTEM_PROMPT = <<~PROMPT
+    あなたは宿泊施設の清掃品質を検査する専門家です。
+    清掃スタッフが撮影した写真を見て、指定された清掃タスクが完了基準を満たしているか判定してください。
+
+    ## 判定ルール
+    - 完了基準（チェックポイント）を満たしている場合: "ok"
+    - 完了基準を満たしていない場合: "ng"
+    - 迷った場合は "ng" とし、具体的な確認ポイントを修正指示として提示してください
+
+    ## 出力形式（JSON のみ、他のテキストは含めないでください）
+    {
+      "result": "ok" or "ng",
+      "feedback": "判定理由（OKの場合は確認できた点、NGの場合は具体的な修正指示）"
+    }
+  PROMPT
+
+  def initialize(photos:, task:, description:, checkpoint:)
+    @photos = Array(photos)
+    @task = task
+    @description = description
+    @checkpoint = checkpoint
+  end
+
+  def call
+    unless ENV["ANTHROPIC_API_KEY"].present?
+      return Result.new(success: false, result: nil, feedback: nil, error: "ANTHROPIC_API_KEY が設定されていません")
+    end
+
+    content = build_content
+    response = client.messages.create(
+      model: ENV.fetch("ANTHROPIC_MODEL", "claude-sonnet-4-6"),
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: "user", content: content }]
+    )
+
+    text_block = response.content.find { |c| c.respond_to?(:type) && c.type.to_s == "text" }
+    text = text_block&.respond_to?(:text) ? text_block.text : text_block.to_s
+    raise JSON::ParserError, "APIからテキスト応答がありませんでした" if text.blank?
+
+    json_str = extract_json(text)
+    data = JSON.parse(json_str, symbolize_names: true)
+
+    Result.new(
+      success: true,
+      result: data[:result],
+      feedback: data[:feedback],
+      error: nil
+    )
+  rescue Anthropic::Errors::APIError => e
+    Result.new(success: false, result: nil, feedback: nil, error: "Anthropic API エラー: #{e.message}")
+  rescue JSON::ParserError => e
+    Result.new(success: false, result: nil, feedback: nil, error: "JSON パースエラー: #{e.message}")
+  rescue StandardError => e
+    Result.new(success: false, result: nil, feedback: nil, error: "予期しないエラー: #{e.message}")
+  end
+
+  private
+
+  def build_content
+    content = []
+
+    @photos.each_with_index do |photo, i|
+      resized = resize_image(photo)
+      image_data = Base64.strict_encode64(resized[:data])
+
+      content << {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: resized[:media_type],
+          data: image_data
+        }
+      }
+
+      content << { type: "text", text: "写真#{i + 1}" } if @photos.size > 1
+    end
+
+    content << {
+      type: "text",
+      text: <<~TEXT
+        以下の清掃タスクの完了状態を判定してください。
+
+        【タスク】#{@task}
+        【作業内容】#{@description}
+        【チェックポイント（完了基準）】#{@checkpoint}
+
+        JSONのみで出力してください。
+      TEXT
+    }
+
+    content
+  end
+
+  def resize_image(photo)
+    source = if photo.respond_to?(:tempfile)
+               photo.tempfile.path
+             elsif photo.respond_to?(:path)
+               photo.path
+             else
+               photo.to_s
+             end
+
+    processor = ImageProcessing::Vips.source(source)
+    result = processor.resize_to_limit(MAX_IMAGE_LONG_EDGE, MAX_IMAGE_LONG_EDGE)
+                      .convert("jpeg")
+                      .saver(quality: 80)
+                      .call
+    { data: File.binread(result.path), media_type: "image/jpeg" }
+  ensure
+    if result.respond_to?(:close)
+      result.close
+      result.unlink if result.respond_to?(:unlink)
+    end
+    photo.rewind if photo.respond_to?(:rewind)
+  end
+
+  def extract_json(text)
+    if text =~ /```(?:json)?\s*\n?(.*?)\n?```/m
+      $1.strip
+    else
+      text.strip
+    end
+  end
+
+  def client
+    @client ||= Anthropic::Client.new(timeout: 30.0)
+  end
+end

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -124,7 +124,10 @@ class CleaningPhotoJudgeService
                       .call
     { data: File.binread(result.path), media_type: "image/jpeg" }
   ensure
-    result.close! if result.respond_to?(:close!)
+    if result
+      File.delete(result.path) if result.respond_to?(:path) && File.exist?(result.path)
+      result.close if result.respond_to?(:close)
+    end
     photo.rewind if photo.respond_to?(:rewind)
   end
 

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -124,7 +124,11 @@ class CleaningPhotoJudgeService
                       .call
     { data: File.binread(result.path), media_type: "image/jpeg" }
   ensure
-    result.close! if result.respond_to?(:close!)
+    if result
+      result_path = result.path if result.respond_to?(:path)
+      result.close! if result.respond_to?(:close!)
+      File.delete(result_path) if result_path && File.exist?(result_path)
+    end
     photo.rewind if photo.respond_to?(:rewind)
   end
 

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -124,10 +124,7 @@ class CleaningPhotoJudgeService
                       .call
     { data: File.binread(result.path), media_type: "image/jpeg" }
   ensure
-    if result.respond_to?(:close)
-      result.close
-      result.unlink if result.respond_to?(:unlink)
-    end
+    result.close! if result.respond_to?(:close!)
     photo.rewind if photo.respond_to?(:rewind)
   end
 
@@ -140,6 +137,6 @@ class CleaningPhotoJudgeService
   end
 
   def client
-    @client ||= Anthropic::Client.new(timeout: 30.0)
+    @client ||= Anthropic::Client.new(timeout: 45.0)
   end
 end

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -73,9 +73,14 @@ class CleaningSessionService
         return { success: false, error: judge_result.error }
       end
 
-      # 3. DB更新（短いトランザクション — attempts_count + attempt + status を一括）
+      # 3. DB更新（短いトランザクション — ロック再取得 + 状態再検証 + 一括更新）
       attempt = nil
       ActiveRecord::Base.transaction do
+        locked_step = session.cleaning_session_steps.lock.find(locked_step.id)
+        unless locked_step.status.in?(%w[pending failed])
+          return { success: false, error: "このステップは既に処理済みです" }
+        end
+
         CleaningSessionStep.where(id: locked_step.id).update_all("attempts_count = attempts_count + 1")
         locked_step.reload
 
@@ -104,10 +109,16 @@ class CleaningSessionService
     end
 
     def skip_step(session)
-      step = session.current_step
-      return nil unless step
+      step = ActiveRecord::Base.transaction do
+        s = session.current_step
+        return nil unless s
 
-      step.update!(status: "skipped")
+        locked = session.cleaning_session_steps.lock.find(s.id)
+        return nil unless locked.status.in?(%w[pending failed])
+
+        locked.update!(status: "skipped")
+        locked
+      end
       step
     end
 

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -89,8 +89,9 @@ class CleaningSessionService
         CleaningSessionStep.where(id: locked_step.id).update_all("attempts_count = attempts_count + 1")
         locked_step.reload
 
+        next_attempt_number = locked_step.cleaning_session_attempts.maximum(:attempt_number).to_i + 1
         attempt = locked_step.cleaning_session_attempts.create!(
-          attempt_number: locked_step.attempts_count,
+          attempt_number: next_attempt_number,
           result: judge_result.result,
           ai_feedback: judge_result.feedback,
           judged_at: Time.current

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -21,6 +21,9 @@ class CleaningSessionService
             area_index: area_idx,
             step_index: step_idx,
             task: step[:task],
+            description: step[:description],
+            checkpoint: step[:checkpoint],
+            estimated_minutes: step[:estimated_minutes],
             status: "pending"
           )
         end
@@ -34,17 +37,15 @@ class CleaningSessionService
       step = session.current_step
       return nil unless step
 
-      manual_step = find_manual_step(session, step)
-
       {
         step_id: step.id,
         area_name: step.area_name,
         area_index: step.area_index,
         step_index: step.step_index,
         task: step.task,
-        description: manual_step&.dig(:description),
-        checkpoint: manual_step&.dig(:checkpoint),
-        estimated_minutes: manual_step&.dig(:estimated_minutes),
+        description: step.description,
+        checkpoint: step.checkpoint,
+        estimated_minutes: step.estimated_minutes,
         status: step.status,
         attempts_count: step.attempts_count,
         total_steps: session.total_steps_count,
@@ -53,13 +54,11 @@ class CleaningSessionService
     end
 
     def judge(session:, step:, photos:)
-      manual_step = find_manual_step(session, step)
-
       judge_result = CleaningPhotoJudgeService.new(
         photos: photos,
         task: step.task,
-        description: manual_step&.dig(:description) || "",
-        checkpoint: manual_step&.dig(:checkpoint) || ""
+        description: step.description || "",
+        checkpoint: step.checkpoint || ""
       ).call
 
       unless judge_result.success?
@@ -157,17 +156,6 @@ class CleaningSessionService
         total_attempts: steps.sum(&:attempts_count),
         area_results: area_results
       }
-    end
-
-    private
-
-    def find_manual_step(session, step)
-      manual_data = session.cleaning_manual.manual_data.deep_symbolize_keys
-      areas = manual_data[:areas] || []
-      area = areas[step.area_index]
-      return nil unless area
-
-      (area[:cleaning_steps] || [])[step.step_index]
     end
   end
 end

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -134,6 +134,17 @@ class CleaningSessionService
       session.update!(status: "completed", completed_at: Time.current)
     end
 
+    def auto_complete_if_done(session)
+      return unless session.in_progress?
+      return if session.current_step
+
+      if session.step_counts.fetch("passed", 0).zero?
+        suspend(session)
+      else
+        complete(session)
+      end
+    end
+
     def build_report(session)
       steps = session.cleaning_session_steps.includes(
         cleaning_session_attempts: { photos_attachments: :blob }

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -162,7 +162,7 @@ class CleaningSessionService
 
       duration_minutes = if session.started_at && session.completed_at
                            ((session.completed_at - session.started_at) / 60.0).round(1)
-                         end
+      end
 
       {
         session_id: session.id,

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -1,4 +1,6 @@
 class CleaningSessionService
+  MAX_ATTEMPTS_PER_STEP = 10
+
   class << self
     def start(cleaning_manual:, staff_name:, client:)
       manual_data = cleaning_manual.manual_data.deep_symbolize_keys
@@ -54,12 +56,13 @@ class CleaningSessionService
     end
 
     def judge(session:, step:, photos:)
-      # 1. ロック取得 + 状態チェック（短いトランザクション）
+      # 1. ロック取得 + 状態チェック + 試行回数上限チェック（短いトランザクション）
       locked_step = ActiveRecord::Base.transaction do
         s = session.cleaning_session_steps.lock.find(step.id)
         s.status.in?(%w[pending failed]) ? s : nil
       end
       return { success: false, error: "このステップは既に処理済みです" } unless locked_step
+      return { success: false, error: "このステップの判定回数上限に達しました" } if locked_step.attempts_count >= MAX_ATTEMPTS_PER_STEP
 
       # 2. AI判定（トランザクション外 — ロック保持しない）
       judge_result = CleaningPhotoJudgeService.new(
@@ -177,7 +180,7 @@ class CleaningSessionService
 
       duration_minutes = if session.started_at && session.completed_at
                            ((session.completed_at - session.started_at) / 60.0).round(1)
-      end
+                         end
 
       {
         session_id: session.id,

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -1,8 +1,8 @@
 class CleaningSessionService
   class << self
     def start(cleaning_manual:, staff_name:, client:)
-      manual_data = cleaning_manual.manual_data
-      areas = manual_data["areas"] || manual_data[:areas] || []
+      manual_data = cleaning_manual.manual_data.deep_symbolize_keys
+      areas = manual_data[:areas] || []
 
       session = CleaningSession.new(
         cleaning_manual: cleaning_manual,
@@ -13,15 +13,14 @@ class CleaningSessionService
       )
 
       areas.each_with_index do |area, area_idx|
-        area_name = area["area_name"] || area[:area_name]
-        steps = area["cleaning_steps"] || area[:cleaning_steps] || []
+        steps = area[:cleaning_steps] || []
 
         steps.each_with_index do |step, step_idx|
           session.cleaning_session_steps.build(
-            area_name: area_name,
+            area_name: area[:area_name],
             area_index: area_idx,
             step_index: step_idx,
-            task: step["task"] || step[:task],
+            task: step[:task],
             status: "pending"
           )
         end
@@ -35,10 +34,7 @@ class CleaningSessionService
       step = session.current_step
       return nil unless step
 
-      manual_data = session.cleaning_manual.manual_data
-      areas = manual_data["areas"] || manual_data[:areas] || []
-      area = areas[step.area_index]
-      manual_step = (area["cleaning_steps"] || area[:cleaning_steps] || [])[step.step_index] if area
+      manual_step = find_manual_step(session, step)
 
       {
         step_id: step.id,
@@ -46,9 +42,9 @@ class CleaningSessionService
         area_index: step.area_index,
         step_index: step.step_index,
         task: step.task,
-        description: manual_step && (manual_step["description"] || manual_step[:description]),
-        checkpoint: manual_step && (manual_step["checkpoint"] || manual_step[:checkpoint]),
-        estimated_minutes: manual_step && (manual_step["estimated_minutes"] || manual_step[:estimated_minutes]),
+        description: manual_step&.dig(:description),
+        checkpoint: manual_step&.dig(:checkpoint),
+        estimated_minutes: manual_step&.dig(:estimated_minutes),
         status: step.status,
         attempts_count: step.attempts_count,
         total_steps: session.total_steps_count,
@@ -57,35 +53,31 @@ class CleaningSessionService
     end
 
     def judge(session:, step:, photos:)
-      manual_data = session.cleaning_manual.manual_data
-      areas = manual_data["areas"] || manual_data[:areas] || []
-      area = areas[step.area_index]
-      manual_step = (area["cleaning_steps"] || area[:cleaning_steps] || [])[step.step_index] if area
-
-      description = manual_step && (manual_step["description"] || manual_step[:description]) || ""
-      checkpoint = manual_step && (manual_step["checkpoint"] || manual_step[:checkpoint]) || ""
+      manual_step = find_manual_step(session, step)
 
       judge_result = CleaningPhotoJudgeService.new(
         photos: photos,
         task: step.task,
-        description: description,
-        checkpoint: checkpoint
+        description: manual_step&.dig(:description) || "",
+        checkpoint: manual_step&.dig(:checkpoint) || ""
       ).call
 
       unless judge_result.success?
         return { success: false, error: judge_result.error }
       end
 
+      # DB レベルでインクリメントして race condition を防止
+      CleaningSessionStep.where(id: step.id).update_all("attempts_count = attempts_count + 1")
+      step.reload
+
       attempt = step.cleaning_session_attempts.create!(
-        attempt_number: step.attempts_count + 1,
+        attempt_number: step.attempts_count,
         result: judge_result.result,
         ai_feedback: judge_result.feedback,
         judged_at: Time.current
       )
 
       photos.each { |photo| attempt.photos.attach(photo) }
-
-      step.update!(attempts_count: step.attempts_count + 1)
 
       if judge_result.result == "ok"
         step.update!(status: "passed", passed_at: Time.current)
@@ -165,6 +157,17 @@ class CleaningSessionService
         total_attempts: steps.sum(&:attempts_count),
         area_results: area_results
       }
+    end
+
+    private
+
+    def find_manual_step(session, step)
+      manual_data = session.cleaning_manual.manual_data.deep_symbolize_keys
+      areas = manual_data[:areas] || []
+      area = areas[step.area_index]
+      return nil unless area
+
+      (area[:cleaning_steps] || [])[step.step_index]
     end
   end
 end

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -1,0 +1,170 @@
+class CleaningSessionService
+  class << self
+    def start(cleaning_manual:, staff_name:, client:)
+      manual_data = cleaning_manual.manual_data
+      areas = manual_data["areas"] || manual_data[:areas] || []
+
+      session = CleaningSession.new(
+        cleaning_manual: cleaning_manual,
+        client: client,
+        staff_name: staff_name,
+        status: "in_progress",
+        started_at: Time.current
+      )
+
+      areas.each_with_index do |area, area_idx|
+        area_name = area["area_name"] || area[:area_name]
+        steps = area["cleaning_steps"] || area[:cleaning_steps] || []
+
+        steps.each_with_index do |step, step_idx|
+          session.cleaning_session_steps.build(
+            area_name: area_name,
+            area_index: area_idx,
+            step_index: step_idx,
+            task: step["task"] || step[:task],
+            status: "pending"
+          )
+        end
+      end
+
+      session.save!
+      session
+    end
+
+    def current_step_data(session)
+      step = session.current_step
+      return nil unless step
+
+      manual_data = session.cleaning_manual.manual_data
+      areas = manual_data["areas"] || manual_data[:areas] || []
+      area = areas[step.area_index]
+      manual_step = (area["cleaning_steps"] || area[:cleaning_steps] || [])[step.step_index] if area
+
+      {
+        step_id: step.id,
+        area_name: step.area_name,
+        area_index: step.area_index,
+        step_index: step.step_index,
+        task: step.task,
+        description: manual_step && (manual_step["description"] || manual_step[:description]),
+        checkpoint: manual_step && (manual_step["checkpoint"] || manual_step[:checkpoint]),
+        estimated_minutes: manual_step && (manual_step["estimated_minutes"] || manual_step[:estimated_minutes]),
+        status: step.status,
+        attempts_count: step.attempts_count,
+        total_steps: session.total_steps_count,
+        completed_steps: session.completed_steps_count
+      }
+    end
+
+    def judge(session:, step:, photos:)
+      manual_data = session.cleaning_manual.manual_data
+      areas = manual_data["areas"] || manual_data[:areas] || []
+      area = areas[step.area_index]
+      manual_step = (area["cleaning_steps"] || area[:cleaning_steps] || [])[step.step_index] if area
+
+      description = manual_step && (manual_step["description"] || manual_step[:description]) || ""
+      checkpoint = manual_step && (manual_step["checkpoint"] || manual_step[:checkpoint]) || ""
+
+      judge_result = CleaningPhotoJudgeService.new(
+        photos: photos,
+        task: step.task,
+        description: description,
+        checkpoint: checkpoint
+      ).call
+
+      unless judge_result.success?
+        return { success: false, error: judge_result.error }
+      end
+
+      attempt = step.cleaning_session_attempts.create!(
+        attempt_number: step.attempts_count + 1,
+        result: judge_result.result,
+        ai_feedback: judge_result.feedback,
+        judged_at: Time.current
+      )
+
+      photos.each { |photo| attempt.photos.attach(photo) }
+
+      step.update!(attempts_count: step.attempts_count + 1)
+
+      if judge_result.result == "ok"
+        step.update!(status: "passed", passed_at: Time.current)
+      else
+        step.update!(status: "failed")
+      end
+
+      {
+        success: true,
+        result: judge_result.result,
+        feedback: judge_result.feedback,
+        attempt_number: attempt.attempt_number
+      }
+    end
+
+    def skip_step(session)
+      step = session.current_step
+      return nil unless step
+
+      step.update!(status: "skipped")
+      step
+    end
+
+    def suspend(session)
+      session.update!(status: "suspended")
+    end
+
+    def resume(session)
+      session.update!(status: "in_progress")
+    end
+
+    def complete(session)
+      session.update!(status: "completed", completed_at: Time.current)
+    end
+
+    def build_report(session)
+      steps = session.cleaning_session_steps.includes(
+        cleaning_session_attempts: { photos_attachments: :blob }
+      ).ordered
+
+      area_results = steps.group_by(&:area_name).map do |area_name, area_steps|
+        {
+          area_name: area_name,
+          steps: area_steps.map do |step|
+            {
+              task: step.task,
+              status: step.status,
+              attempts_count: step.attempts_count,
+              attempts: step.cleaning_session_attempts.map do |attempt|
+                {
+                  attempt_number: attempt.attempt_number,
+                  result: attempt.result,
+                  feedback: attempt.ai_feedback,
+                  judged_at: attempt.judged_at
+                }
+              end
+            }
+          end
+        }
+      end
+
+      duration_minutes = if session.started_at && session.completed_at
+                           ((session.completed_at - session.started_at) / 60.0).round(1)
+                         end
+
+      {
+        session_id: session.id,
+        staff_name: session.staff_name,
+        status: session.status,
+        started_at: session.started_at,
+        completed_at: session.completed_at,
+        duration_minutes: duration_minutes,
+        total_steps: session.total_steps_count,
+        passed_steps: steps.count { |s| s.status == "passed" },
+        skipped_steps: steps.count { |s| s.status == "skipped" },
+        failed_steps: steps.count { |s| s.status == "failed" },
+        total_attempts: steps.sum(&:attempts_count),
+        area_results: area_results
+      }
+    end
+  end
+end

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -65,16 +65,19 @@ class CleaningSessionService
         return { success: false, error: judge_result.error }
       end
 
-      # DB レベルでインクリメントして race condition を防止
-      CleaningSessionStep.where(id: step.id).update_all("attempts_count = attempts_count + 1")
-      step.reload
+      # update_all + create! を一括実行して attempts_count と attempts レコードの不整合を防止
+      attempt = nil
+      ActiveRecord::Base.transaction do
+        CleaningSessionStep.where(id: step.id).update_all("attempts_count = attempts_count + 1")
+        step.reload
 
-      attempt = step.cleaning_session_attempts.create!(
-        attempt_number: step.attempts_count,
-        result: judge_result.result,
-        ai_feedback: judge_result.feedback,
-        judged_at: Time.current
-      )
+        attempt = step.cleaning_session_attempts.create!(
+          attempt_number: step.attempts_count,
+          result: judge_result.result,
+          ai_feedback: judge_result.feedback,
+          judged_at: Time.current
+        )
+      end
 
       photos.each { |photo| attempt.photos.attach(photo) }
 

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -75,10 +75,12 @@ class CleaningSessionService
 
       # 3. DB更新（短いトランザクション — ロック再取得 + 状態再検証 + 一括更新）
       attempt = nil
+      already_processed = false
       ActiveRecord::Base.transaction do
         locked_step = session.cleaning_session_steps.lock.find(locked_step.id)
         unless locked_step.status.in?(%w[pending failed])
-          return { success: false, error: "このステップは既に処理済みです" }
+          already_processed = true
+          raise ActiveRecord::Rollback
         end
 
         CleaningSessionStep.where(id: locked_step.id).update_all("attempts_count = attempts_count + 1")
@@ -97,6 +99,8 @@ class CleaningSessionService
           locked_step.update!(status: "failed")
         end
       end
+
+      return { success: false, error: "このステップは既に処理済みです" } if already_processed
 
       photos.each { |photo| attempt.photos.attach(photo) }
 

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -101,11 +101,11 @@ class CleaningSessionService
         else
           locked_step.update!(status: "failed")
         end
+
+        photos.each { |photo| attempt.photos.attach(photo) }
       end
 
       return { success: false, error: "このステップは既に処理済みです" } if already_processed
-
-      photos.each { |photo| attempt.photos.attach(photo) }
 
       {
         success: true,

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -116,24 +116,27 @@ class CleaningSessionService
     end
 
     def skip_step(session)
-      step = ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction do
         s = session.current_step
-        return nil unless s
+        next nil unless s
 
         locked = session.cleaning_session_steps.lock.find(s.id)
-        return nil unless locked.status.in?(%w[pending failed])
+        next nil unless locked.status.in?(%w[pending failed])
 
         locked.update!(status: "skipped")
         locked
       end
-      step
     end
 
     def suspend(session)
+      raise ArgumentError, "in_progress のセッションのみ中断できます" unless session.in_progress?
+
       session.update!(status: "suspended")
     end
 
     def resume(session)
+      raise ArgumentError, "suspended のセッションのみ再開できます" unless session.suspended?
+
       session.update!(status: "in_progress")
     end
 

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -156,9 +156,7 @@ class CleaningSessionService
     end
 
     def build_report(session)
-      steps = session.cleaning_session_steps.includes(
-        cleaning_session_attempts: { photos_attachments: :blob }
-      ).ordered
+      steps = session.cleaning_session_steps.includes(:cleaning_session_attempts).ordered
 
       area_results = steps.group_by(&:area_name).map do |area_name, area_steps|
         {

--- a/rails/platform/app/services/cleaning_session_service.rb
+++ b/rails/platform/app/services/cleaning_session_service.rb
@@ -54,38 +54,46 @@ class CleaningSessionService
     end
 
     def judge(session:, step:, photos:)
+      # 1. ロック取得 + 状態チェック（短いトランザクション）
+      locked_step = ActiveRecord::Base.transaction do
+        s = session.cleaning_session_steps.lock.find(step.id)
+        s.status.in?(%w[pending failed]) ? s : nil
+      end
+      return { success: false, error: "このステップは既に処理済みです" } unless locked_step
+
+      # 2. AI判定（トランザクション外 — ロック保持しない）
       judge_result = CleaningPhotoJudgeService.new(
         photos: photos,
-        task: step.task,
-        description: step.description || "",
-        checkpoint: step.checkpoint || ""
+        task: locked_step.task,
+        description: locked_step.description || "",
+        checkpoint: locked_step.checkpoint || ""
       ).call
 
       unless judge_result.success?
         return { success: false, error: judge_result.error }
       end
 
-      # update_all + create! を一括実行して attempts_count と attempts レコードの不整合を防止
+      # 3. DB更新（短いトランザクション — attempts_count + attempt + status を一括）
       attempt = nil
       ActiveRecord::Base.transaction do
-        CleaningSessionStep.where(id: step.id).update_all("attempts_count = attempts_count + 1")
-        step.reload
+        CleaningSessionStep.where(id: locked_step.id).update_all("attempts_count = attempts_count + 1")
+        locked_step.reload
 
-        attempt = step.cleaning_session_attempts.create!(
-          attempt_number: step.attempts_count,
+        attempt = locked_step.cleaning_session_attempts.create!(
+          attempt_number: locked_step.attempts_count,
           result: judge_result.result,
           ai_feedback: judge_result.feedback,
           judged_at: Time.current
         )
+
+        if judge_result.result == "ok"
+          locked_step.update!(status: "passed", passed_at: Time.current)
+        else
+          locked_step.update!(status: "failed")
+        end
       end
 
       photos.each { |photo| attempt.photos.attach(photo) }
-
-      if judge_result.result == "ok"
-        step.update!(status: "passed", passed_at: Time.current)
-      else
-        step.update!(status: "failed")
-      end
 
       {
         success: true,

--- a/rails/platform/app/views/cleaning_manuals/index.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/index.html.erb
@@ -3,7 +3,7 @@
 <div class="w-full max-w-4xl mx-auto">
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">清掃マニュアル一覧</h1>
-    <%= render "shared/button", label: "新規作成", href: new_cleaning_manual_path %>
+    <%= render "shared/button", label: "新規作成", href: new_cleaning_manual_path(client_code: @client_code) %>
   </div>
 
   <form method="get" class="mb-6 flex gap-4 items-end">

--- a/rails/platform/app/views/cleaning_manuals/show.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/show.html.erb
@@ -16,10 +16,9 @@
     <div class="flex items-center gap-3">
       <% if @manual.status == "published" %>
         <%= render "shared/badge", label: "公開", variant: :success, size: :md %>
-        <% suspended_session = @manual.cleaning_sessions.where(status: "suspended").order(updated_at: :desc).first %>
-        <% if suspended_session %>
+        <% if @suspended_session %>
           <%= link_to "清掃を再開する",
-              cleaning_session_path(suspended_session, client_code: @client_code || @manual.client.code),
+              cleaning_session_path(@suspended_session, client_code: @client_code || @manual.client.code),
               class: "bg-yellow-600 hover:bg-yellow-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition" %>
         <% end %>
         <%= link_to "清掃を開始する",

--- a/rails/platform/app/views/cleaning_manuals/show.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/show.html.erb
@@ -16,6 +16,12 @@
     <div class="flex items-center gap-3">
       <% if @manual.status == "published" %>
         <%= render "shared/badge", label: "公開", variant: :success, size: :md %>
+        <% suspended_session = @manual.cleaning_sessions.where(status: "suspended").order(updated_at: :desc).first %>
+        <% if suspended_session %>
+          <%= link_to "清掃を再開する",
+              cleaning_session_path(suspended_session, client_code: @client_code || @manual.client.code),
+              class: "bg-yellow-600 hover:bg-yellow-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition" %>
+        <% end %>
         <%= link_to "清掃を開始する",
             new_cleaning_session_path(cleaning_manual_id: @manual.id, client_code: @client_code || @manual.client.code),
             class: "bg-teal-600 hover:bg-teal-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition" %>

--- a/rails/platform/app/views/cleaning_manuals/show.html.erb
+++ b/rails/platform/app/views/cleaning_manuals/show.html.erb
@@ -13,11 +13,16 @@
       <h1 class="text-2xl font-bold"><%= @manual.property_name %></h1>
       <p class="text-gray-400"><%= @manual.room_type %></p>
     </div>
-    <% if @manual.status == "published" %>
-      <%= render "shared/badge", label: "公開", variant: :success, size: :md %>
-    <% else %>
-      <%= render "shared/badge", label: "下書き", variant: :warning, size: :md %>
-    <% end %>
+    <div class="flex items-center gap-3">
+      <% if @manual.status == "published" %>
+        <%= render "shared/badge", label: "公開", variant: :success, size: :md %>
+        <%= link_to "清掃を開始する",
+            new_cleaning_session_path(cleaning_manual_id: @manual.id, client_code: @client_code || @manual.client.code),
+            class: "bg-teal-600 hover:bg-teal-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition" %>
+      <% else %>
+        <%= render "shared/badge", label: "下書き", variant: :warning, size: :md %>
+      <% end %>
+    </div>
   </div>
 
   <% data = @manual.manual_data.deep_symbolize_keys %>

--- a/rails/platform/app/views/cleaning_sessions/new.html.erb
+++ b/rails/platform/app/views/cleaning_sessions/new.html.erb
@@ -1,0 +1,68 @@
+<% content_for(:title) { "清掃開始 - #{@manual.property_name}" } %>
+
+<% content_for(:breadcrumb) do %>
+  <%= render "shared/breadcrumb", items: [
+    { label: "清掃マニュアル一覧", path: cleaning_manuals_path(client_code: @client_code) },
+    { label: @manual.property_name, path: cleaning_manual_path(@manual, client_code: @client_code) },
+    { label: "清掃開始" }
+  ] %>
+<% end %>
+
+<div class="w-full max-w-lg mx-auto">
+  <h1 class="text-2xl font-bold mb-2">清掃を開始する</h1>
+  <p class="text-gray-400 mb-6"><%= @manual.property_name %> - <%= @manual.room_type %></p>
+
+  <!-- マニュアル概要 -->
+  <div class="grid grid-cols-3 gap-4 mb-8">
+    <%= render "shared/card", padding: "p-4" do %>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-teal-400"><%= @manual_data[:areas]&.size || 0 %></p>
+        <p class="text-sm text-gray-400">エリア</p>
+      </div>
+    <% end %>
+    <%= render "shared/card", padding: "p-4" do %>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-teal-400"><%= @manual_data[:areas]&.sum { |a| a[:cleaning_steps]&.size || 0 } || 0 %></p>
+        <p class="text-sm text-gray-400">ステップ</p>
+      </div>
+    <% end %>
+    <%= render "shared/card", padding: "p-4" do %>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-teal-400"><%= @manual_data[:total_estimated_minutes] || 0 %></p>
+        <p class="text-sm text-gray-400">推定時間(分)</p>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- セッション開始フォーム -->
+  <div data-controller="cleaning-session-start"
+       data-cleaning-session-start-client-code-value="<%= @client_code %>"
+       data-cleaning-session-start-manual-id-value="<%= @manual.id %>">
+
+    <%= render "shared/card" do %>
+      <div class="space-y-4">
+        <div>
+          <label for="staff_name" class="block text-sm font-medium text-gray-300 mb-1">担当者名</label>
+          <input type="text" id="staff_name"
+                 data-cleaning-session-start-target="staffName"
+                 class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-500 focus:ring-teal-500 focus:border-teal-500"
+                 placeholder="例: 田中太郎">
+        </div>
+
+        <button type="button"
+                data-cleaning-session-start-target="submitButton"
+                data-action="click->cleaning-session-start#start"
+                class="w-full bg-teal-600 hover:bg-teal-700 text-white font-medium py-3 px-4 rounded-lg transition">
+          清掃を開始する
+        </button>
+
+        <!-- エラー表示 -->
+        <div data-cleaning-session-start-target="error" class="hidden">
+          <div class="bg-red-950 border border-red-700 text-red-300 text-sm px-4 py-2 rounded">
+            <span data-cleaning-session-start-target="errorMessage"></span>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/rails/platform/app/views/cleaning_sessions/report.html.erb
+++ b/rails/platform/app/views/cleaning_sessions/report.html.erb
@@ -1,0 +1,106 @@
+<% content_for(:title) { "清掃レポート - #{@manual.property_name}" } %>
+
+<% content_for(:breadcrumb) do %>
+  <%= render "shared/breadcrumb", items: [
+    { label: "清掃マニュアル一覧", path: cleaning_manuals_path(client_code: @client_code) },
+    { label: @manual.property_name, path: cleaning_manual_path(@manual, client_code: @client_code) },
+    { label: "清掃レポート" }
+  ] %>
+<% end %>
+
+<div class="w-full max-w-2xl mx-auto">
+  <h1 class="text-2xl font-bold mb-2">清掃レポート</h1>
+  <p class="text-gray-400 mb-6"><%= @manual.property_name %> - <%= @manual.room_type %></p>
+
+  <!-- サマリー -->
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+    <%= render "shared/card", padding: "p-4" do %>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-teal-400"><%= @report[:staff_name] %></p>
+        <p class="text-sm text-gray-400">担当者</p>
+      </div>
+    <% end %>
+    <%= render "shared/card", padding: "p-4" do %>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-teal-400"><%= @report[:duration_minutes] || "-" %></p>
+        <p class="text-sm text-gray-400">所要時間(分)</p>
+      </div>
+    <% end %>
+    <%= render "shared/card", padding: "p-4" do %>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-green-400"><%= @report[:passed_steps] %></p>
+        <p class="text-sm text-gray-400">合格</p>
+      </div>
+    <% end %>
+    <%= render "shared/card", padding: "p-4" do %>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-yellow-400"><%= @report[:skipped_steps] %></p>
+        <p class="text-sm text-gray-400">スキップ</p>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- 試行回数サマリー -->
+  <%= render "shared/card", class: "mb-6" do %>
+    <div class="flex items-center justify-between">
+      <span class="text-gray-400">総試行回数</span>
+      <span class="font-medium"><%= @report[:total_attempts] %>回</span>
+    </div>
+    <div class="flex items-center justify-between mt-2">
+      <span class="text-gray-400">開始時刻</span>
+      <span class="font-medium"><%= @report[:started_at]&.strftime("%Y-%m-%d %H:%M") %></span>
+    </div>
+    <% if @report[:completed_at] %>
+      <div class="flex items-center justify-between mt-2">
+        <span class="text-gray-400">完了時刻</span>
+        <span class="font-medium"><%= @report[:completed_at]&.strftime("%Y-%m-%d %H:%M") %></span>
+      </div>
+    <% end %>
+  <% end %>
+
+  <!-- エリア別結果 -->
+  <% @report[:area_results]&.each do |area| %>
+    <div class="bg-gray-900 shadow rounded-lg overflow-hidden mb-4">
+      <div class="bg-gray-800 px-4 py-3 border-b border-gray-700">
+        <h2 class="font-semibold"><%= area[:area_name] %></h2>
+      </div>
+      <div class="p-4 space-y-3">
+        <% area[:steps]&.each do |step| %>
+          <div class="flex items-start gap-3 py-2 border-b border-gray-800 last:border-0">
+            <% case step[:status] %>
+            <% when "passed" %>
+              <span class="flex-shrink-0 w-6 h-6 bg-green-900 text-green-400 rounded-full flex items-center justify-center text-xs">&#10003;</span>
+            <% when "skipped" %>
+              <span class="flex-shrink-0 w-6 h-6 bg-yellow-900 text-yellow-400 rounded-full flex items-center justify-center text-xs">-</span>
+            <% when "failed" %>
+              <span class="flex-shrink-0 w-6 h-6 bg-red-900 text-red-400 rounded-full flex items-center justify-center text-xs">&#10007;</span>
+            <% else %>
+              <span class="flex-shrink-0 w-6 h-6 bg-gray-700 text-gray-400 rounded-full flex items-center justify-center text-xs">?</span>
+            <% end %>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium"><%= step[:task] %></p>
+              <% if step[:attempts_count] > 0 %>
+                <p class="text-xs text-gray-500 mt-1">試行回数: <%= step[:attempts_count] %>回</p>
+              <% end %>
+              <% step[:attempts]&.each do |attempt| %>
+                <div class="mt-2 text-xs p-2 rounded bg-gray-800">
+                  <span class="<%= attempt[:result] == 'ok' ? 'text-green-400' : 'text-red-400' %>">
+                    <%= attempt[:result] == 'ok' ? 'OK' : 'NG' %>
+                  </span>
+                  <span class="text-gray-500 ml-2"><%= attempt[:feedback] %></span>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <!-- 戻るリンク -->
+  <div class="text-center mt-6">
+    <%= link_to "マニュアルに戻る",
+        cleaning_manual_path(@manual, client_code: @client_code),
+        class: "text-teal-400 hover:text-teal-300 text-sm transition" %>
+  </div>
+</div>

--- a/rails/platform/app/views/cleaning_sessions/show.html.erb
+++ b/rails/platform/app/views/cleaning_sessions/show.html.erb
@@ -1,0 +1,149 @@
+<% content_for(:title) { "清掃実行中 - #{@manual.property_name}" } %>
+
+<div class="w-full max-w-lg mx-auto"
+     data-controller="cleaning-session"
+     data-cleaning-session-session-id-value="<%= @session.id %>"
+     data-cleaning-session-client-code-value="<%= @session.client.code %>"
+     data-cleaning-session-manual-name-value="<%= @manual.property_name %>">
+
+  <!-- ヘッダー -->
+  <div class="flex items-center justify-between mb-4">
+    <div>
+      <h1 class="text-lg font-bold"><%= @manual.property_name %></h1>
+      <p class="text-sm text-gray-400"><%= @session.staff_name %></p>
+    </div>
+    <button type="button"
+            data-action="click->cleaning-session#suspend"
+            data-cleaning-session-target="suspendButton"
+            class="text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 px-3 py-1.5 rounded transition">
+      中断する
+    </button>
+  </div>
+
+  <!-- 進捗バー -->
+  <div class="mb-6">
+    <div class="flex items-center justify-between text-sm text-gray-400 mb-1">
+      <span data-cleaning-session-target="progressText">0 / 0 ステップ完了</span>
+      <span data-cleaning-session-target="progressPercent">0%</span>
+    </div>
+    <div class="w-full bg-gray-700 rounded-full h-2.5">
+      <div data-cleaning-session-target="progressBar"
+           class="bg-teal-500 h-2.5 rounded-full transition-all duration-300"
+           style="width: 0%"></div>
+    </div>
+  </div>
+
+  <!-- ステップ表示エリア -->
+  <div data-cleaning-session-target="stepArea">
+    <!-- 現在のステップ -->
+    <div class="bg-gray-900 shadow rounded-lg overflow-hidden mb-4">
+      <div class="bg-gray-800 px-4 py-3 border-b border-gray-700">
+        <p class="text-sm text-teal-400" data-cleaning-session-target="areaName"></p>
+      </div>
+      <div class="p-4 space-y-3">
+        <h2 class="text-lg font-semibold" data-cleaning-session-target="stepTask"></h2>
+        <p class="text-sm text-gray-400" data-cleaning-session-target="stepDescription"></p>
+        <div class="bg-gray-800 rounded-lg p-3">
+          <p class="text-xs text-gray-500 mb-1">チェックポイント</p>
+          <p class="text-sm text-green-400" data-cleaning-session-target="stepCheckpoint"></p>
+        </div>
+        <p class="text-xs text-gray-500" data-cleaning-session-target="stepTime"></p>
+      </div>
+    </div>
+
+    <!-- カメラ・写真エリア -->
+    <div class="bg-gray-900 shadow rounded-lg p-4 mb-4">
+      <input type="file"
+             accept="image/jpeg,image/png,image/webp"
+             capture="environment"
+             multiple
+             data-cleaning-session-target="cameraInput"
+             data-action="change->cleaning-session#photosSelected"
+             class="hidden">
+
+      <!-- 写真プレビュー -->
+      <div data-cleaning-session-target="photoPreview" class="hidden mb-4">
+        <div data-cleaning-session-target="photoGrid" class="grid grid-cols-3 gap-2"></div>
+      </div>
+
+      <!-- 撮影ボタン -->
+      <button type="button"
+              data-action="click->cleaning-session#openCamera"
+              data-cleaning-session-target="cameraButton"
+              class="w-full bg-gray-700 hover:bg-gray-600 text-gray-200 font-medium py-3 px-4 rounded-lg transition flex items-center justify-center gap-2">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+        写真を撮影する
+      </button>
+
+      <!-- 操作ボタン -->
+      <div class="grid grid-cols-2 gap-3 mt-3">
+        <button type="button"
+                data-action="click->cleaning-session#judgeStep"
+                data-cleaning-session-target="judgeButton"
+                disabled
+                class="bg-teal-600 hover:bg-teal-700 disabled:bg-gray-700 disabled:text-gray-500 text-white font-medium py-2.5 px-4 rounded-lg transition">
+          判定する
+        </button>
+        <button type="button"
+                data-action="click->cleaning-session#skipStep"
+                data-cleaning-session-target="skipButton"
+                class="bg-gray-700 hover:bg-gray-600 text-gray-300 font-medium py-2.5 px-4 rounded-lg transition">
+          スキップ
+        </button>
+      </div>
+    </div>
+
+    <!-- ローディング表示 -->
+    <div data-cleaning-session-target="loading" class="hidden">
+      <div class="bg-gray-900 shadow rounded-lg p-6 text-center">
+        <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-teal-400 mb-3"></div>
+        <p class="text-gray-400">AI判定中...</p>
+        <button type="button"
+                data-action="click->cleaning-session#cancelJudge"
+                class="mt-3 text-sm text-gray-500 hover:text-gray-300 underline transition">
+          キャンセル
+        </button>
+      </div>
+    </div>
+
+    <!-- 判定結果 -->
+    <div data-cleaning-session-target="judgeResult" class="hidden mb-4">
+      <div data-cleaning-session-target="judgeResultCard" class="shadow rounded-lg p-4">
+        <div class="flex items-center gap-2 mb-2">
+          <span data-cleaning-session-target="judgeResultBadge" class="text-sm font-medium px-2.5 py-0.5 rounded-full"></span>
+          <span data-cleaning-session-target="judgeResultLabel" class="text-sm font-medium"></span>
+        </div>
+        <p data-cleaning-session-target="judgeResultFeedback" class="text-sm"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- 完了画面 -->
+  <div data-cleaning-session-target="completedArea" class="hidden">
+    <div class="bg-gray-900 shadow rounded-lg p-6 text-center">
+      <div class="text-4xl mb-3">&#10003;</div>
+      <h2 class="text-xl font-bold text-teal-400 mb-2">清掃完了</h2>
+      <p class="text-gray-400 mb-4">すべてのステップが完了しました</p>
+      <a data-cleaning-session-target="reportLink"
+         href="#"
+         class="inline-block bg-teal-600 hover:bg-teal-700 text-white font-medium py-2 px-6 rounded-lg transition">
+        レポートを確認する
+      </a>
+    </div>
+  </div>
+
+  <!-- エラー表示 -->
+  <div data-cleaning-session-target="error" class="hidden mb-4">
+    <div class="bg-red-950 border border-red-700 text-red-300 text-sm px-4 py-3 rounded-lg">
+      <div class="flex items-center justify-between">
+        <span data-cleaning-session-target="errorMessage"></span>
+        <button type="button"
+                data-action="click->cleaning-session#retryJudge"
+                data-cleaning-session-target="retryButton"
+                class="hidden text-sm underline hover:text-red-200 transition">
+          再試行
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/rails/platform/config/routes.rb
+++ b/rails/platform/config/routes.rb
@@ -23,6 +23,18 @@ Rails.application.routes.draw do
         member do
           get :status
         end
+        resources :cleaning_sessions, only: [ :create ]
+      end
+
+      resources :cleaning_sessions, only: [ :show ] do
+        member do
+          get :current_step
+          post :judge
+          patch :skip
+          patch :suspend
+          patch :resume
+          get :report
+        end
       end
 
       resources :amex_statements, only: [] do
@@ -63,6 +75,11 @@ Rails.application.routes.draw do
   # Web UI
   resources :clients
   resources :cleaning_manuals, only: [ :index, :show, :new ]
+  resources :cleaning_sessions, only: [ :new, :show ] do
+    member do
+      get :report
+    end
+  end
   resources :amex_statements, only: [ :new ]
   resources :bank_statements, only: [ :new ]
   resources :invoices, only: [ :new ]

--- a/rails/platform/db/migrate/20260326000001_create_cleaning_sessions.rb
+++ b/rails/platform/db/migrate/20260326000001_create_cleaning_sessions.rb
@@ -1,0 +1,16 @@
+class CreateCleaningSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :cleaning_sessions do |t|
+      t.references :cleaning_manual, null: false, foreign_key: true
+      t.references :client, null: false, foreign_key: true
+      t.string :staff_name, null: false
+      t.string :status, null: false, default: "in_progress"
+      t.datetime :started_at, null: false
+      t.datetime :completed_at
+      t.timestamps
+    end
+
+    add_index :cleaning_sessions, [:client_id, :status]
+    add_index :cleaning_sessions, [:cleaning_manual_id, :status]
+  end
+end

--- a/rails/platform/db/migrate/20260326000002_create_cleaning_session_steps.rb
+++ b/rails/platform/db/migrate/20260326000002_create_cleaning_session_steps.rb
@@ -1,0 +1,20 @@
+class CreateCleaningSessionSteps < ActiveRecord::Migration[8.0]
+  def change
+    create_table :cleaning_session_steps do |t|
+      t.references :cleaning_session, null: false, foreign_key: true
+      t.string :area_name, null: false
+      t.integer :area_index, null: false
+      t.integer :step_index, null: false
+      t.string :task, null: false
+      t.string :status, null: false, default: "pending"
+      t.integer :attempts_count, null: false, default: 0
+      t.datetime :passed_at
+      t.timestamps
+    end
+
+    add_index :cleaning_session_steps,
+              [:cleaning_session_id, :area_index, :step_index],
+              unique: true,
+              name: "idx_session_steps_unique"
+  end
+end

--- a/rails/platform/db/migrate/20260326000002_create_cleaning_session_steps.rb
+++ b/rails/platform/db/migrate/20260326000002_create_cleaning_session_steps.rb
@@ -19,5 +19,9 @@ class CreateCleaningSessionSteps < ActiveRecord::Migration[8.0]
               [:cleaning_session_id, :area_index, :step_index],
               unique: true,
               name: "idx_session_steps_unique"
+
+    add_index :cleaning_session_steps,
+              [:cleaning_session_id, :status],
+              name: "idx_session_steps_session_status"
   end
 end

--- a/rails/platform/db/migrate/20260326000002_create_cleaning_session_steps.rb
+++ b/rails/platform/db/migrate/20260326000002_create_cleaning_session_steps.rb
@@ -7,6 +7,9 @@ class CreateCleaningSessionSteps < ActiveRecord::Migration[8.0]
       t.integer :step_index, null: false
       t.string :task, null: false
       t.string :status, null: false, default: "pending"
+      t.text :description
+      t.text :checkpoint
+      t.integer :estimated_minutes
       t.integer :attempts_count, null: false, default: 0
       t.datetime :passed_at
       t.timestamps

--- a/rails/platform/db/migrate/20260326000003_create_cleaning_session_attempts.rb
+++ b/rails/platform/db/migrate/20260326000003_create_cleaning_session_attempts.rb
@@ -1,0 +1,17 @@
+class CreateCleaningSessionAttempts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :cleaning_session_attempts do |t|
+      t.references :cleaning_session_step, null: false, foreign_key: true
+      t.integer :attempt_number, null: false
+      t.string :result, null: false
+      t.text :ai_feedback
+      t.datetime :judged_at, null: false
+      t.timestamps
+    end
+
+    add_index :cleaning_session_attempts,
+              [:cleaning_session_step_id, :attempt_number],
+              unique: true,
+              name: "idx_session_attempts_unique"
+  end
+end

--- a/rails/platform/db/migrate/20260326000004_add_description_and_checkpoint_to_cleaning_session_steps.rb
+++ b/rails/platform/db/migrate/20260326000004_add_description_and_checkpoint_to_cleaning_session_steps.rb
@@ -1,0 +1,7 @@
+class AddDescriptionAndCheckpointToCleaningSessionSteps < ActiveRecord::Migration[8.0]
+  def change
+    add_column :cleaning_session_steps, :description, :text
+    add_column :cleaning_session_steps, :checkpoint, :text
+    add_column :cleaning_session_steps, :estimated_minutes, :integer
+  end
+end

--- a/rails/platform/db/migrate/20260326000004_add_description_and_checkpoint_to_cleaning_session_steps.rb
+++ b/rails/platform/db/migrate/20260326000004_add_description_and_checkpoint_to_cleaning_session_steps.rb
@@ -1,7 +1,0 @@
-class AddDescriptionAndCheckpointToCleaningSessionSteps < ActiveRecord::Migration[8.0]
-  def change
-    add_column :cleaning_session_steps, :description, :text
-    add_column :cleaning_session_steps, :checkpoint, :text
-    add_column :cleaning_session_steps, :estimated_minutes, :integer
-  end
-end

--- a/rails/platform/db/schema.rb
+++ b/rails/platform/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_23_040806) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_26_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -82,6 +82,48 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_040806) do
     t.index ["client_id", "property_name"], name: "index_cleaning_manuals_on_client_id_and_property_name"
     t.index ["client_id"], name: "index_cleaning_manuals_on_client_id"
     t.index ["status"], name: "index_cleaning_manuals_on_status"
+  end
+
+  create_table "cleaning_session_attempts", force: :cascade do |t|
+    t.bigint "cleaning_session_step_id", null: false
+    t.integer "attempt_number", null: false
+    t.string "result", null: false
+    t.text "ai_feedback"
+    t.datetime "judged_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cleaning_session_step_id", "attempt_number"], name: "idx_session_attempts_unique", unique: true
+    t.index ["cleaning_session_step_id"], name: "index_cleaning_session_attempts_on_cleaning_session_step_id"
+  end
+
+  create_table "cleaning_session_steps", force: :cascade do |t|
+    t.bigint "cleaning_session_id", null: false
+    t.string "area_name", null: false
+    t.integer "area_index", null: false
+    t.integer "step_index", null: false
+    t.string "task", null: false
+    t.string "status", default: "pending", null: false
+    t.integer "attempts_count", default: 0, null: false
+    t.datetime "passed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cleaning_session_id", "area_index", "step_index"], name: "idx_session_steps_unique", unique: true
+    t.index ["cleaning_session_id"], name: "index_cleaning_session_steps_on_cleaning_session_id"
+  end
+
+  create_table "cleaning_sessions", force: :cascade do |t|
+    t.bigint "cleaning_manual_id", null: false
+    t.bigint "client_id", null: false
+    t.string "staff_name", null: false
+    t.string "status", default: "in_progress", null: false
+    t.datetime "started_at", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cleaning_manual_id", "status"], name: "index_cleaning_sessions_on_cleaning_manual_id_and_status"
+    t.index ["cleaning_manual_id"], name: "index_cleaning_sessions_on_cleaning_manual_id"
+    t.index ["client_id", "status"], name: "index_cleaning_sessions_on_client_id_and_status"
+    t.index ["client_id"], name: "index_cleaning_sessions_on_client_id"
   end
 
   create_table "clients", force: :cascade do |t|
@@ -167,6 +209,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_040806) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "cleaning_manuals", "clients"
+  add_foreign_key "cleaning_session_attempts", "cleaning_session_steps"
+  add_foreign_key "cleaning_session_steps", "cleaning_sessions"
+  add_foreign_key "cleaning_sessions", "cleaning_manuals"
+  add_foreign_key "cleaning_sessions", "clients"
   add_foreign_key "journal_entries", "clients"
   add_foreign_key "journal_entries", "statement_batches"
   add_foreign_key "journal_entry_lines", "journal_entries"

--- a/rails/platform/db/schema.rb
+++ b/rails/platform/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_26_000003) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_26_000004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -107,6 +107,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_26_000003) do
     t.datetime "passed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "description"
+    t.text "checkpoint"
+    t.integer "estimated_minutes"
     t.index ["cleaning_session_id", "area_index", "step_index"], name: "idx_session_steps_unique", unique: true
     t.index ["cleaning_session_id"], name: "index_cleaning_session_steps_on_cleaning_session_id"
   end

--- a/rails/platform/spec/factories/cleaning_session_attempts.rb
+++ b/rails/platform/spec/factories/cleaning_session_attempts.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :cleaning_session_attempt do
+    cleaning_session_step
+    attempt_number { 1 }
+    result { "ok" }
+    ai_feedback { "清掃状態は良好です。" }
+    judged_at { Time.current }
+
+    trait :ng do
+      result { "ng" }
+      ai_feedback { "ベッドシーツにしわが残っています。" }
+    end
+  end
+end

--- a/rails/platform/spec/factories/cleaning_session_steps.rb
+++ b/rails/platform/spec/factories/cleaning_session_steps.rb
@@ -5,6 +5,9 @@ FactoryBot.define do
     area_index { 0 }
     step_index { 0 }
     task { "ベッドメイキング" }
+    description { "シーツを交換し、枕を配置する" }
+    checkpoint { "シーツにしわがないこと" }
+    estimated_minutes { 5 }
     status { "pending" }
     attempts_count { 0 }
 

--- a/rails/platform/spec/factories/cleaning_session_steps.rb
+++ b/rails/platform/spec/factories/cleaning_session_steps.rb
@@ -1,0 +1,26 @@
+FactoryBot.define do
+  factory :cleaning_session_step do
+    cleaning_session
+    area_name { "寝室" }
+    area_index { 0 }
+    step_index { 0 }
+    task { "ベッドメイキング" }
+    status { "pending" }
+    attempts_count { 0 }
+
+    trait :passed do
+      status { "passed" }
+      passed_at { Time.current }
+      attempts_count { 1 }
+    end
+
+    trait :failed do
+      status { "failed" }
+      attempts_count { 1 }
+    end
+
+    trait :skipped do
+      status { "skipped" }
+    end
+  end
+end

--- a/rails/platform/spec/factories/cleaning_sessions.rb
+++ b/rails/platform/spec/factories/cleaning_sessions.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :cleaning_session do
+    cleaning_manual { association :cleaning_manual, :published }
+    client { cleaning_manual.client }
+    staff_name { "テスト担当者" }
+    status { "in_progress" }
+    started_at { Time.current }
+
+    trait :completed do
+      status { "completed" }
+      completed_at { Time.current }
+    end
+
+    trait :suspended do
+      status { "suspended" }
+    end
+  end
+end

--- a/rails/platform/spec/models/cleaning_session_attempt_spec.rb
+++ b/rails/platform/spec/models/cleaning_session_attempt_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe CleaningSessionAttempt, type: :model do
+  describe "バリデーション" do
+    it "有効なファクトリであること" do
+      attempt = build(:cleaning_session_attempt)
+      expect(attempt).to be_valid
+    end
+
+    it "attempt_number が必須であること" do
+      attempt = build(:cleaning_session_attempt, attempt_number: nil)
+      expect(attempt).not_to be_valid
+    end
+
+    it "result が必須であること" do
+      attempt = build(:cleaning_session_attempt, result: nil)
+      expect(attempt).not_to be_valid
+    end
+
+    it "result が不正な値の場合エラーになること" do
+      attempt = build(:cleaning_session_attempt, result: "invalid")
+      expect(attempt).not_to be_valid
+    end
+
+    it "judged_at が必須であること" do
+      attempt = build(:cleaning_session_attempt, judged_at: nil)
+      expect(attempt).not_to be_valid
+    end
+  end
+end

--- a/rails/platform/spec/models/cleaning_session_spec.rb
+++ b/rails/platform/spec/models/cleaning_session_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe CleaningSession, type: :model do
+  describe "バリデーション" do
+    it "有効なファクトリであること" do
+      session = build(:cleaning_session)
+      expect(session).to be_valid
+    end
+
+    it "staff_name が必須であること" do
+      session = build(:cleaning_session, staff_name: nil)
+      expect(session).not_to be_valid
+      expect(session.errors[:staff_name]).to be_present
+    end
+
+    it "status が必須であること" do
+      session = build(:cleaning_session, status: nil)
+      expect(session).not_to be_valid
+    end
+
+    it "status が不正な値の場合エラーになること" do
+      session = build(:cleaning_session, status: "invalid")
+      expect(session).not_to be_valid
+      expect(session.errors[:status]).to be_present
+    end
+
+    it "started_at が必須であること" do
+      session = build(:cleaning_session, started_at: nil)
+      expect(session).not_to be_valid
+    end
+  end
+
+  describe "スコープ" do
+    describe ".for_client" do
+      it "指定した client_code のセッションのみ返すこと" do
+        client_a = create(:client, :hotel, code: "client_a")
+        client_b = create(:client, :hotel, code: "client_b")
+        manual_a = create(:cleaning_manual, :published, client: client_a)
+        manual_b = create(:cleaning_manual, :published, client: client_b)
+        session_a = create(:cleaning_session, cleaning_manual: manual_a, client: client_a)
+        _session_b = create(:cleaning_session, cleaning_manual: manual_b, client: client_b)
+
+        result = CleaningSession.for_client("client_a")
+        expect(result).to contain_exactly(session_a)
+      end
+    end
+
+    describe ".active" do
+      it "進行中のセッションのみ返すこと" do
+        active = create(:cleaning_session)
+        _completed = create(:cleaning_session, :completed)
+
+        result = CleaningSession.active
+        expect(result).to contain_exactly(active)
+      end
+    end
+  end
+
+  describe "#current_step" do
+    it "最初のpendingステップを返すこと" do
+      session = create(:cleaning_session)
+      _passed = create(:cleaning_session_step, :passed, cleaning_session: session, area_index: 0, step_index: 0)
+      pending_step = create(:cleaning_session_step, cleaning_session: session, area_index: 0, step_index: 1)
+
+      expect(session.current_step).to eq(pending_step)
+    end
+
+    it "failedステップがある場合はそれを返すこと" do
+      session = create(:cleaning_session)
+      failed_step = create(:cleaning_session_step, :failed, cleaning_session: session, area_index: 0, step_index: 0)
+
+      expect(session.current_step).to eq(failed_step)
+    end
+
+    it "すべて完了の場合はnilを返すこと" do
+      session = create(:cleaning_session)
+      create(:cleaning_session_step, :passed, cleaning_session: session)
+
+      expect(session.current_step).to be_nil
+    end
+  end
+
+  describe "#completed_steps_count" do
+    it "passed と skipped の合計を返すこと" do
+      session = create(:cleaning_session)
+      create(:cleaning_session_step, :passed, cleaning_session: session, area_index: 0, step_index: 0)
+      create(:cleaning_session_step, :skipped, cleaning_session: session, area_index: 0, step_index: 1)
+      create(:cleaning_session_step, cleaning_session: session, area_index: 0, step_index: 2)
+
+      expect(session.completed_steps_count).to eq(2)
+    end
+  end
+end

--- a/rails/platform/spec/models/cleaning_session_step_spec.rb
+++ b/rails/platform/spec/models/cleaning_session_step_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe CleaningSessionStep, type: :model do
+  describe "バリデーション" do
+    it "有効なファクトリであること" do
+      step = build(:cleaning_session_step)
+      expect(step).to be_valid
+    end
+
+    it "area_name が必須であること" do
+      step = build(:cleaning_session_step, area_name: nil)
+      expect(step).not_to be_valid
+    end
+
+    it "task が必須であること" do
+      step = build(:cleaning_session_step, task: nil)
+      expect(step).not_to be_valid
+    end
+
+    it "status が不正な値の場合エラーになること" do
+      step = build(:cleaning_session_step, status: "invalid")
+      expect(step).not_to be_valid
+    end
+  end
+
+  describe "スコープ" do
+    describe ".ordered" do
+      it "area_index, step_index の昇順で返すこと" do
+        session = create(:cleaning_session)
+        step_b = create(:cleaning_session_step, cleaning_session: session, area_index: 1, step_index: 0)
+        step_a = create(:cleaning_session_step, cleaning_session: session, area_index: 0, step_index: 1)
+        step_first = create(:cleaning_session_step, cleaning_session: session, area_index: 0, step_index: 0)
+
+        result = CleaningSessionStep.ordered
+        expect(result).to eq([step_first, step_a, step_b])
+      end
+    end
+  end
+end

--- a/rails/platform/spec/requests/api/v1/cleaning_sessions_spec.rb
+++ b/rails/platform/spec/requests/api/v1/cleaning_sessions_spec.rb
@@ -115,6 +115,56 @@ RSpec.describe "Api::V1::CleaningSessions", type: :request do
     end
   end
 
+  describe "POST /api/v1/cleaning_sessions/:id/judge" do
+    let(:session) { CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client) }
+    let(:photo) do
+      path = Rails.root.join("spec/fixtures/files/test_image.jpg")
+      Rack::Test::UploadedFile.new(path, "image/jpeg")
+    end
+
+    before do
+      mock_response = double("Response",
+        content: [double("Content", type: "text", text: '{"result":"ok","feedback":"合格です"}')]
+      )
+      mock_messages = double("Messages", create: mock_response)
+      mock_client = double("Anthropic::Client", messages: mock_messages)
+      allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+      allow_any_instance_of(CleaningPhotoJudgeService).to receive(:resize_image).and_return(
+        { data: "fake_image_data", media_type: "image/jpeg" }
+      )
+    end
+
+    it "写真を送信してOK判定を受けること" do
+      post "/api/v1/cleaning_sessions/#{session.id}/judge",
+           params: { client_code: client_code, photos: [photo] },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data["result"]).to eq("ok")
+      expect(data["feedback"]).to eq("合格です")
+      expect(data["session_status"]).to eq("completed")
+    end
+
+    it "写真なしの場合エラーを返すこと" do
+      post "/api/v1/cleaning_sessions/#{session.id}/judge",
+           params: { client_code: client_code },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "完了済みセッションでは判定できないこと" do
+      session.update!(status: "completed", completed_at: Time.current)
+
+      post "/api/v1/cleaning_sessions/#{session.id}/judge",
+           params: { client_code: client_code, photos: [photo] },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
   describe "PATCH /api/v1/cleaning_sessions/:id/skip" do
     it "ステップをスキップすること" do
       session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)

--- a/rails/platform/spec/requests/api/v1/cleaning_sessions_spec.rb
+++ b/rails/platform/spec/requests/api/v1/cleaning_sessions_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::CleaningSessions", type: :request do
+  let(:client) { create(:client, :hotel, code: "test_hotel") }
+  let(:client_code) { client.code }
+  let(:api_token_record) { create(:api_token) }
+  let(:authorization_header) { { "Authorization" => "Bearer #{api_token_record.raw_token}" } }
+  let(:manual) { create(:cleaning_manual, :published, client: client) }
+
+  describe "POST /api/v1/cleaning_manuals/:id/cleaning_sessions" do
+    it "セッションを作成すること" do
+      post "/api/v1/cleaning_manuals/#{manual.id}/cleaning_sessions",
+           params: { client_code: client_code, staff_name: "田中" },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:created)
+      data = JSON.parse(response.body)
+      expect(data["staff_name"]).to eq("田中")
+      expect(data["status"]).to eq("in_progress")
+      expect(data["total_steps"]).to eq(1)
+    end
+
+    it "staff_name がない場合エラーを返すこと" do
+      post "/api/v1/cleaning_manuals/#{manual.id}/cleaning_sessions",
+           params: { client_code: client_code },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "未公開マニュアルの場合404を返すこと" do
+      draft_manual = create(:cleaning_manual, client: client, status: "draft")
+
+      post "/api/v1/cleaning_manuals/#{draft_manual.id}/cleaning_sessions",
+           params: { client_code: client_code, staff_name: "田中" },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "他テナントのマニュアルでセッション作成できないこと" do
+      other_client = create(:client, :hotel, code: "other_hotel")
+      other_manual = create(:cleaning_manual, :published, client: other_client)
+
+      post "/api/v1/cleaning_manuals/#{other_manual.id}/cleaning_sessions",
+           params: { client_code: client_code, staff_name: "田中" },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "非ホテルクライアントの場合403を返すこと" do
+      restaurant = create(:client, code: "restaurant_client", industry: "restaurant")
+
+      post "/api/v1/cleaning_manuals/#{manual.id}/cleaning_sessions",
+           params: { client_code: restaurant.code, staff_name: "田中" },
+           headers: authorization_header
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "GET /api/v1/cleaning_sessions/:id" do
+    it "セッション詳細を返すこと" do
+      session = create(:cleaning_session, cleaning_manual: manual, client: client)
+
+      get "/api/v1/cleaning_sessions/#{session.id}",
+          params: { client_code: client_code },
+          headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data["id"]).to eq(session.id)
+      expect(data["staff_name"]).to eq(session.staff_name)
+    end
+
+    it "他テナントのセッションにアクセスできないこと" do
+      other_client = create(:client, :hotel, code: "other_hotel")
+      other_manual = create(:cleaning_manual, :published, client: other_client)
+      other_session = create(:cleaning_session, cleaning_manual: other_manual, client: other_client)
+
+      get "/api/v1/cleaning_sessions/#{other_session.id}",
+          params: { client_code: client_code },
+          headers: authorization_header
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /api/v1/cleaning_sessions/:id/current_step" do
+    it "現在のステップ情報を返すこと" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      get "/api/v1/cleaning_sessions/#{session.id}/current_step",
+          params: { client_code: client_code },
+          headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data["task"]).to eq("ベッドメイキング")
+      expect(data["area_name"]).to eq("寝室")
+    end
+
+    it "全ステップ完了時はメッセージを返すこと" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      session.cleaning_session_steps.update_all(status: "passed")
+
+      get "/api/v1/cleaning_sessions/#{session.id}/current_step",
+          params: { client_code: client_code },
+          headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data["message"]).to be_present
+    end
+  end
+
+  describe "PATCH /api/v1/cleaning_sessions/:id/skip" do
+    it "ステップをスキップすること" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      patch "/api/v1/cleaning_sessions/#{session.id}/skip",
+            params: { client_code: client_code },
+            headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data["skipped_step"]["task"]).to eq("ベッドメイキング")
+    end
+
+    it "中断中のセッションではスキップできないこと" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      session.update!(status: "suspended")
+
+      patch "/api/v1/cleaning_sessions/#{session.id}/skip",
+            params: { client_code: client_code },
+            headers: authorization_header
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "PATCH /api/v1/cleaning_sessions/:id/suspend" do
+    it "セッションを中断すること" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      patch "/api/v1/cleaning_sessions/#{session.id}/suspend",
+            params: { client_code: client_code },
+            headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      expect(session.reload.status).to eq("suspended")
+    end
+  end
+
+  describe "PATCH /api/v1/cleaning_sessions/:id/resume" do
+    it "セッションを再開すること" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      session.update!(status: "suspended")
+
+      patch "/api/v1/cleaning_sessions/#{session.id}/resume",
+            params: { client_code: client_code },
+            headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      expect(session.reload.status).to eq("in_progress")
+    end
+
+    it "進行中のセッションでは再開できないこと" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      patch "/api/v1/cleaning_sessions/#{session.id}/resume",
+            params: { client_code: client_code },
+            headers: authorization_header
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "GET /api/v1/cleaning_sessions/:id/report" do
+    it "レポートを返すこと" do
+      session = CleaningSessionService.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      CleaningSessionService.complete(session)
+
+      get "/api/v1/cleaning_sessions/#{session.id}/report",
+          params: { client_code: client_code },
+          headers: authorization_header
+
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)
+      expect(data["staff_name"]).to eq("田中")
+      expect(data["status"]).to eq("completed")
+    end
+  end
+end

--- a/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe CleaningPhotoJudgeService do
       end
     end
 
+    context "AI が不正な result 値を返す場合" do
+      let(:mock_response) do
+        double("Response",
+          content: [double("Content", type: "text", text: '{"result":"pass","feedback":"良い"}')]
+        )
+      end
+
+      it "エラーを返すこと" do
+        result = service.call
+        expect(result.success?).to be false
+        expect(result.error).to include("不正")
+      end
+    end
+
     context "JSON パースエラーの場合" do
       let(:mock_response) do
         double("Response",

--- a/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
@@ -67,7 +67,16 @@ RSpec.describe CleaningPhotoJudgeService do
 
       before do
         mock_messages = double("Messages")
-        allow(mock_messages).to receive(:create).and_raise(StandardError.new("API connection failed"))
+        allow(mock_messages).to receive(:create).and_raise(
+          Anthropic::Errors::APIError.new(
+            url: "https://api.anthropic.com/v1/messages",
+            status: 500,
+            headers: {},
+            body: { error: { message: "API connection failed" } },
+            request: double("Request"),
+            response: double("Response")
+          )
+        )
         mock_client_err = double("Anthropic::Client", messages: mock_messages)
         allow(Anthropic::Client).to receive(:new).and_return(mock_client_err)
       end

--- a/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe CleaningPhotoJudgeService do
   end
 
   describe "#call" do
+    context "ANTHROPIC_API_KEY が未設定の場合" do
+      let(:mock_response) { nil }
+
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return(nil)
+      end
+
+      it "エラーを返すこと" do
+        result = service.call
+        expect(result.success?).to be false
+        expect(result.error).to include("ANTHROPIC_API_KEY")
+      end
+    end
+
     context "API が OK を返す場合" do
       let(:mock_response) do
         double("Response",

--- a/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe CleaningPhotoJudgeService do
+  let(:photo) do
+    path = Rails.root.join("spec/fixtures/files/test_image.jpg")
+    ActionDispatch::Http::UploadedFile.new(
+      tempfile: File.open(path),
+      filename: "test_image.jpg",
+      type: "image/jpeg"
+    )
+  end
+
+  let(:service) do
+    described_class.new(
+      photos: [photo],
+      task: "ベッドメイキング",
+      description: "シーツを交換し、枕を配置する",
+      checkpoint: "シーツにしわがないこと"
+    )
+  end
+
+  let(:mock_client) do
+    client = double("Anthropic::Client")
+    messages = double("Messages")
+    allow(client).to receive(:messages).and_return(messages)
+    allow(messages).to receive(:create).and_return(mock_response)
+    client
+  end
+
+  before do
+    allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+  end
+
+  describe "#call" do
+    context "API が OK を返す場合" do
+      let(:mock_response) do
+        double("Response",
+          content: [double("Content", type: "text", text: '{"result":"ok","feedback":"清掃状態は良好です。"}')]
+        )
+      end
+
+      it "OK 判定を返すこと" do
+        result = service.call
+        expect(result.success?).to be true
+        expect(result.result).to eq("ok")
+        expect(result.feedback).to eq("清掃状態は良好です。")
+      end
+    end
+
+    context "API が NG を返す場合" do
+      let(:mock_response) do
+        double("Response",
+          content: [double("Content", type: "text", text: '{"result":"ng","feedback":"シーツにしわが残っています。"}')]
+        )
+      end
+
+      it "NG 判定を返すこと" do
+        result = service.call
+        expect(result.success?).to be true
+        expect(result.result).to eq("ng")
+        expect(result.feedback).to include("しわ")
+      end
+    end
+
+    context "API エラーの場合" do
+      let(:mock_response) { nil }
+
+      before do
+        mock_messages = double("Messages")
+        allow(mock_messages).to receive(:create).and_raise(StandardError.new("API connection failed"))
+        mock_client_err = double("Anthropic::Client", messages: mock_messages)
+        allow(Anthropic::Client).to receive(:new).and_return(mock_client_err)
+      end
+
+      it "エラーを返すこと" do
+        result = service.call
+        expect(result.success?).to be false
+        expect(result.error).to include("エラー")
+      end
+    end
+
+    context "JSON パースエラーの場合" do
+      let(:mock_response) do
+        double("Response",
+          content: [double("Content", type: "text", text: "これはJSONではありません")]
+        )
+      end
+
+      it "エラーを返すこと" do
+        result = service.call
+        expect(result.success?).to be false
+        expect(result.error).to include("パースエラー")
+      end
+    end
+  end
+end

--- a/rails/platform/spec/services/cleaning_session_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_session_service_spec.rb
@@ -164,6 +164,20 @@ RSpec.describe CleaningSessionService do
       end
     end
 
+    context "試行回数上限に達している場合" do
+      let(:judge_response_json) { '{"result":"ok","feedback":"良好"}' }
+
+      it "エラーを返しAI判定を実行しないこと" do
+        step.update!(attempts_count: CleaningSessionService::MAX_ATTEMPTS_PER_STEP)
+
+        result = described_class.judge(session: session, step: step, photos: [photo])
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to include("上限")
+        expect(step.reload.attempts_count).to eq(CleaningSessionService::MAX_ATTEMPTS_PER_STEP)
+      end
+    end
+
     context "AI判定サービスがエラーの場合" do
       let(:judge_response_json) { "" }
 

--- a/rails/platform/spec/services/cleaning_session_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_session_service_spec.rb
@@ -183,6 +183,33 @@ RSpec.describe CleaningSessionService do
     end
   end
 
+  describe ".auto_complete_if_done" do
+    it "全ステップ完了時にセッションを completed にすること" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      session.cleaning_session_steps.update_all(status: "passed")
+      session.reload
+
+      described_class.auto_complete_if_done(session)
+      expect(session.reload.status).to eq("completed")
+    end
+
+    it "全ステップ skipped 時にセッションを suspended にすること" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      session.cleaning_session_steps.update_all(status: "skipped")
+      session.reload
+
+      described_class.auto_complete_if_done(session)
+      expect(session.reload.status).to eq("suspended")
+    end
+
+    it "未完了ステップがある場合は何もしないこと" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      described_class.auto_complete_if_done(session)
+      expect(session.reload.status).to eq("in_progress")
+    end
+  end
+
   describe ".build_report" do
     it "レポートデータを返すこと" do
       session = create(:cleaning_session, cleaning_manual: manual, client: client, started_at: 1.hour.ago, completed_at: Time.current, status: "completed")

--- a/rails/platform/spec/services/cleaning_session_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_session_service_spec.rb
@@ -1,0 +1,127 @@
+require "rails_helper"
+
+RSpec.describe CleaningSessionService do
+  let(:client) { create(:client, :hotel, code: "test_hotel") }
+  let(:manual) { create(:cleaning_manual, :published, client: client) }
+
+  describe ".start" do
+    it "セッションを作成すること" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      expect(session).to be_persisted
+      expect(session.status).to eq("in_progress")
+      expect(session.staff_name).to eq("田中")
+      expect(session.client).to eq(client)
+    end
+
+    it "manual_data からステップレコードを作成すること" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      steps = session.cleaning_session_steps
+      expect(steps.count).to eq(1)
+
+      step = steps.first
+      expect(step.area_name).to eq("寝室")
+      expect(step.task).to eq("ベッドメイキング")
+      expect(step.status).to eq("pending")
+    end
+
+    it "複数エリア・複数ステップのマニュアルでも正しくステップを作成すること" do
+      multi_area_manual = create(:cleaning_manual, :published, client: client, manual_data: {
+        areas: [
+          {
+            area_name: "寝室",
+            cleaning_steps: [
+              { order: 1, task: "ベッドメイキング", description: "desc1", checkpoint: "cp1", estimated_minutes: 5 },
+              { order: 2, task: "掃除機がけ", description: "desc2", checkpoint: "cp2", estimated_minutes: 3 }
+            ]
+          },
+          {
+            area_name: "バスルーム",
+            cleaning_steps: [
+              { order: 1, task: "浴槽洗い", description: "desc3", checkpoint: "cp3", estimated_minutes: 10 }
+            ]
+          }
+        ]
+      })
+
+      session = described_class.start(cleaning_manual: multi_area_manual, staff_name: "田中", client: client)
+      expect(session.cleaning_session_steps.count).to eq(3)
+    end
+  end
+
+  describe ".current_step_data" do
+    it "現在のステップ情報を返すこと" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      data = described_class.current_step_data(session)
+
+      expect(data[:task]).to eq("ベッドメイキング")
+      expect(data[:area_name]).to eq("寝室")
+      expect(data[:description]).to eq("シーツを交換し、枕を配置する")
+      expect(data[:checkpoint]).to eq("シーツにしわがないこと")
+      expect(data[:total_steps]).to eq(1)
+      expect(data[:completed_steps]).to eq(0)
+    end
+
+    it "すべて完了の場合は nil を返すこと" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      session.cleaning_session_steps.update_all(status: "passed")
+
+      expect(described_class.current_step_data(session)).to be_nil
+    end
+  end
+
+  describe ".skip_step" do
+    it "現在のステップをスキップすること" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      step = described_class.skip_step(session)
+
+      expect(step.status).to eq("skipped")
+    end
+
+    it "すべて完了の場合は nil を返すこと" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      session.cleaning_session_steps.update_all(status: "passed")
+
+      expect(described_class.skip_step(session)).to be_nil
+    end
+  end
+
+  describe ".suspend / .resume" do
+    it "セッションを中断・再開できること" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+
+      described_class.suspend(session)
+      expect(session.reload.status).to eq("suspended")
+
+      described_class.resume(session)
+      expect(session.reload.status).to eq("in_progress")
+    end
+  end
+
+  describe ".complete" do
+    it "セッションを完了にすること" do
+      session = described_class.start(cleaning_manual: manual, staff_name: "田中", client: client)
+      described_class.complete(session)
+
+      expect(session.reload.status).to eq("completed")
+      expect(session.completed_at).to be_present
+    end
+  end
+
+  describe ".build_report" do
+    it "レポートデータを返すこと" do
+      session = create(:cleaning_session, cleaning_manual: manual, client: client, started_at: 1.hour.ago, completed_at: Time.current, status: "completed")
+      step = create(:cleaning_session_step, :passed, cleaning_session: session, area_name: "寝室", task: "ベッドメイキング")
+      create(:cleaning_session_attempt, cleaning_session_step: step, result: "ok", ai_feedback: "良好")
+
+      report = described_class.build_report(session)
+
+      expect(report[:staff_name]).to eq(session.staff_name)
+      expect(report[:status]).to eq("completed")
+      expect(report[:duration_minutes]).to be_present
+      expect(report[:passed_steps]).to eq(1)
+      expect(report[:area_results].first[:area_name]).to eq("寝室")
+    end
+  end
+end

--- a/rails/platform/spec/services/cleaning_session_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_session_service_spec.rb
@@ -109,6 +109,80 @@ RSpec.describe CleaningSessionService do
     end
   end
 
+  describe ".judge" do
+    let(:session) { described_class.start(cleaning_manual: manual, staff_name: "田中", client: client) }
+    let(:step) { session.current_step }
+    let(:photo) do
+      path = Rails.root.join("spec/fixtures/files/test_image.jpg")
+      { io: File.open(path), filename: "test_image.jpg", content_type: "image/jpeg" }
+    end
+
+    before do
+      mock_response = double("Response",
+        content: [double("Content", type: "text", text: judge_response_json)]
+      )
+      mock_messages = double("Messages", create: mock_response)
+      mock_client = double("Anthropic::Client", messages: mock_messages)
+      allow(Anthropic::Client).to receive(:new).and_return(mock_client)
+      allow_any_instance_of(CleaningPhotoJudgeService).to receive(:resize_image).and_return(
+        { data: "fake_image_data", media_type: "image/jpeg" }
+      )
+    end
+
+    context "OK 判定の場合" do
+      let(:judge_response_json) { '{"result":"ok","feedback":"清掃状態は良好です。"}' }
+
+      it "attempt を作成しステップを passed にすること" do
+        result = described_class.judge(session: session, step: step, photos: [photo])
+
+        expect(result[:success]).to be true
+        expect(result[:result]).to eq("ok")
+        expect(step.reload.status).to eq("passed")
+        expect(step.attempts_count).to eq(1)
+        expect(step.cleaning_session_attempts.count).to eq(1)
+      end
+    end
+
+    context "NG 判定の場合" do
+      let(:judge_response_json) { '{"result":"ng","feedback":"シーツにしわがあります。"}' }
+
+      it "attempt を作成しステップを failed にすること" do
+        result = described_class.judge(session: session, step: step, photos: [photo])
+
+        expect(result[:success]).to be true
+        expect(result[:result]).to eq("ng")
+        expect(step.reload.status).to eq("failed")
+        expect(step.attempts_count).to eq(1)
+      end
+
+      it "NG 後に再判定できること" do
+        described_class.judge(session: session, step: step, photos: [photo])
+        expect(step.reload.status).to eq("failed")
+
+        # current_step は failed を優先して返す
+        expect(session.reload.current_step).to eq(step)
+      end
+    end
+
+    context "AI判定サービスがエラーの場合" do
+      let(:judge_response_json) { "" }
+
+      before do
+        allow_any_instance_of(CleaningPhotoJudgeService).to receive(:call).and_return(
+          CleaningPhotoJudgeService::Result.new(success: false, result: nil, feedback: nil, error: "APIエラー")
+        )
+      end
+
+      it "エラーを返しステップを変更しないこと" do
+        result = described_class.judge(session: session, step: step, photos: [photo])
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to eq("APIエラー")
+        expect(step.reload.status).to eq("pending")
+      end
+    end
+  end
+
   describe ".build_report" do
     it "レポートデータを返すこと" do
       session = create(:cleaning_session, cleaning_manual: manual, client: client, started_at: 1.hour.ago, completed_at: Time.current, status: "completed")


### PR DESCRIPTION
## 概要

清掃スタッフがスマホで1ステップずつ作業し、AI写真判定で品質を担保するインタラクティブ清掃モードを実装しました。

## 変更内容

### 新規モデル
- **CleaningSession** — 清掃セッション（スタッフ名・状態・開始/完了時刻）
- **CleaningSessionStep** — セッション内の各ステップ（マニュアルからスナップショット保存）
- **CleaningSessionAttempt** — ステップごとの判定試行（AI判定結果・写真）

### サービス
- **CleaningSessionService** — セッション開始・判定・スキップ・中断/再開・完了・自動完了判定・レポート生成
- **CleaningPhotoJudgeService** — Claude Vision APIによる清掃写真のOK/NG同期判定

### API（8エンドポイント）
| メソッド | パス | 機能 |
|---|---|---|
| POST | `/cleaning_manuals/:id/cleaning_sessions` | セッション作成 |
| GET | `/cleaning_sessions/:id` | セッション詳細 |
| GET | `/cleaning_sessions/:id/current_step` | 現在ステップ取得 |
| POST | `/cleaning_sessions/:id/judge` | AI写真判定 |
| PATCH | `/cleaning_sessions/:id/skip` | ステップスキップ |
| PATCH | `/cleaning_sessions/:id/suspend` | セッション中断 |
| PATCH | `/cleaning_sessions/:id/resume` | セッション再開 |
| GET | `/cleaning_sessions/:id/report` | 完了レポート |

### UI
- モバイルファーストUI（Stimulus + カメラAPI連携）
- マニュアル詳細画面に「清掃開始」「清掃を再開する」導線を追加
- 清掃マニュアル新規作成リンクに `client_code` 引き継ぎを修正

### 設計上のポイント
- `judge` はトランザクション外でAI判定し、DB更新のみ短いトランザクションで実行（ロック保持時間の最小化）
- `judge` / `skip_step` ともに行ロック+状態再検証で競合状態を防止
- ステップ作成時に `description` / `checkpoint` / `estimated_minutes` をスナップショット保存（マニュアル更新耐性）
- `auto_complete_if_done` をサービス層に配置し、全ステップskip時は `suspended`、それ以外は `completed` に遷移
- `resume` / `suspend` にサービス層で状態ガードを追加（不正な状態遷移を防止）
- `judge` のレート制限（`MAX_ATTEMPTS_PER_STEP = 10`）をコントローラ・サービス両層でチェック
- `CleaningPhotoJudgeService` のエラーハンドリングを `IOError` / `Vips::Error` に限定（`StandardError` の広すぎるrescueを修正）
- 一時ファイルの確実な削除（`File.delete` + `close`）
- NG判定後に写真プレビューを自動リセットし再撮影を促す

## テスト方法

```bash
make up
make test  # 全547テスト合格
```

### 手動確認
- [x] 清掃マニュアル詳細 →「清掃開始」→ スタッフ名入力 → ステップ表示
- [x] 写真撮影 → AI判定 → OK/NGフィードバック確認
- [x] NG判定 → 再撮影 → OK判定のフロー確認
- [x] セッション中断 → 再開で続きから再開されることを確認
- [x] 全ステップスキップ → 警告メッセージが表示されることを確認
- [x] 完了レポート画面の表示確認

## チェックリスト

- [x] テスト追加（547テスト合格）
- [x] RuboCop 準拠
- [x] マイグレーション作成（3ファイルに統合済み）
- [x] ドキュメント更新
- [x] セキュリティチェック
- [x] コードレビュー指摘事項対応済み

Closes #212