### PR TITLE
feat(platform): レシート重複検知とtransaction_no自動採番 (issue#292, issue#293)

### DIFF
--- a/rails/platform/app/jobs/concerns/journal_entry_creator.rb
+++ b/rails/platform/app/jobs/concerns/journal_entry_creator.rb
@@ -1,25 +1,36 @@
 module JournalEntryCreator
   extend ActiveSupport::Concern
 
+  class DuplicateFound < StandardError
+    attr_reader :existing_entry
+
+    def initialize(existing_entry)
+      @existing_entry = existing_entry
+      super("duplicate receipt")
+    end
+  end
+
   private
 
   def create_journal_entries(batch, data)
-    source_period = if data[:receipt_date].present?
-      begin
-        date = Date.parse(data[:receipt_date])
-        "#{date.year}年#{date.month}月"
-      rescue Date::Error
-        nil
-      end
+    source_period = build_source_period(data[:receipt_date])
+    transactions = data[:transactions] || []
+
+    if batch.source_type == "receipt"
+      existing = find_duplicate_receipt(batch.client, transactions)
+      raise DuplicateFound.new(existing) if existing
     end
 
-    transactions = data[:transactions] || []
-    transactions.each do |txn|
+    base_txn_no = batch.client.journal_entries
+                       .where(source_type: batch.source_type, source_period: source_period)
+                       .maximum(:transaction_no).to_i
+
+    transactions.each_with_index do |txn, idx|
       batch.journal_entries.create!(
         client: batch.client,
         source_type: batch.source_type,
         source_period: source_period,
-        transaction_no: txn[:transaction_no],
+        transaction_no: base_txn_no + idx + 1,
         date: txn[:date],
         description: txn[:description] || "",
         tag: txn[:tag] || "receipt",
@@ -49,6 +60,38 @@ module JournalEntryCreator
           }
         ]
       )
+    end
+  end
+
+  def build_source_period(receipt_date)
+    return nil if receipt_date.blank?
+
+    date = Date.parse(receipt_date)
+    "#{date.year}年#{date.month}月"
+  rescue Date::Error
+    nil
+  end
+
+  def find_duplicate_receipt(client, transactions)
+    return nil if transactions.blank?
+
+    first_txn = transactions.first
+    date = first_txn[:date]
+    return nil if date.blank?
+
+    amount = first_txn[:debit_amount].to_i
+    invoice = first_txn[:debit_invoice].to_s.strip
+    partner = first_txn[:debit_partner].to_s.strip
+
+    scope = client.journal_entries
+                  .where(source_type: "receipt", date: date)
+                  .joins(:journal_entry_lines)
+                  .where(journal_entry_lines: { side: "debit", amount: amount })
+
+    if invoice.present?
+      scope.where(journal_entry_lines: { invoice: invoice }).first
+    elsif partner.present?
+      scope.where(journal_entry_lines: { partner: partner }).first
     end
   end
 end

--- a/rails/platform/app/jobs/receipt_line_process_job.rb
+++ b/rails/platform/app/jobs/receipt_line_process_job.rb
@@ -68,12 +68,17 @@ class ReceiptLineProcessJob < ApplicationJob
     result = service.call
 
     if result.success?
-      ActiveRecord::Base.transaction do
-        create_journal_entries(batch, result.data)
-        batch.update!(status: "completed", summary: result.data[:summary] || {})
-      end
+      begin
+        ActiveRecord::Base.transaction do
+          create_journal_entries(batch, result.data)
+          batch.update!(status: "completed", summary: result.data[:summary] || {})
+        end
 
-      @line_service.push(line_user_id, format_success_message(result.data))
+        @line_service.push(line_user_id, format_success_message(result.data))
+      rescue DuplicateFound => e
+        batch.update!(status: "duplicate", error_message: "重複検知: 既存 JE id=#{e.existing_entry.id}")
+        @line_service.push(line_user_id, format_duplicate_message(e.existing_entry))
+      end
     elsif result.retryable?
       raise RetryableError, result.error
     else
@@ -87,6 +92,18 @@ class ReceiptLineProcessJob < ApplicationJob
       end
       @line_service.push(line_user_id, message)
     end
+  end
+
+  def format_duplicate_message(existing_entry)
+    debit_line = existing_entry.journal_entry_lines.find_by(side: "debit")
+    partner = debit_line&.partner.presence || existing_entry.description
+    amount = debit_line&.amount
+
+    lines = ["このレシートは処理済みです。"]
+    lines << "📅 #{existing_entry.date} に登録"
+    lines << "🏪 #{partner}" if partner.present?
+    lines << "💰 ¥#{amount}" if amount
+    lines.join("\n")
   end
 
   def format_success_message(data)

--- a/rails/platform/app/jobs/receipt_process_job.rb
+++ b/rails/platform/app/jobs/receipt_process_job.rb
@@ -32,6 +32,8 @@ class ReceiptProcessJob < ApplicationJob
             error_message: nil
           )
         end
+      rescue DuplicateFound => e
+        batch.update!(status: "duplicate", error_message: "重複検知: 既存 JE id=#{e.existing_entry.id}")
       rescue ActiveRecord::RecordInvalid => e
         batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end

--- a/rails/platform/app/models/statement_batch.rb
+++ b/rails/platform/app/models/statement_batch.rb
@@ -1,5 +1,5 @@
 class StatementBatch < ApplicationRecord
-  STATUSES = %w[processing completed failed].freeze
+  STATUSES = %w[processing completed failed duplicate].freeze
 
   belongs_to :client
   has_many :journal_entries, dependent: :nullify

--- a/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
@@ -167,6 +167,45 @@ RSpec.describe ReceiptLineProcessJob, type: :job do
       end
     end
 
+    context "重複レシート（インボイス一致）" do
+      let(:mock_service) { instance_double(ReceiptProcessorService, call: receipt_result) }
+
+      before do
+        allow(ReceiptProcessorService).to receive(:new).and_return(mock_service)
+        create(:journal_entry, :receipt,
+          client: client,
+          source_period: "2026年3月",
+          transaction_no: 1,
+          date: "2026-03-13",
+          debit_invoice: "T1234567890123",
+          debit_partner: "別店舗",
+          debit_amount: 1080
+        )
+      end
+
+      it "新規JournalEntryを作成しないこと" do
+        expect {
+          described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+        }.not_to change(JournalEntry, :count)
+      end
+
+      it "StatementBatchをduplicateにすること" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        batch = StatementBatch.last
+        expect(batch.status).to eq("duplicate")
+      end
+
+      it "重複通知をLINEで送信すること" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).to have_received(:push).with(
+          line_user_id,
+          a_string_including("このレシートは処理済みです")
+        )
+      end
+    end
+
     context "リトライ可能なAPIエラー" do
       let(:error_result) do
         ReceiptProcessorService::Result.new(

--- a/rails/platform/spec/jobs/receipt_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_process_job_spec.rb
@@ -226,6 +226,86 @@ RSpec.describe ReceiptProcessJob, type: :job do
     end
   end
 
+  context "重複レシート（インボイス番号一致）の場合" do
+    before do
+      create(:journal_entry, :receipt,
+        client: client,
+        source_period: "2026年3月",
+        transaction_no: 1,
+        date: "2026-03-01",
+        debit_invoice: "T9876543210123",
+        debit_partner: "別店舗",
+        debit_amount: 2160
+      )
+    end
+
+    it "新規JournalEntryを作成しないこと" do
+      expect {
+        described_class.perform_now(batch.id)
+      }.not_to change(JournalEntry, :count)
+    end
+
+    it "ステータスをduplicateに更新すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("duplicate")
+      expect(batch.error_message).to include("重複検知")
+    end
+  end
+
+  context "重複レシート（インボイス番号なし・支払先一致）の場合" do
+    let(:mock_result_data) do
+      super().merge(
+        transactions: [
+          super()[:transactions].first.merge(debit_invoice: "")
+        ]
+      )
+    end
+
+    before do
+      create(:journal_entry, :receipt,
+        client: client,
+        source_period: "2026年3月",
+        transaction_no: 1,
+        date: "2026-03-01",
+        debit_invoice: "",
+        debit_partner: "マックスバリュ やんばる店",
+        debit_amount: 2160
+      )
+    end
+
+    it "ステータスをduplicateに更新し新規JEを作らないこと" do
+      expect {
+        described_class.perform_now(batch.id)
+      }.not_to change(JournalEntry, :count)
+
+      batch.reload
+      expect(batch.status).to eq("duplicate")
+    end
+  end
+
+  context "同月に別レシートがある場合（transaction_no衝突しないこと）" do
+    before do
+      create(:journal_entry, :receipt,
+        client: client,
+        source_period: "2026年3月",
+        transaction_no: 1,
+        date: "2026-03-02",
+        debit_invoice: "T0000000000001",
+        debit_partner: "別店舗",
+        debit_amount: 500
+      )
+    end
+
+    it "transaction_noがmax+1で採番されること" do
+      described_class.perform_now(batch.id)
+
+      new_entry = JournalEntry.where(statement_batch_id: batch.id).first
+      expect(new_entry.transaction_no).to eq(2)
+    end
+  end
+
   it "レコードが存在しない場合は静かに終了すること" do
     expect {
       described_class.perform_now(-1)


### PR DESCRIPTION
## Summary

LINE経由のレシート処理で発生していた2つの問題を同時に修正。

Closes #292
Closes #293

### 1. レシート重複検知（issue#292）

同じレシートを2回送信したときに二重計上を防ぐ仕組みを追加。

- 判定キー: インボイス番号があれば \`インボイス + 日付 + 金額\`、なければ \`支払先 + 日付 + 金額\` の3点一致
- 判定スコープ: 同一 Client の \`source_type: receipt\` 内
- 重複時の動作: 新規仕訳を作らず \`StatementBatch.status = duplicate\`、LINE 経由なら既存仕訳の情報を返信

### 2. transaction_no 自動採番（issue#293）

Claude から返される \`transaction_no\` をそのまま使うと、同じ source_period 内で衝突する（多くは 1 同士）バグの修正。

- \`create_journal_entries\` で同 scope の \`max(transaction_no) + 1\` から採番
- AMEX/Bank/Invoice にも適用（全 source_type で一貫）

## 主な変更

| ファイル | 変更 |
|---|---|
| \`app/jobs/concerns/journal_entry_creator.rb\` | 重複検知、max+1採番、DuplicateFound 例外 |
| \`app/jobs/receipt_line_process_job.rb\` | DuplicateFound rescue、重複時LINE返信 |
| \`app/jobs/receipt_process_job.rb\` | DuplicateFound rescue、status=duplicate |
| \`app/models/statement_batch.rb\` | STATUSES に "duplicate" 追加 |

## Test plan

- [x] \`make test\` 564 examples, 0 failures
- [ ] 本番デプロイ後、E2E
  - [ ] 同じレシート（インボイス番号一致）を2回送る → 2回目は重複拒否
  - [ ] 同月の別レシートを連続で送る → 両方とも仕訳作成