### PR TITLE
fix(platform): マニュアル生成のJSON解析改善とAVIF画像対応 (issue#265)

### DIFF
--- a/rails/platform/app/controllers/api/v1/cleaning_manuals_controller.rb
+++ b/rails/platform/app/controllers/api/v1/cleaning_manuals_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class CleaningManualsController < BaseController
-      ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/webp].freeze
+      ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/webp image/avif].freeze
       MAX_IMAGE_SIZE = 10.megabytes
       MAX_IMAGE_COUNT = 50
 
@@ -26,7 +26,7 @@ module Api
 
         invalid = images.reject { |img| Marcel::MimeType.for(img.tempfile, name: img.original_filename).in?(ALLOWED_CONTENT_TYPES) }
         if invalid.any?
-          return render_error("対応していない画像形式が含まれています。JPEG, PNG, WebP のみ対応しています。")
+          return render_error("対応していない画像形式が含まれています。JPEG, PNG, WebP, AVIF のみ対応しています。")
         end
 
         oversized = images.select { |img| img.size > MAX_IMAGE_SIZE }

--- a/rails/platform/app/controllers/cleaning_manuals_controller.rb
+++ b/rails/platform/app/controllers/cleaning_manuals_controller.rb
@@ -22,7 +22,7 @@ class CleaningManualsController < ApplicationController
   private
 
   def set_client
-    @client_code = params[:client_code] || ""
+    @client_code = params[:client_code].presence
     @client = Client.find_by(code: @client_code)
   end
 

--- a/rails/platform/app/services/cleaning_manual_generator_service.rb
+++ b/rails/platform/app/services/cleaning_manual_generator_service.rb
@@ -189,16 +189,15 @@ class CleaningManualGeneratorService
     result = processor.resize_to_limit(MAX_IMAGE_LONG_EDGE, MAX_IMAGE_LONG_EDGE).convert("jpeg").saver(quality: 80).call
     { data: File.binread(result.path), media_type: "image/jpeg" }
   ensure
-    if result.respond_to?(:close)
-      result.close
-      result.unlink if result.respond_to?(:unlink)
-    end
+    result&.close! if result.respond_to?(:close!)
     image.rewind
   end
 
   def extract_json(text)
-    if text =~ /```(?:json)?\s*\n?(.*?)\n?```/m
+    if text =~ /```(?:json)?\s*\n(.*?)\n\s*```/m
       $1.strip
+    elsif text =~ /\{.*\}/m
+      text[/\{.*\}/m].strip
     else
       text.strip
     end

--- a/rails/platform/app/services/cleaning_manual_generator_service.rb
+++ b/rails/platform/app/services/cleaning_manual_generator_service.rb
@@ -189,7 +189,7 @@ class CleaningManualGeneratorService
     result = processor.resize_to_limit(MAX_IMAGE_LONG_EDGE, MAX_IMAGE_LONG_EDGE).convert("jpeg").saver(quality: 80).call
     { data: File.binread(result.path), media_type: "image/jpeg" }
   ensure
-    result&.close! if result.respond_to?(:close!)
+    result.close! if result.respond_to?(:close!)
     image.rewind
   end
 

--- a/rails/platform/spec/services/cleaning_manual_generator_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_manual_generator_service_spec.rb
@@ -107,6 +107,28 @@ RSpec.describe CleaningManualGeneratorService do
       end
     end
 
+    context "JSONがコードブロックなしでテキストに埋まっている場合" do
+      let(:mock_response) do
+        double("Response",
+          content: [
+            double("Content", type: "text", text: "以下がマニュアルです。\n#{valid_response_json}\n何かご質問があれば。")
+          ]
+        )
+      end
+
+      it "JSON部分を抽出してパースできること" do
+        service = described_class.new(
+          images: [image_file],
+          property_name: "テスト施設",
+          room_type: "スタンダード"
+        )
+
+        result = service.call
+        expect(result.success?).to be true
+        expect(result.data[:areas]).to be_present
+      end
+    end
+
     context "APIエラーが発生した場合" do
       before do
         messages = double("Messages")


### PR DESCRIPTION
## 概要
清掃マニュアル生成時のJSON解析エラーとAVIF画像非対応の問題を修正。

closes #265

## 変更内容
- `CleaningManualGeneratorService#extract_json` の正規表現を改善し、コードブロックなしのJSON応答にもフォールバック対応
- `ALLOWED_CONTENT_TYPES` に `image/avif` を追加（Airbnb等のAVIF画像に対応）
- `CleaningManualsController#set_client` を `|| ""` から `.presence` に統一
- `resize_image` の Tempfile クリーンアップを `close!` に統一
- JSON抽出のテストケース追加

## テスト方法
- [x] `make test` で全テストパス（485 examples, 0 failures）
- [x] AVIF画像をアップロードしてマニュアル生成できること（libvips heifload + dav1dデコーダ確認済み、AVIF→JPEG変換成功）
- [x] AI応答がコードブロックなしでもJSON解析できること（spec追加済み）
- [x] 清掃マニュアル一覧→新規作成でclient_codeが引き継がれること（API経由で動作確認済み）

## チェックリスト
- [x] コミットメッセージがConventional Commits準拠
- [x] テスト追加済み
- [x] libvips AVIF対応確認済み（heifload + dav1dプラグイン利用可能）
- [x] 既存テスト全パス