### PR TITLE
fix(infra): worker コンテナの外部API疎通を確保 (issue#283)

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -55,6 +55,7 @@ services:
         condition: service_healthy
     networks:
       - internal
+      - web-proxy-net
     restart: unless-stopped
 
 networks:


### PR DESCRIPTION
## Summary

- `compose.production.yaml` の `worker` サービスが `internal: true` ネットワークのみに参加しており、外部APIに一切到達できなかった
- `web-proxy-net` を worker にも追加し、`LineMessagingService` / `Anthropic API` などの外部疎通を確保

Closes #283

## 背景

本番VPSでLINE経由のレシート画像処理（`ReceiptLineProcessJob`）を実行したところ、worker が `api-data.line.me` への DNS 解決で失敗していた。

\`\`\`
Socket::ResolutionError: Failed to open TCP connection to api-data.line.me:443
  at app/services/line_messaging_service.rb:31 (get_content)
  at app/jobs/receipt_line_process_job.rb:24 (perform)
\`\`\`

原因は `compose.production.yaml` における network 構成のズレ:

| サービス | network 所属 | 外部疎通 |
|---|---|---|
| platform | internal, web-proxy-net | OK |
| worker | internal（internal: true） | NG |

## Test plan

- [ ] マージ後、本番VPSで \`git pull && docker compose -f compose.production.yaml --env-file .env.production up -d --force-recreate worker\`
- [ ] worker内で \`getent hosts api-data.line.me\` が成功
- [ ] 失敗していた \`ReceiptLineProcessJob\` をリトライ → 画像取得 → 仕訳生成 → LINE返信まで完走