### PR TITLE
feat(platform): LINE友だち追加で即時利用可能にする (issue#288)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -36,6 +36,10 @@ LINE_CHANNEL_ACCESS_TOKEN=your_line_channel_access_token_here
 # LINE Webhook署名検証用
 LINE_CHANNEL_SECRET=your_line_channel_secret_here
 
+# LINE公式アカウントを友だち追加したユーザーを自動で紐付けるClientのコード
+# 該当Clientは clients テーブルに存在している必要がある
+LINE_DEFAULT_CLIENT_CODE=parijona
+
 # LINE経理自動化ワークフロー用
 # Master_User_Config シートが存在するGoogle SheetsのID
 # 取得: スプレッドシートURLの /d/{この部分}/ から抽出

--- a/rails/platform/app/controllers/line_webhook_controller.rb
+++ b/rails/platform/app/controllers/line_webhook_controller.rb
@@ -58,12 +58,12 @@ class LineWebhookController < ApplicationController
     line_user_id = event.dig("source", "userId")
     return unless line_user_id.present?
 
-    client = Client.find_by(line_user_id: line_user_id)
+    client = LineFollower.find_by(line_user_id: line_user_id)&.client
 
     unless client
       LineMessagingService.reply(
         event["replyToken"],
-        "このLINEアカウントは未登録です。管理者にお問い合わせください。"
+        "このLINEアカウントは未登録です。一度ブロックを解除して友だち追加し直してください。"
       )
       return
     end
@@ -79,14 +79,30 @@ class LineWebhookController < ApplicationController
     line_user_id = event.dig("source", "userId")
     return unless line_user_id.present?
 
-    client = Client.find_by(line_user_id: line_user_id)
+    client = default_client
 
-    message = if client
-      "#{client.name}さん、友だち追加ありがとうございます！\n領収書・レシートの画像を送信すると、自動で仕訳データを作成します。"
-    else
-      "友だち追加ありがとうございます！\nこのLINEアカウントはまだ登録されていません。管理者にお問い合わせください。"
+    unless client
+      LineMessagingService.reply(
+        event["replyToken"],
+        "友だち追加ありがとうございます！\nサービスの初期設定が完了していません。管理者にお問い合わせください。"
+      )
+      return
     end
 
-    LineMessagingService.reply(event["replyToken"], message)
+    LineFollower.find_or_create_by!(line_user_id: line_user_id) do |follower|
+      follower.client = client
+    end
+
+    LineMessagingService.reply(
+      event["replyToken"],
+      "#{client.name}さん、友だち追加ありがとうございます！\n領収書・レシートの画像を送信すると、自動で仕訳データを作成します。"
+    )
+  end
+
+  def default_client
+    code = ENV["LINE_DEFAULT_CLIENT_CODE"]
+    return nil unless code.present?
+
+    Client.find_by(code: code)
   end
 end

--- a/rails/platform/app/models/client.rb
+++ b/rails/platform/app/models/client.rb
@@ -18,13 +18,13 @@ class Client < ApplicationRecord
   has_many :cleaning_manuals, dependent: :restrict_with_error
   has_many :cleaning_sessions, dependent: :restrict_with_error
   has_many :statement_batches, dependent: :restrict_with_error
+  has_many :line_followers, dependent: :destroy
 
   # === バリデーション ===
   validates :code, presence: true, uniqueness: true
   validates :name, presence: true
   validates :status, inclusion: { in: STATUSES.keys }
   validates :industry, inclusion: { in: %w[restaurant hotel tour] }, allow_nil: true
-  validates :line_user_id, uniqueness: true, allow_nil: true
 
   # === スコープ ===
   scope :active, -> { where(status: "active") }

--- a/rails/platform/app/models/line_follower.rb
+++ b/rails/platform/app/models/line_follower.rb
@@ -1,0 +1,5 @@
+class LineFollower < ApplicationRecord
+  belongs_to :client
+
+  validates :line_user_id, presence: true, uniqueness: true
+end

--- a/rails/platform/db/migrate/20260601000001_create_line_followers.rb
+++ b/rails/platform/db/migrate/20260601000001_create_line_followers.rb
@@ -1,0 +1,12 @@
+class CreateLineFollowers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :line_followers do |t|
+      t.references :client, null: false, foreign_key: true
+      t.string :line_user_id, null: false, comment: "LINE user ID"
+
+      t.timestamps
+    end
+
+    add_index :line_followers, :line_user_id, unique: true
+  end
+end

--- a/rails/platform/db/migrate/20260601000002_migrate_clients_line_user_id_to_followers.rb
+++ b/rails/platform/db/migrate/20260601000002_migrate_clients_line_user_id_to_followers.rb
@@ -1,0 +1,19 @@
+class MigrateClientsLineUserIdToFollowers < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      INSERT INTO line_followers (client_id, line_user_id, created_at, updated_at)
+      SELECT id, line_user_id, NOW(), NOW()
+      FROM clients
+      WHERE line_user_id IS NOT NULL
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE clients c
+      SET line_user_id = lf.line_user_id
+      FROM line_followers lf
+      WHERE lf.client_id = c.id
+    SQL
+  end
+end

--- a/rails/platform/db/migrate/20260601000003_remove_line_user_id_from_clients.rb
+++ b/rails/platform/db/migrate/20260601000003_remove_line_user_id_from_clients.rb
@@ -1,0 +1,6 @@
+class RemoveLineUserIdFromClients < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :clients, name: "index_clients_on_line_user_id"
+    remove_column :clients, :line_user_id, :string, comment: "LINE user ID（Webhook識別用）"
+  end
+end

--- a/rails/platform/db/schema.rb
+++ b/rails/platform/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_26_000004) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_01_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -135,11 +135,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_26_000004) do
     t.string "industry", comment: "業種: restaurant / hotel / tour"
     t.jsonb "services", default: {}, comment: "サービス設定"
     t.string "status", default: "active", comment: "ステータス: active / trial / inactive"
-    t.string "line_user_id", comment: "LINE user ID（Webhook識別用）"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "idx_clients_code", unique: true
-    t.index ["line_user_id"], name: "index_clients_on_line_user_id", unique: true, where: "(line_user_id IS NOT NULL)"
     t.index ["services"], name: "idx_clients_services", using: :gin
   end
 
@@ -163,6 +161,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_26_000004) do
     t.index ["source_type", "source_period"], name: "idx_journal_entries_source"
     t.index ["statement_batch_id"], name: "index_journal_entries_on_statement_batch_id"
     t.index ["status"], name: "idx_journal_entries_review_required", where: "((status)::text = 'review_required'::text)"
+  end
+
+  create_table "line_followers", force: :cascade do |t|
+    t.bigint "client_id", null: false
+    t.string "line_user_id", null: false, comment: "LINE user ID"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_id"], name: "index_line_followers_on_client_id"
+    t.index ["line_user_id"], name: "index_line_followers_on_line_user_id", unique: true
   end
 
   create_table "journal_entry_lines", force: :cascade do |t|
@@ -219,5 +226,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_26_000004) do
   add_foreign_key "journal_entries", "clients"
   add_foreign_key "journal_entries", "statement_batches"
   add_foreign_key "journal_entry_lines", "journal_entries"
+  add_foreign_key "line_followers", "clients"
   add_foreign_key "statement_batches", "clients"
 end

--- a/rails/platform/spec/factories/clients.rb
+++ b/rails/platform/spec/factories/clients.rb
@@ -18,8 +18,10 @@ FactoryBot.define do
       status { "trial" }
     end
 
-    trait :with_line do
-      sequence(:line_user_id) { |n| "U#{n.to_s.rjust(32, '0')}" }
+    trait :with_line_follower do
+      after(:create) do |client|
+        create(:line_follower, client: client)
+      end
     end
   end
 end

--- a/rails/platform/spec/factories/line_followers.rb
+++ b/rails/platform/spec/factories/line_followers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :line_follower do
+    association :client
+    sequence(:line_user_id) { |n| "U#{n.to_s.rjust(32, '0')}" }
+  end
+end

--- a/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ReceiptLineProcessJob, type: :job do
-  let(:client) { create(:client, line_user_id: "U1234567890abcdef") }
-  let(:line_user_id) { client.line_user_id }
+  let(:client) { create(:client) }
+  let(:line_user_id) { "U1234567890abcdef" }
   let(:message_id) { "msg_001" }
   let(:image_binary) { "\xFF\xD8\xFF\xE0test_image_data".b }
   let(:fingerprint) { Digest::SHA256.hexdigest(image_binary) }

--- a/rails/platform/spec/models/line_follower_spec.rb
+++ b/rails/platform/spec/models/line_follower_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe LineFollower, type: :model do
+  describe "バリデーション" do
+    it "factoryで有効なレコードを作れること" do
+      expect(build(:line_follower)).to be_valid
+    end
+
+    it "line_user_idがなければ無効" do
+      expect(build(:line_follower, line_user_id: nil)).not_to be_valid
+    end
+
+    it "line_user_idが重複すると無効" do
+      existing = create(:line_follower)
+      duplicate = build(:line_follower, line_user_id: existing.line_user_id)
+      expect(duplicate).not_to be_valid
+    end
+
+    it "clientがなければ無効" do
+      expect(build(:line_follower, client: nil)).not_to be_valid
+    end
+  end
+
+  describe "関連" do
+    it "clientに属する" do
+      client = create(:client)
+      follower = create(:line_follower, client: client)
+      expect(follower.client).to eq(client)
+    end
+
+    it "1 Client に対して複数の follower を作れる" do
+      client = create(:client)
+      create(:line_follower, client: client)
+      create(:line_follower, client: client)
+      expect(client.line_followers.count).to eq(2)
+    end
+
+    it "Client が destroy されたとき関連 follower も削除される" do
+      client = create(:client)
+      create(:line_follower, client: client)
+      expect { client.destroy }.to change(LineFollower, :count).by(-1)
+    end
+  end
+end

--- a/rails/platform/spec/requests/line_webhook_spec.rb
+++ b/rails/platform/spec/requests/line_webhook_spec.rb
@@ -3,12 +3,17 @@ require "rails_helper"
 RSpec.describe "LineWebhook", type: :request do
   let(:channel_secret) { "test_channel_secret" }
   let(:channel_token) { "test_channel_token" }
-  let(:client) { create(:client, line_user_id: "U1234567890abcdef") }
+  let(:default_client_code) { "parijona" }
+  let(:client) { create(:client, code: default_client_code, name: "Parijona") }
+  let(:follower_user_id) { "U1234567890abcdef1234567890abcdef" }
+  let!(:follower) { create(:line_follower, client: client, line_user_id: follower_user_id) }
 
   before do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with("LINE_CHANNEL_SECRET").and_return(channel_secret)
     allow(ENV).to receive(:fetch).with("LINE_CHANNEL_TOKEN").and_return(channel_token)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("LINE_DEFAULT_CLIENT_CODE").and_return(default_client_code)
   end
 
   def sign_body(body)
@@ -25,7 +30,7 @@ RSpec.describe "LineWebhook", type: :request do
     }
   end
 
-  def image_event(user_id: client.line_user_id, message_id: "msg_001", reply_token: "reply_token_001")
+  def image_event(user_id: follower_user_id, message_id: "msg_001", reply_token: "reply_token_001")
     {
       "type" => "message",
       "replyToken" => reply_token,
@@ -34,7 +39,7 @@ RSpec.describe "LineWebhook", type: :request do
     }
   end
 
-  def follow_event(user_id: client.line_user_id, reply_token: "reply_token_002")
+  def follow_event(user_id: follower_user_id, reply_token: "reply_token_002")
     {
       "type" => "follow",
       "replyToken" => reply_token,
@@ -80,11 +85,7 @@ RSpec.describe "LineWebhook", type: :request do
     end
 
     describe "画像メッセージ処理" do
-      before do
-        client # ensure client exists
-      end
-
-      it "登録済みユーザーからの画像でジョブをエンキューすること" do
+      it "登録済みフォロワーからの画像でジョブをエンキューすること" do
         allow(ReceiptLineProcessJob).to receive(:perform_later)
 
         post_webhook({ "events" => [image_event] })
@@ -93,17 +94,19 @@ RSpec.describe "LineWebhook", type: :request do
         expect(ReceiptLineProcessJob).to have_received(:perform_later).with(
           client_id: client.id,
           message_id: "msg_001",
-          line_user_id: client.line_user_id
+          line_user_id: follower_user_id
         )
       end
 
       it "未登録ユーザーからの画像でエラーメッセージを返信すること" do
+        allow(ReceiptLineProcessJob).to receive(:perform_later)
         line_response = instance_double(Net::HTTPSuccess, is_a?: true, code: "200", body: "{}")
         allow(Net::HTTP).to receive(:start).and_return(line_response)
 
         post_webhook({ "events" => [image_event(user_id: "U_unknown_user")] })
 
         expect(response).to have_http_status(:ok)
+        expect(ReceiptLineProcessJob).not_to have_received(:perform_later)
       end
 
       it "テキストメッセージは無視されること" do
@@ -112,7 +115,7 @@ RSpec.describe "LineWebhook", type: :request do
         text_event = {
           "type" => "message",
           "replyToken" => "reply_token_003",
-          "source" => { "type" => "user", "userId" => client.line_user_id },
+          "source" => { "type" => "user", "userId" => follower_user_id },
           "message" => { "type" => "text", "text" => "こんにちは" }
         }
         post_webhook({ "events" => [text_event] })
@@ -123,21 +126,48 @@ RSpec.describe "LineWebhook", type: :request do
     end
 
     describe "Follow Event処理" do
-      it "登録済みユーザーのフォローでウェルカムメッセージを返信すること" do
-        client # ensure client exists
-        line_response = instance_double(Net::HTTPSuccess, is_a?: true, code: "200", body: "{}")
-        allow(Net::HTTP).to receive(:start).and_return(line_response)
+      let(:line_response) { instance_double(Net::HTTPSuccess, is_a?: true, code: "200", body: "{}") }
 
-        post_webhook({ "events" => [follow_event] })
+      before do
+        allow(Net::HTTP).to receive(:start).and_return(line_response)
+      end
+
+      it "新規ユーザーのフォローでLineFollowerが自動作成され、ウェルカムメッセージが返信されること" do
+        new_user_id = "U_brand_new_follower" + "0" * 12
+
+        expect {
+          post_webhook({ "events" => [follow_event(user_id: new_user_id)] })
+        }.to change(LineFollower, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        created = LineFollower.find_by(line_user_id: new_user_id)
+        expect(created.client).to eq(client)
+      end
+
+      it "既存ユーザーのフォローでは新規作成されない（idempotent）" do
+        expect {
+          post_webhook({ "events" => [follow_event] })
+        }.not_to change(LineFollower, :count)
 
         expect(response).to have_http_status(:ok)
       end
 
-      it "未登録ユーザーのフォローで案内メッセージを返信すること" do
-        line_response = instance_double(Net::HTTPSuccess, is_a?: true, code: "200", body: "{}")
-        allow(Net::HTTP).to receive(:start).and_return(line_response)
+      it "LINE_DEFAULT_CLIENT_CODEのClientが存在しない場合は登録せず案内メッセージを返信" do
+        allow(ENV).to receive(:[]).with("LINE_DEFAULT_CLIENT_CODE").and_return("nonexistent")
 
-        post_webhook({ "events" => [follow_event(user_id: "U_new_user")] })
+        expect {
+          post_webhook({ "events" => [follow_event(user_id: "U_unmapped" + "0" * 24)] })
+        }.not_to change(LineFollower, :count)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "LINE_DEFAULT_CLIENT_CODE未設定の場合は登録しないこと" do
+        allow(ENV).to receive(:[]).with("LINE_DEFAULT_CLIENT_CODE").and_return(nil)
+
+        expect {
+          post_webhook({ "events" => [follow_event(user_id: "U_no_default" + "0" * 21)] })
+        }.not_to change(LineFollower, :count)
 
         expect(response).to have_http_status(:ok)
       end
@@ -145,20 +175,21 @@ RSpec.describe "LineWebhook", type: :request do
 
     describe "複数イベント" do
       it "複数イベントを順に処理すること" do
-        client # ensure client exists
         allow(ReceiptLineProcessJob).to receive(:perform_later)
         line_response = instance_double(Net::HTTPSuccess, is_a?: true, code: "200", body: "{}")
         allow(Net::HTTP).to receive(:start).and_return(line_response)
+        new_follower_id = "U_new_follower" + "0" * 18
 
         post_webhook({
           "events" => [
             image_event(message_id: "msg_001", reply_token: "rt_001"),
-            follow_event(user_id: "U_new_follower", reply_token: "rt_002")
+            follow_event(user_id: new_follower_id, reply_token: "rt_002")
           ]
         })
 
         expect(response).to have_http_status(:ok)
         expect(ReceiptLineProcessJob).to have_received(:perform_later).once
+        expect(LineFollower.find_by(line_user_id: new_follower_id)).to be_present
       end
     end
   end


### PR DESCRIPTION
## Summary

LINE公式アカウントを **友だち追加するだけ** でレシート画像を送れる状態にする。

- \`Client.line_user_id\`（1対1）を廃止し、\`line_followers\` テーブル（1 Client : N LineFollowers）を新設
- \`LineWebhookController#handle_follow\` で \`find_or_create_by!\` による自動登録
- \`LineWebhookController#handle_message\` を \`LineFollower\` 経由の N:1 検索に変更
- 紐付け先 Client を環境変数 \`LINE_DEFAULT_CLIENT_CODE\` で指定（例: \`parijona\`）

Closes #288

## 変更内容

### データモデル

| ファイル | 変更 |
|---|---|
| \`db/migrate/20260601000001_create_line_followers.rb\` | 新規テーブル |
| \`db/migrate/20260601000002_migrate_clients_line_user_id_to_followers.rb\` | 既存clients.line_user_idを移行 |
| \`db/migrate/20260601000003_remove_line_user_id_from_clients.rb\` | clients.line_user_idカラム削除 |
| \`app/models/line_follower.rb\` | 新規モデル |
| \`app/models/client.rb\` | has_many :line_followers 追加、line_user_id バリデーション削除 |

### コントローラ

\`app/controllers/line_webhook_controller.rb\`:

- \`handle_message\`: \`LineFollower.find_by(line_user_id: ...)&.client\` で取得
- \`handle_follow\`: \`LineFollower.find_or_create_by!\` で自動登録（既存ならno-op）
- \`default_client\`: ENV\["LINE_DEFAULT_CLIENT_CODE"\] から取得

### 環境変数

\`.env.local.example\` に \`LINE_DEFAULT_CLIENT_CODE=parijona\` を追記。本番では \`.env.local\` に追加する必要あり（デプロイ手順参照）。

### テスト

- \`spec/models/line_follower_spec.rb\` 新規（validation, association）
- \`spec/factories/line_followers.rb\` 新規
- \`spec/requests/line_webhook_spec.rb\` 拡張（自動登録、idempotent、デフォルトclient不在ケース）
- \`spec/factories/clients.rb\`: \`:with_line\` トレイトを \`:with_line_follower\` に変更
- \`spec/jobs/receipt_line_process_job_spec.rb\`: client.line_user_id 参照を直接値に置き換え

全557テスト通過確認済み（\`make test\`）。

## デプロイ手順

1. 本番 \`/srv/landbase_ai_suite/.env.local\` に \`LINE_DEFAULT_CLIENT_CODE=parijona\` を追加
2. \`make prod-deploy\` 実行
3. 既存の \`Client(parijona).line_user_id\` が \`line_followers\` テーブルに自動移行される
4. 友だち追加テスト: パリジョーナのスタッフが公式アカウントを友だち追加 → 即レシート送信可

## セキュリティ考慮

「友だち追加 = 即利用可」のため、第三者が無関係に追加した場合もそのレシートが Parijona の仕訳として保存される。LINE公式アカウント側で **アカウントを「承認制」または「ID検索のみ」** に設定することを運用ルールに含める必要あり。

## Test plan

- [ ] CI green
- [ ] マイグレーション 3件が \`make prod-deploy\` で正常適用される
- [ ] 既存 Parijona の line_user_id がデータ移行で line_followers に移る
- [ ] 新規LINEアカウントを友だち追加 → LineFollower自動作成 → ウェルカム返信
- [ ] その新規アカウントからレシート画像送信 → ジョブ起動 → 仕訳生成 → LINE返信