### PR TITLE
fix(platform): LINE返信の金額を合計+デリミタ表示に修正 (issue#295)

### DIFF
--- a/rails/platform/app/jobs/receipt_line_process_job.rb
+++ b/rails/platform/app/jobs/receipt_line_process_job.rb
@@ -107,15 +107,22 @@ class ReceiptLineProcessJob < ApplicationJob
   end
 
   def format_success_message(data)
-    txn = data[:transactions]&.first
-    return "領収書を処理しました。" unless txn
+    txns = data[:transactions] || []
+    first_txn = txns.first
+    return "領収書を処理しました。" unless first_txn
+
+    total = data.dig(:summary, :total_amount) || txns.sum { |t| t[:debit_amount].to_i }
 
     lines = ["📝 領収書を処理しました", ""]
-    lines << "📅 日付: #{txn[:date]}"
-    lines << "🏪 支払先: #{txn[:debit_partner]}" if txn[:debit_partner].present?
-    lines << "💰 金額: ¥#{txn[:debit_amount]&.to_s(:delimited) rescue txn[:debit_amount]}"
-    lines << "📂 勘定科目: #{txn[:debit_account]}"
-    lines << "🔍 判定元: #{txn[:status] == "review_required" ? "AI推論（要確認）" : "AIマッチング"}"
+    lines << "📅 日付: #{first_txn[:date]}"
+    lines << "🏪 支払先: #{first_txn[:debit_partner]}" if first_txn[:debit_partner].present?
+    lines << "💰 合計金額: ¥#{ActiveSupport::NumberHelper.number_to_delimited(total)}"
+    if txns.size > 1
+      lines << "📂 内訳: #{txns.size}件の仕訳"
+    else
+      lines << "📂 勘定科目: #{first_txn[:debit_account]}"
+    end
+    lines << "🔍 判定元: #{first_txn[:status] == "review_required" ? "AI推論（要確認）" : "AIマッチング"}"
     lines.join("\n")
   end
 

--- a/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
@@ -99,6 +99,77 @@ RSpec.describe ReceiptLineProcessJob, type: :job do
           a_string_including("領収書を処理しました")
         )
       end
+
+      it "合計金額がデリミタ付きで表示されること（単一取引）" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).to have_received(:push).with(
+          line_user_id,
+          a_string_including("合計金額: ¥1,080")
+        )
+      end
+    end
+
+    context "正常系（複数取引のレシート）" do
+      let(:success_data_multi) do
+        {
+          is_receipt: true,
+          receipt_date: "2026-03-13",
+          transactions: [
+            {
+              transaction_no: 1,
+              date: "2026-03-13",
+              debit_account: "仕入高",
+              debit_partner: "綿半",
+              debit_invoice: "T1111111111111",
+              debit_amount: 4597,
+              credit_account: "現金",
+              credit_amount: 4597,
+              description: "食品",
+              status: "ok"
+            },
+            {
+              transaction_no: 2,
+              date: "2026-03-13",
+              debit_account: "消耗品費",
+              debit_partner: "綿半",
+              debit_invoice: "T1111111111111",
+              debit_amount: 1795,
+              credit_account: "現金",
+              credit_amount: 1795,
+              description: "日用品",
+              status: "ok"
+            }
+          ],
+          summary: { total_amount: 6392 }
+        }
+      end
+      let(:multi_result) do
+        ReceiptProcessorService::Result.new(success: true, data: success_data_multi, error: nil, reason: nil)
+      end
+      let(:mock_service) { instance_double(ReceiptProcessorService, call: multi_result) }
+
+      before do
+        allow(ReceiptProcessorService).to receive(:new).and_return(mock_service)
+      end
+
+      it "summary.total_amountをデリミタ付きで表示すること" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).to have_received(:push).with(
+          line_user_id,
+          a_string_including("合計金額: ¥6,392")
+        )
+      end
+
+      it "件数で内訳を示すこと" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).to have_received(:push).with(
+          line_user_id,
+          a_string_including("内訳: 2件の仕訳")
+        )
+      end
     end
 
     context "画像取得失敗" do


### PR DESCRIPTION
## Summary

LINE 返信の金額表示を「最初の取引額」から「レシート全体の合計（デリミタ付き）」に修正。

Closes #295

## Before / After

Before:
\`\`\`
📝 領収書を処理しました

📅 日付: 2026-04-08
🏪 支払先: 綿半 富士河口湖店
💰 金額: ¥4597          ← 最初の取引額のみ、デリミタなし
📂 勘定科目: 仕入高
🔍 判定元: AI推論（要確認）
\`\`\`

After:
\`\`\`
📝 領収書を処理しました

📅 日付: 2026-04-08
🏪 支払先: 綿半 富士河口湖店
💰 合計金額: ¥6,392     ← 合計、デリミタあり
📂 内訳: 2件の仕訳       ← 複数取引のとき
🔍 判定元: AI推論（要確認）
\`\`\`

## Test plan

- [x] make test ARGS="spec/jobs/receipt_line_process_job_spec.rb" → 18 examples, 0 failures
- [ ] 本番デプロイ後、複数取引レシートを送信して合計とデリミタを目視確認