### PR TITLE
fix(platform): amex/bank/invoice にも transaction_no 自動採番を適用 (issue#304)

### DIFF
--- a/rails/platform/app/jobs/amex_statement_process_job.rb
+++ b/rails/platform/app/jobs/amex_statement_process_job.rb
@@ -1,4 +1,6 @@
 class AmexStatementProcessJob < ApplicationJob
+  include JournalEntryCreator
+
   class RetryableError < StandardError; end
 
   queue_as :default
@@ -40,45 +42,4 @@ class AmexStatementProcessJob < ApplicationJob
     end
   end
 
-  private
-
-  def create_journal_entries(batch, data)
-    transactions = data[:transactions] || []
-    transactions.each do |txn|
-      batch.journal_entries.create!(
-        client: batch.client,
-        source_type: batch.source_type,
-        source_period: data[:statement_period],
-        transaction_no: txn[:transaction_no],
-        date: txn[:date],
-        description: txn[:description] || "",
-        tag: txn[:tag] || "amex",
-        memo: txn[:memo] || "",
-        cardholder: txn[:cardholder] || "",
-        status: txn[:status] || "ok",
-        journal_entry_lines_attributes: [
-          {
-            side: "debit",
-            account: txn[:debit_account],
-            sub_account: txn[:debit_sub_account] || "",
-            department: txn[:debit_department] || "",
-            partner: txn[:debit_partner] || "",
-            tax_category: txn[:debit_tax_category] || "",
-            invoice: txn[:debit_invoice] || "",
-            amount: txn[:debit_amount]
-          },
-          {
-            side: "credit",
-            account: txn[:credit_account],
-            sub_account: txn[:credit_sub_account] || "",
-            department: txn[:credit_department] || "",
-            partner: txn[:credit_partner] || "",
-            tax_category: txn[:credit_tax_category] || "",
-            invoice: txn[:credit_invoice] || "",
-            amount: txn[:credit_amount]
-          }
-        ]
-      )
-    end
-  end
 end

--- a/rails/platform/app/jobs/bank_statement_process_job.rb
+++ b/rails/platform/app/jobs/bank_statement_process_job.rb
@@ -1,4 +1,6 @@
 class BankStatementProcessJob < ApplicationJob
+  include JournalEntryCreator
+
   class RetryableError < StandardError; end
 
   queue_as :default
@@ -40,45 +42,4 @@ class BankStatementProcessJob < ApplicationJob
     end
   end
 
-  private
-
-  def create_journal_entries(batch, data)
-    transactions = data[:transactions] || []
-    transactions.each do |txn|
-      batch.journal_entries.create!(
-        client: batch.client,
-        source_type: batch.source_type,
-        source_period: data[:statement_period],
-        transaction_no: txn[:transaction_no],
-        date: txn[:date],
-        description: txn[:description] || "",
-        tag: txn[:tag] || "bank",
-        memo: txn[:memo] || "",
-        cardholder: txn[:cardholder] || "",
-        status: txn[:status] || "ok",
-        journal_entry_lines_attributes: [
-          {
-            side: "debit",
-            account: txn[:debit_account],
-            sub_account: txn[:debit_sub_account] || "",
-            department: txn[:debit_department] || "",
-            partner: txn[:debit_partner] || "",
-            tax_category: txn[:debit_tax_category] || "",
-            invoice: txn[:debit_invoice] || "",
-            amount: txn[:debit_amount]
-          },
-          {
-            side: "credit",
-            account: txn[:credit_account],
-            sub_account: txn[:credit_sub_account] || "",
-            department: txn[:credit_department] || "",
-            partner: txn[:credit_partner] || "",
-            tax_category: txn[:credit_tax_category] || "",
-            invoice: txn[:credit_invoice] || "",
-            amount: txn[:credit_amount]
-          }
-        ]
-      )
-    end
-  end
 end

--- a/rails/platform/app/jobs/concerns/journal_entry_creator.rb
+++ b/rails/platform/app/jobs/concerns/journal_entry_creator.rb
@@ -13,7 +13,7 @@ module JournalEntryCreator
   private
 
   def create_journal_entries(batch, data)
-    source_period = build_source_period(data[:receipt_date])
+    source_period = resolve_source_period(batch, data)
     transactions = data[:transactions] || []
 
     if batch.source_type == "receipt"
@@ -33,9 +33,9 @@ module JournalEntryCreator
         transaction_no: base_txn_no + idx + 1,
         date: txn[:date],
         description: txn[:description] || "",
-        tag: txn[:tag] || "receipt",
+        tag: txn[:tag] || batch.source_type,
         memo: txn[:memo] || "",
-        cardholder: "",
+        cardholder: txn[:cardholder] || "",
         status: txn[:status] || "ok",
         journal_entry_lines_attributes: [
           {
@@ -60,6 +60,17 @@ module JournalEntryCreator
           }
         ]
       )
+    end
+  end
+
+  def resolve_source_period(batch, data)
+    case batch.source_type
+    when "receipt"
+      build_source_period(data[:receipt_date])
+    when "invoice"
+      build_source_period(data[:invoice_date])
+    else
+      data[:statement_period]
     end
   end
 

--- a/rails/platform/app/jobs/invoice_process_job.rb
+++ b/rails/platform/app/jobs/invoice_process_job.rb
@@ -1,4 +1,6 @@
 class InvoiceProcessJob < ApplicationJob
+  include JournalEntryCreator
+
   class RetryableError < StandardError; end
 
   queue_as :default
@@ -40,50 +42,4 @@ class InvoiceProcessJob < ApplicationJob
     end
   end
 
-  private
-
-  def create_journal_entries(batch, data)
-    source_period = if data[:invoice_date].present?
-      date = Date.parse(data[:invoice_date])
-      "#{date.year}年#{date.month}月"
-    end
-
-    transactions = data[:transactions] || []
-    transactions.each do |txn|
-      batch.journal_entries.create!(
-        client: batch.client,
-        source_type: batch.source_type,
-        source_period: source_period,
-        transaction_no: txn[:transaction_no],
-        date: txn[:date],
-        description: txn[:description] || "",
-        tag: txn[:tag] || "invoice",
-        memo: txn[:memo] || "",
-        cardholder: "",
-        status: txn[:status] || "ok",
-        journal_entry_lines_attributes: [
-          {
-            side: "debit",
-            account: txn[:debit_account],
-            sub_account: txn[:debit_sub_account] || "",
-            department: txn[:debit_department] || "",
-            partner: txn[:debit_partner] || "",
-            tax_category: txn[:debit_tax_category] || "",
-            invoice: txn[:debit_invoice] || "",
-            amount: txn[:debit_amount]
-          },
-          {
-            side: "credit",
-            account: txn[:credit_account],
-            sub_account: txn[:credit_sub_account] || "",
-            department: txn[:credit_department] || "",
-            partner: txn[:credit_partner] || "",
-            tax_category: txn[:credit_tax_category] || "",
-            invoice: txn[:credit_invoice] || "",
-            amount: txn[:credit_amount]
-          }
-        ]
-      )
-    end
-  end
 end

--- a/rails/platform/spec/jobs/amex_statement_process_job_spec.rb
+++ b/rails/platform/spec/jobs/amex_statement_process_job_spec.rb
@@ -93,6 +93,21 @@ RSpec.describe AmexStatementProcessJob, type: :job do
     expect(credit.amount).to eq(3280)
   end
 
+  context "同一source_periodに既存のJournalEntryがある場合" do
+    before do
+      create(:journal_entry, :amex, client: client, source_period: "2026年1月", transaction_no: 10)
+    end
+
+    it "transaction_noをmax+1から採番してユニーク制約衝突を回避すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("completed")
+      entry = batch.journal_entries.first
+      expect(entry.transaction_no).to eq(11)
+    end
+  end
+
   context "retryableなエラーの場合" do
     let(:mock_result) do
       AmexStatementProcessorService::Result.new(

--- a/rails/platform/spec/jobs/bank_statement_process_job_spec.rb
+++ b/rails/platform/spec/jobs/bank_statement_process_job_spec.rb
@@ -84,6 +84,28 @@ RSpec.describe BankStatementProcessJob, type: :job do
     expect(entry.statement_batch).to eq(batch)
     expect(entry.source_type).to eq("bank")
     expect(entry.tag).to eq("bank")
+    expect(entry.transaction_no).to eq(1)
+  end
+
+  context "同一source_periodに既存のJournalEntryがある場合" do
+    before do
+      create(:journal_entry, :bank, client: client, source_period: "2026年1月", transaction_no: 5)
+    end
+
+    it "transaction_noをmax+1から採番してユニーク制約衝突を回避すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("completed")
+      entry = batch.journal_entries.first
+      expect(entry.transaction_no).to eq(6)
+    end
+  end
+
+  it "成功時のJournalEntry詳細を検証" do
+    described_class.perform_now(batch.id)
+
+    entry = JournalEntry.last
 
     debit = entry.debit_lines.first
     expect(debit.account).to eq("水道光熱費")

--- a/rails/platform/spec/jobs/invoice_process_job_spec.rb
+++ b/rails/platform/spec/jobs/invoice_process_job_spec.rb
@@ -103,6 +103,21 @@ RSpec.describe InvoiceProcessJob, type: :job do
     expect(entry.source_period).to eq("2026年2月")
   end
 
+  context "同一source_periodに既存のJournalEntryがある場合" do
+    before do
+      create(:journal_entry, :invoice, client: client, source_period: "2026年2月", transaction_no: 3)
+    end
+
+    it "transaction_noをmax+1から採番してユニーク制約衝突を回避すること" do
+      described_class.perform_now(batch.id)
+
+      batch.reload
+      expect(batch.status).to eq("completed")
+      entry = batch.journal_entries.first
+      expect(entry.transaction_no).to eq(4)
+    end
+  end
+
   context "retryableなエラーの場合" do
     let(:mock_result) do
       InvoiceProcessorService::Result.new(


### PR DESCRIPTION
Closes #304

## Summary

PR #294 で receipt 向けに導入した \`JournalEntryCreator\` concern を amex/bank/invoice の3 job にも適用。本番テストで bank 明細を同 source_period で複数アップすると 'Transaction noはすでに存在します' エラーで2件目以降が失敗していた問題を解消。

## 変更点

- \`amex_statement_process_job\` / \`bank_statement_process_job\` / \`invoice_process_job\` を \`include JournalEntryCreator\` に変更し、独自 \`create_journal_entries\` を削除（131行削除→72行追加）
- \`JournalEntryCreator#resolve_source_period\` を source_type で分岐:
  - receipt → \`build_source_period(data[:receipt_date])\`
  - invoice → \`build_source_period(data[:invoice_date])\`
  - amex/bank → \`data[:statement_period]\`
- 3 job spec に「同一source_periodに既存のJournalEntryがある場合、max+1から採番」のテスト追加

## Test plan

- [x] \`make test ARGS=spec/jobs/\` 80 examples 全パス
- [ ] 本番デプロイ後、bank ID 17 を再アップロードして completed になること
- [ ] 同 source_period の別 batch アップロードで衝突しないこと