### PR TITLE
fix(platform): LINE友だち追加メッセージから個人呼びかけを外す (issue#290)

### DIFF
--- a/rails/platform/app/controllers/line_webhook_controller.rb
+++ b/rails/platform/app/controllers/line_webhook_controller.rb
@@ -95,7 +95,7 @@ class LineWebhookController < ApplicationController
 
     LineMessagingService.reply(
       event["replyToken"],
-      "#{client.name}さん、友だち追加ありがとうございます！\n領収書・レシートの画像を送信すると、自動で仕訳データを作成します。"
+      "友だち追加ありがとうございます！\n#{client.name}のレシート受付に登録しました。\n領収書・レシートの画像を送信すると、自動で仕訳データを作成します。"
     )
   end
 


### PR DESCRIPTION
## Summary

PR #289 のウェルカムメッセージ「\`#{client.name}さん、友だち追加ありがとうございます！\`」を、業務名を所属表記として使う形に変更。

Closes #290

## Before / After

Before:
\`\`\`
Parijonaさん、友だち追加ありがとうございます！
領収書・レシートの画像を送信すると、自動で仕訳データを作成します。
\`\`\`

After:
\`\`\`
友だち追加ありがとうございます！
Parijonaのレシート受付に登録しました。
領収書・レシートの画像を送信すると、自動で仕訳データを作成します。
\`\`\`

## Test plan

- [x] \`make test ARGS="spec/requests/line_webhook_spec.rb"\` → 12 examples, 0 failures
- [ ] 本番デプロイ後、友だち追加でメッセージ確認