### PR TITLE
fix(platform): worker でPDFが読めないFileNotFoundErrorを修正 (issue#297)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,13 +132,24 @@ ngrok-status: ## ngrokの状態確認
 # ================================
 
 .PHONY: prod-deploy
-prod-deploy: ## 本番: Platformデプロイ（build → up → db:prepare）
+prod-deploy: prod-storage-check ## 本番: Platformデプロイ（build → up → db:prepare）
 	@echo "${GREEN}Deploying Platform...${NC}"
 	docker compose -f compose.production.yaml --env-file .env.production build --no-cache
 	docker compose -f compose.production.yaml --env-file .env.production down
 	docker compose -f compose.production.yaml --env-file .env.production up -d
 	docker compose -f compose.production.yaml --env-file .env.production exec platform rails db:prepare
 	@echo "${GREEN}Platform deployed successfully.${NC}"
+
+.PHONY: prod-storage-check
+prod-storage-check: ## 本番: ActiveStorage bind mount 用 ./storage ディレクトリの所有権チェック
+	@mkdir -p storage
+	@OWNER=$$(stat -c '%u:%g' storage 2>/dev/null || stat -f '%u:%g' storage); \
+	if [ "$$OWNER" != "999:999" ]; then \
+		echo "${RED}ERROR: ./storage must be owned by 999:999 (rails user inside container), but is $$OWNER${NC}"; \
+		echo "${RED}Run: sudo chown -R 999:999 storage${NC}"; \
+		exit 1; \
+	fi
+	@echo "${GREEN}storage directory ownership OK (999:999)${NC}"
 
 .PHONY: prod-logs
 prod-logs: ## 本番: ログ表示

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -30,6 +30,8 @@ services:
       - .env.local
     expose:
       - "3000"
+    volumes:
+      - ./storage:/platform/storage
     depends_on:
       db-suite:
         condition: service_healthy
@@ -50,6 +52,8 @@ services:
     env_file:
       - .env.production
       - .env.local
+    volumes:
+      - ./storage:/platform/storage
     depends_on:
       platform:
         condition: service_healthy

--- a/rails/platform/app/jobs/cleaning_manual_generate_job.rb
+++ b/rails/platform/app/jobs/cleaning_manual_generate_job.rb
@@ -1,15 +1,15 @@
 class CleaningManualGenerateJob < ApplicationJob
+  class RetryableError < StandardError; end
+
   queue_as :default
 
-  retry_on StandardError, wait: 5.seconds, attempts: 2
+  retry_on RetryableError, wait: 5.seconds, attempts: 2 do |job, exception|
+    manual_id = job.arguments.first
+    manual = CleaningManual.find_by(id: manual_id)
+    manual&.update(status: "failed", error_message: "リトライ上限到達: #{exception.message}")
+  end
 
   discard_on ActiveRecord::RecordNotFound
-
-  after_discard do |_job, exception|
-    manual_id = _job.arguments.first
-    manual = CleaningManual.find_by(id: manual_id)
-    manual&.update(status: "failed", error_message: "ジョブ実行エラー: #{exception.message}")
-  end
 
   def perform(cleaning_manual_id, labels: [])
     manual = CleaningManual.find(cleaning_manual_id)
@@ -28,6 +28,8 @@ class CleaningManualGenerateJob < ApplicationJob
 
       if result.success?
         manual.update!(manual_data: result.data, status: "draft", error_message: nil)
+      elsif result.retryable?
+        raise RetryableError, result.error
       else
         manual.update!(status: "failed", error_message: result.error)
       end

--- a/rails/platform/app/jobs/receipt_line_process_job.rb
+++ b/rails/platform/app/jobs/receipt_line_process_job.rb
@@ -29,7 +29,9 @@ class ReceiptLineProcessJob < ApplicationJob
 
     fingerprint = Digest::SHA256.hexdigest(image_binary)
 
-    existing = StatementBatch.find_by(client: client, pdf_fingerprint: fingerprint)
+    existing = StatementBatch
+      .where(client: client, pdf_fingerprint: fingerprint, status: %w[processing completed duplicate])
+      .first
     if existing
       if existing.status == "processing"
         process_receipt(existing, line_user_id)
@@ -87,6 +89,8 @@ class ReceiptLineProcessJob < ApplicationJob
       message = case result.reason
       when :non_receipt
         "領収書またはレシートの画像を送信してください。"
+      when :file_not_found
+        "画像ファイルの読み込みに失敗しました。もう一度送信してください。"
       else
         "処理中にエラーが発生しました。もう一度お試しください。"
       end

--- a/rails/platform/app/services/amex_statement_processor_service.rb
+++ b/rails/platform/app/services/amex_statement_processor_service.rb
@@ -1,7 +1,7 @@
 require "combine_pdf"
 
 class AmexStatementProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error].freeze
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -174,6 +174,8 @@ class AmexStatementProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
+  rescue ActiveStorage::FileNotFoundError => e
+    Result.new(success: false, data: {}, error: "PDFファイルが見つかりません: #{e.message}", reason: :file_not_found)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/bank_statement_processor_service.rb
+++ b/rails/platform/app/services/bank_statement_processor_service.rb
@@ -1,7 +1,7 @@
 require "combine_pdf"
 
 class BankStatementProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error].freeze
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -179,6 +179,8 @@ class BankStatementProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
+  rescue ActiveStorage::FileNotFoundError => e
+    Result.new(success: false, data: {}, error: "PDFファイルが見つかりません: #{e.message}", reason: :file_not_found)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/cleaning_manual_generator_service.rb
+++ b/rails/platform/app/services/cleaning_manual_generator_service.rb
@@ -1,8 +1,11 @@
 require "image_processing/vips"
 
 class CleaningManualGeneratorService
-  Result = Data.define(:success, :data, :error) do
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
+
+  Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
+    def retryable? = !success && !NON_RETRYABLE_REASONS.include?(reason)
   end
 
   MAX_IMAGES_PER_BATCH = 20
@@ -70,7 +73,7 @@ class CleaningManualGeneratorService
 
   def call
     unless ENV["ANTHROPIC_API_KEY"].present?
-      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません")
+      return Result.new(success: false, data: {}, error: "ANTHROPIC_API_KEY が設定されていません", reason: :config_error)
     end
 
     batches = @images.each_slice(MAX_IMAGES_PER_BATCH).to_a
@@ -78,18 +81,20 @@ class CleaningManualGeneratorService
     if batches.size == 1
       result = generate_for_batch(batches.first)
       return result unless result.success?
-      Result.new(success: true, data: result.data, error: nil)
+      Result.new(success: true, data: result.data, error: nil, reason: nil)
     else
       merged = merge_batch_results(batches)
       return merged unless merged.success?
-      Result.new(success: true, data: merged.data, error: nil)
+      Result.new(success: true, data: merged.data, error: nil, reason: nil)
     end
+  rescue ActiveStorage::FileNotFoundError => e
+    Result.new(success: false, data: {}, error: "画像ファイルが見つかりません: #{e.message}", reason: :file_not_found)
   rescue Anthropic::Errors::APIError => e
-    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e
-    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "JSON パースエラー: #{e.message}", reason: :parse_error)
   rescue StandardError => e
-    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}")
+    Result.new(success: false, data: {}, error: "予期しないエラー: #{e.message}", reason: :unexpected_error)
   end
 
   private
@@ -114,7 +119,7 @@ class CleaningManualGeneratorService
     data[:room_type] = @room_type
     data[:generated_at] = Time.current.iso8601
 
-    Result.new(success: true, data: data, error: nil)
+    Result.new(success: true, data: data, error: nil, reason: nil)
   end
 
   def merge_batch_results(batches)
@@ -152,7 +157,7 @@ class CleaningManualGeneratorService
       total_estimated_minutes: total_minutes
     }
 
-    Result.new(success: true, data: data, error: nil)
+    Result.new(success: true, data: data, error: nil, reason: nil)
   end
 
   def build_content(image_batch)

--- a/rails/platform/app/services/invoice_processor_service.rb
+++ b/rails/platform/app/services/invoice_processor_service.rb
@@ -1,7 +1,7 @@
 require "combine_pdf"
 
 class InvoiceProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error].freeze
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -179,6 +179,8 @@ class InvoiceProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
+  rescue ActiveStorage::FileNotFoundError => e
+    Result.new(success: false, data: {}, error: "PDFファイルが見つかりません: #{e.message}", reason: :file_not_found)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/receipt_processor_service.rb
+++ b/rails/platform/app/services/receipt_processor_service.rb
@@ -1,5 +1,5 @@
 class ReceiptProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error non_receipt unsupported_format].freeze
+  NON_RETRYABLE_REASONS = %i[config_error non_receipt unsupported_format file_not_found].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -180,6 +180,8 @@ class ReceiptProcessorService
     end
 
     Result.new(success: true, data: data, error: nil, reason: nil)
+  rescue ActiveStorage::FileNotFoundError => e
+    Result.new(success: false, data: {}, error: "画像ファイルが見つかりません: #{e.message}", reason: :file_not_found)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/spec/jobs/cleaning_manual_generate_job_spec.rb
+++ b/rails/platform/spec/jobs/cleaning_manual_generate_job_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe CleaningManualGenerateJob, type: :job do
     CleaningManualGeneratorService::Result.new(
       success: true,
       data: { property_name: "テスト", areas: [], supplies_needed: [], total_estimated_minutes: 0 },
-      error: nil
+      error: nil,
+      reason: nil
     )
   end
 
@@ -32,10 +33,10 @@ RSpec.describe CleaningManualGenerateJob, type: :job do
     expect(manual.error_message).to be_nil
   end
 
-  context "サービスが失敗した場合" do
+  context "non-retryableな失敗の場合" do
     let(:mock_result) do
       CleaningManualGeneratorService::Result.new(
-        success: false, data: {}, error: "APIエラー"
+        success: false, data: {}, error: "APIキー未設定", reason: :config_error
       )
     end
 
@@ -44,7 +45,37 @@ RSpec.describe CleaningManualGenerateJob, type: :job do
 
       manual.reload
       expect(manual.status).to eq("failed")
-      expect(manual.error_message).to eq("APIエラー")
+      expect(manual.error_message).to eq("APIキー未設定")
+    end
+  end
+
+  context "retryableな失敗の場合" do
+    let(:mock_result) do
+      CleaningManualGeneratorService::Result.new(
+        success: false, data: {}, error: "Anthropic API エラー: timeout", reason: :api_error
+      )
+    end
+
+    it "RetryableErrorをraiseすること" do
+      job = described_class.new(manual.id)
+
+      expect { job.perform(manual.id) }.to raise_error(CleaningManualGenerateJob::RetryableError, "Anthropic API エラー: timeout")
+    end
+  end
+
+  context "file_not_found の場合" do
+    let(:mock_result) do
+      CleaningManualGeneratorService::Result.new(
+        success: false, data: {}, error: "画像ファイルが見つかりません: ActiveStorage::FileNotFoundError", reason: :file_not_found
+      )
+    end
+
+    it "リトライせずステータスをfailedに更新すること" do
+      described_class.perform_now(manual.id)
+
+      manual.reload
+      expect(manual.status).to eq("failed")
+      expect(manual.error_message).to include("画像ファイルが見つかりません")
     end
   end
 

--- a/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
@@ -208,6 +208,62 @@ RSpec.describe ReceiptLineProcessJob, type: :job do
       end
     end
 
+    context "過去にfailedになった同一画像" do
+      let(:mock_service) { instance_double(ReceiptProcessorService, call: receipt_result) }
+
+      before do
+        create(:statement_batch, :failed, client: client, source_type: "receipt", pdf_fingerprint: fingerprint)
+        allow(ReceiptProcessorService).to receive(:new).and_return(mock_service)
+      end
+
+      it "重複扱いせず新規バッチを作成して処理すること" do
+        expect {
+          described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+        }.to change(StatementBatch, :count).by(1)
+      end
+
+      it "重複メッセージを送信しないこと" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).not_to have_received(:push).with(
+          line_user_id,
+          "この画像は既に処理済みです。"
+        )
+      end
+    end
+
+    context "file_not_found エラー" do
+      let(:file_not_found_result) do
+        ReceiptProcessorService::Result.new(
+          success: false, data: {}, error: "画像ファイルが見つかりません: ActiveStorage::FileNotFoundError", reason: :file_not_found
+        )
+      end
+
+      before do
+        allow(ReceiptProcessorService).to receive(:new).and_return(
+          instance_double(ReceiptProcessorService, call: file_not_found_result)
+        )
+      end
+
+      it "専用エラーメッセージをLINEで送信すること" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).to have_received(:push).with(
+          line_user_id,
+          "画像ファイルの読み込みに失敗しました。もう一度送信してください。"
+        )
+      end
+
+      it "リトライせずStatementBatchをfailedにすること" do
+        expect {
+          described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+        }.not_to raise_error
+
+        batch = StatementBatch.last
+        expect(batch.status).to eq("failed")
+      end
+    end
+
     context "非領収書画像" do
       let(:non_receipt_result) do
         ReceiptProcessorService::Result.new(

--- a/rails/platform/spec/services/amex_statement_processor_service_spec.rb
+++ b/rails/platform/spec/services/amex_statement_processor_service_spec.rb
@@ -492,6 +492,30 @@ RSpec.describe AmexStatementProcessorService do
         result = described_class::Result.new(success: false, data: {}, error: "error", reason: :config_error)
         expect(result.retryable?).to be false
       end
+
+      it "file_not_foundはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :file_not_found)
+        expect(result.retryable?).to be false
+      end
+    end
+
+    context "ActiveStorage::FileNotFoundError が発生した場合" do
+      it "file_not_found reasonで失敗し、retryableでないこと" do
+        broken_pdf = double("BrokenAttachment")
+        allow(broken_pdf).to receive(:respond_to?).with(:download).and_return(true)
+        allow(broken_pdf).to receive(:respond_to?).with(:read).and_return(false)
+        allow(broken_pdf).to receive(:download).and_raise(
+          ActiveStorage::FileNotFoundError, "missing file"
+        )
+
+        service = described_class.new(pdf: broken_pdf, client_code: client.code)
+        result = service.call
+
+        expect(result.success?).to be false
+        expect(result.reason).to eq(:file_not_found)
+        expect(result.error).to include("PDFファイルが見つかりません")
+        expect(result.retryable?).to be false
+      end
     end
   end
 end

--- a/rails/platform/spec/services/bank_statement_processor_service_spec.rb
+++ b/rails/platform/spec/services/bank_statement_processor_service_spec.rb
@@ -501,6 +501,11 @@ RSpec.describe BankStatementProcessorService do
         result = described_class::Result.new(success: false, data: {}, error: "error", reason: :config_error)
         expect(result.retryable?).to be false
       end
+
+      it "file_not_foundはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :file_not_found)
+        expect(result.retryable?).to be false
+      end
     end
   end
 end

--- a/rails/platform/spec/services/invoice_processor_service_spec.rb
+++ b/rails/platform/spec/services/invoice_processor_service_spec.rb
@@ -511,6 +511,11 @@ RSpec.describe InvoiceProcessorService do
         expect(result.retryable?).to be false
       end
 
+      it "file_not_foundはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :file_not_found)
+        expect(result.retryable?).to be false
+      end
+
       it "成功時はretryableでないこと" do
         result = described_class::Result.new(success: true, data: {}, error: nil, reason: nil)
         expect(result.retryable?).to be false

--- a/rails/platform/spec/services/receipt_processor_service_spec.rb
+++ b/rails/platform/spec/services/receipt_processor_service_spec.rb
@@ -381,5 +381,24 @@ RSpec.describe ReceiptProcessorService do
         expect(result.error).to include("max_tokens")
       end
     end
+
+    context "ActiveStorage::FileNotFoundError が発生した場合" do
+      it "file_not_found reasonで失敗し、retryableでないこと" do
+        broken_image = double("BrokenAttachment")
+        allow(broken_image).to receive(:respond_to?).with(:download).and_return(true)
+        allow(broken_image).to receive(:respond_to?).with(:read).and_return(false)
+        allow(broken_image).to receive(:download).and_raise(
+          ActiveStorage::FileNotFoundError, "missing file"
+        )
+
+        service = described_class.new(image: broken_image, client_code: client.code)
+        result = service.call
+
+        expect(result.success?).to be false
+        expect(result.reason).to eq(:file_not_found)
+        expect(result.error).to include("画像ファイルが見つかりません")
+        expect(result.retryable?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #297

## Summary
- 本番で全アップロード処理が \`ActiveStorage::FileNotFoundError\` で失敗していた問題を修正
- 根本原因: \`compose.production.yaml\` で platform / worker が別コンテナなのに storage volume が未共有
- コードレビュー指摘のCRITICAL 3件も同PRで対応

## 変更点

### Storage volume共有 (根本原因の解決)
- \`compose.production.yaml\`: platform/worker に \`./storage:/platform/storage\` bind mount 追加
- \`Makefile\`: prod-deploy 前に ./storage の所有権 (999:999) を自動チェック

### FileNotFoundError のリトライ不可化
- 4つの processor サービス (amex/bank/invoice/receipt) で \`ActiveStorage::FileNotFoundError\` 専用 rescue + \`:file_not_found\` reason を \`NON_RETRYABLE_REASONS\` に追加
- CleaningManualGeneratorService も同パターンに揃える + Job を retry_on RetryableError パターンに統一
- 対応する spec にテスト追加

### LINE flow のループ解消
- \`ReceiptLineProcessJob\`: fingerprint dedup に \`status: %w[processing completed duplicate]\` フィルタを追加（failed は除外）
- \`case result.reason\` に \`:file_not_found\` 分岐追加

## マージ後の本番デプロイ手順

\`\`\`bash
ssh devuser@parijona.land-bank.ai
cd /srv/landbase_ai_suite

# 1. ホスト側 storage ディレクトリを準備
mkdir -p storage
sudo chown -R 999:999 storage  # railsユーザー UID

# 2. 修正を取り込んでデプロイ
git pull
make prod-deploy  # prod-storage-check が自動で権限を検証

# 3. 検証
docker compose -f compose.production.yaml --env-file .env.production exec worker \
  bash -lc 'ls -la /platform/storage/'  # rails:rails で書き込み可能
\`\`\`

その後、ユーザーに failed 状態の Amex/銀行/請求書/レシートPDF (ID 1-3, 10-13) を再アップロードしてもらう。
LINE経由のレシートも、過去にfailedしたものを再送すれば処理可能。

## フォローアップ issue

コードレビューで挙がったHIGH/MEDIUM/LOW指摘は別issueで対応:
- #299 ActiveStorageエラーメッセージのUX改善とEACCES/ENOSPCのrescue追加
- #300 Docker コンテナ運用の堅牢化 (UID固定、Dockerfileコメント、dev compose統一)
- #301 本番storage運用整備 (gitignore、orphan blob掃除、healthcheck、backup)
- #302 LINE flowで attach() 失敗時のprocessing ロック対策
- #303 ActiveStorage関連 specで instance_double 使用

## Test plan
- [x] \`make test ARGS=\"spec/services/ spec/jobs/\"\` 192 examples 全パス
- [ ] 本番デプロイ後、worker コンテナで \`/platform/storage/\` が rails:rails で書き込み可能なこと
- [ ] ユーザーがPDFを再アップロードしてAmex/銀行/請求書/レシートが成功すること
- [ ] LINE経由で過去にfailedになった画像を再送して処理が通ること