### PR TITLE
fix(platform): 弥生CSVの税区分を3区分に統一（暫定方針） (issue#308)

### DIFF
--- a/rails/platform/app/services/yayoi_export_service.rb
+++ b/rails/platform/app/services/yayoi_export_service.rb
@@ -4,6 +4,10 @@ class YayoiExportService
   SINGLE_ENTRY_FLAG = "2000"
   SINGLE_TYPE = "0"
 
+  TAX_CATEGORY_STANDARD = "課対仕入込10%"
+  TAX_CATEGORY_REDUCED  = "課対仕入込軽減8%"
+  TAX_CATEGORY_OUT      = "対象外"
+
   def export_single_entry(entries)
     entries = entries.includes(:journal_entry_lines) if entries.respond_to?(:includes)
 
@@ -29,14 +33,14 @@ class YayoiExportService
       debit&.sub_account&.presence || "",      # 4: 借方補助科目
       debit&.department&.presence || "",       # 5: 借方部門
       debit&.partner&.presence || "",          # 6: 借方取引先
-      debit&.tax_category&.presence || "",     # 7: 借方税区分
+      map_tax_category(debit&.tax_category),   # 7: 借方税区分
       debit&.invoice&.presence || "",          # 8: 借方インボイス
       debit&.amount || 0,                      # 9: 借方金額
       credit&.account || "",                   # 10: 貸方勘定科目
       credit&.sub_account&.presence || "",     # 11: 貸方補助科目
       credit&.department&.presence || "",      # 12: 貸方部門
       credit&.partner&.presence || "",         # 13: 貸方取引先
-      credit&.tax_category&.presence || "",    # 14: 貸方税区分
+      map_tax_category(credit&.tax_category),  # 14: 貸方税区分
       credit&.invoice&.presence || "",         # 15: 貸方インボイス
       credit&.amount || 0,                     # 16: 貸方金額
       entry.description.presence || "",        # 17: 摘要
@@ -49,5 +53,19 @@ class YayoiExportService
       "",                                      # 24: 予備3
       ""                                       # 25: 予備4
     ]
+  end
+
+  # クレカ明細等は適格／非適格の判定不能のため、すべて適格扱いで弥生の3区分に丸める。
+  # 空文字は弥生で「税区分なし」を意味するため、そのまま空文字で返す。
+  def map_tax_category(raw)
+    return "" if raw.blank?
+
+    if raw.include?("軽減") || raw.include?("8%")
+      TAX_CATEGORY_REDUCED
+    elsif raw.include?("10%")
+      TAX_CATEGORY_STANDARD
+    else
+      TAX_CATEGORY_OUT
+    end
   end
 end

--- a/rails/platform/spec/services/yayoi_export_service_spec.rb
+++ b/rails/platform/spec/services/yayoi_export_service_spec.rb
@@ -94,4 +94,63 @@ RSpec.describe YayoiExportService do
       expect(rows[0][15]).to eq("0")
     end
   end
+
+  describe "税区分マッピング (適格扱い3区分への統一)" do
+    def build_entry(debit_tax:, credit_tax: "", date: Date.new(2026, 3, 1))
+      create(:journal_entry, client: client, date: date,
+             debit_account: "消耗品費", debit_tax_category: debit_tax, debit_amount: 1_000,
+             credit_account: "未払金", credit_tax_category: credit_tax, credit_amount: 1_000)
+    end
+
+    def export_row(entry)
+      decode_csv(service.export_single_entry(JournalEntry.where(id: entry.id))).first
+    end
+
+    it "「課税仕入10%（インボイス）」を「課対仕入込10%」に変換すること" do
+      entry = build_entry(debit_tax: "課税仕入10%（インボイス）")
+      expect(export_row(entry)[6]).to eq("課対仕入込10%")
+    end
+
+    it "「課税仕入10%（非インボイス）」を「課対仕入込10%」に変換すること" do
+      entry = build_entry(debit_tax: "課税仕入10%（非インボイス）")
+      expect(export_row(entry)[6]).to eq("課対仕入込10%")
+    end
+
+    it "「課税仕入10%」を「課対仕入込10%」に変換すること" do
+      entry = build_entry(debit_tax: "課税仕入10%")
+      expect(export_row(entry)[6]).to eq("課対仕入込10%")
+    end
+
+    it "「課税仕入8%（軽減・インボイス）」を「課対仕入込軽減8%」に変換すること" do
+      entry = build_entry(debit_tax: "課税仕入8%（軽減・インボイス）")
+      expect(export_row(entry)[6]).to eq("課対仕入込軽減8%")
+    end
+
+    it "「課税仕入8%（軽減・非インボイス）」を「課対仕入込軽減8%」に変換すること" do
+      entry = build_entry(debit_tax: "課税仕入8%（軽減・非インボイス）")
+      expect(export_row(entry)[6]).to eq("課対仕入込軽減8%")
+    end
+
+    it "「対象外」をそのまま「対象外」とすること" do
+      entry = build_entry(debit_tax: "対象外")
+      expect(export_row(entry)[6]).to eq("対象外")
+    end
+
+    it "「非課税仕入」を「対象外」に丸めること" do
+      entry = build_entry(debit_tax: "非課税仕入")
+      expect(export_row(entry)[6]).to eq("対象外")
+    end
+
+    it "「課対仕入（リバースチャージ）」を「対象外」に丸めること" do
+      entry = build_entry(debit_tax: "課対仕入（リバースチャージ）")
+      expect(export_row(entry)[6]).to eq("対象外")
+    end
+
+    it "空文字は空文字のまま出力されること（貸方など）" do
+      entry = build_entry(debit_tax: "課税仕入10%", credit_tax: "")
+      row = export_row(entry)
+      expect(row[6]).to eq("課対仕入込10%")
+      expect(row[13]).to eq("")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- 弥生CSV出力時、DBの税区分文字列を弥生公式の3区分（\`課対仕入込10%\` / \`課対仕入込軽減8%\` / \`対象外\`）にマッピング
- 適格サフィックスは付与せず、弥生側の自動判定（取引日・取引先・科目から判定）に委ねる
- DB の \`tax_category\` 値は変更せず、CSV 出力時のみ正規化

Closes #308

## 変更内容

### \`app/services/yayoi_export_service.rb\`

- \`map_tax_category\` メソッドを追加
- 借方/貸方の税区分を CSV 出力時に 3 区分のいずれかに変換
- 空文字は空文字のまま出力（弥生で「税区分なし」の意味）

### マッピングルール

| DB上の文字列 | → CSV出力 |
|---|---|
| 10%を含む（\`課税仕入10%（インボイス）\` 等） | \`課対仕入込10%\` |
| 8%・軽減を含む（\`課税仕入8%（軽減・〜）\` 等） | \`課対仕入込軽減8%\` |
| その他（\`対象外\` / \`非課税仕入\` / \`課対仕入（リバースチャージ）\` 等） | \`対象外\` |
| 空文字 | 空文字 |

## 暫定方針について

仕様の細部について検討事項が残るため、一旦この方針で実装してリリースし、実運用フィードバックを経て修正する想定。詳細は #308 参照。

## Test plan

- [x] 既存テスト (11 件) が全てパス
- [x] マッピング検証 spec (9 件) を追加し全てパス
  - 課税仕入10%（インボイス） → 課対仕入込10%
  - 課税仕入10%（非インボイス） → 課対仕入込10%
  - 課税仕入10% → 課対仕入込10%
  - 課税仕入8%（軽減・インボイス） → 課対仕入込軽減8%
  - 課税仕入8%（軽減・非インボイス） → 課対仕入込軽減8%
  - 対象外 → 対象外
  - 非課税仕入 → 対象外
  - 課対仕入（リバースチャージ） → 対象外
  - 空文字 → 空文字
- [x] CSV エンコーディング（Windows-31J）が維持されることを確認
- [ ] 実運用での弥生インポート動作確認