### PR TITLE
feat(platform): 仕訳台帳に削除機能（1件 + バッチ単位）(issue#313, issue#285)

### DIFF
--- a/rails/platform/app/controllers/journal_entries_controller.rb
+++ b/rails/platform/app/controllers/journal_entries_controller.rb
@@ -33,6 +33,12 @@ class JournalEntriesController < ApplicationController
     end
   end
 
+  def destroy
+    @entry = JournalEntry.for_client(@client_code).find(params[:id])
+    @entry.destroy!
+    redirect_to journal_entries_path(client_code: @client_code), notice: "仕訳を削除しました"
+  end
+
   def export
     entries = JournalEntry.for_client(@client_code)
     entries = entries.by_source(params[:source_type]) if params[:source_type].present?

--- a/rails/platform/app/controllers/statement_batches_controller.rb
+++ b/rails/platform/app/controllers/statement_batches_controller.rb
@@ -7,6 +7,15 @@ class StatementBatchesController < ApplicationController
     @sidebar_client = @client
   end
 
+  def destroy
+    @batch = StatementBatch.find(params[:id])
+    client_code = @batch.client&.code
+    je_count = @batch.journal_entries.count
+    @batch.destroy!
+    redirect_to journal_entries_path(client_code: client_code),
+                notice: "処理バッチを削除しました（仕訳 #{je_count} 件もあわせて削除）"
+  end
+
   private
 
   def record_not_found

--- a/rails/platform/app/controllers/statement_batches_controller.rb
+++ b/rails/platform/app/controllers/statement_batches_controller.rb
@@ -8,8 +8,8 @@ class StatementBatchesController < ApplicationController
   end
 
   def destroy
-    @batch = StatementBatch.find(params[:id])
-    client_code = @batch.client&.code
+    client_code = params[:client_code]
+    @batch = StatementBatch.for_client(client_code).find(params[:id])
     je_count = @batch.journal_entries.count
     @batch.destroy!
     redirect_to journal_entries_path(client_code: client_code),

--- a/rails/platform/app/javascript/controllers/double_confirm_controller.js
+++ b/rails/platform/app/javascript/controllers/double_confirm_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 削除など破壊的操作の前に2段階の confirm を挟む。
+// どちらかキャンセルされた時点で submit を中断する。
+//
+// 使い方:
+//   <%= button_to "削除", path, method: :delete,
+//       form: {
+//         data: {
+//           controller: "double-confirm",
+//           action: "submit->double-confirm#confirm",
+//           double_confirm_first_message_value: "削除してよろしいですか？",
+//           double_confirm_second_message_value: "本当に削除しますか？元に戻せません。"
+//         }
+//       } %>
+export default class extends Controller {
+  static values = {
+    firstMessage: { type: String, default: "削除してよろしいですか？" },
+    secondMessage: { type: String, default: "本当に削除しますか？元に戻せません。" }
+  }
+
+  confirm(event) {
+    if (window.confirm(this.firstMessageValue) && window.confirm(this.secondMessageValue)) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+  }
+}

--- a/rails/platform/app/models/statement_batch.rb
+++ b/rails/platform/app/models/statement_batch.rb
@@ -2,7 +2,7 @@ class StatementBatch < ApplicationRecord
   STATUSES = %w[processing completed failed duplicate].freeze
 
   belongs_to :client
-  has_many :journal_entries, dependent: :nullify
+  has_many :journal_entries, dependent: :destroy
   has_one_attached :pdf
 
   validates :source_type, presence: true, inclusion: { in: %w[amex bank invoice receipt] }

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -133,6 +133,19 @@
                 <% if entry.status == "review_required" %>
                   <%= link_to "編集", edit_journal_entry_path(entry, client_code: @client_code), class: "text-amber-500 hover:text-amber-400" %>
                 <% end %>
+                <%= button_to "削除",
+                      journal_entry_path(entry, client_code: @client_code),
+                      method: :delete,
+                      form: {
+                        class: "inline",
+                        data: {
+                          controller: "double-confirm",
+                          action: "submit->double-confirm#confirm",
+                          "double-confirm-first-message-value": "この仕訳を削除してよろしいですか？",
+                          "double-confirm-second-message-value": "本当に削除しますか？元に戻せません。"
+                        }
+                      },
+                      class: "text-red-400 hover:text-red-300 bg-transparent border-0 p-0 cursor-pointer" %>
               </td>
             </tr>
           <% end %>

--- a/rails/platform/app/views/journal_entries/show.html.erb
+++ b/rails/platform/app/views/journal_entries/show.html.erb
@@ -17,6 +17,20 @@
       <% else %>
         <%= render "shared/badge", label: "OK", variant: :success, size: :md %>
       <% end %>
+      <%= render "shared/button",
+            label: "削除",
+            variant: :danger,
+            size: :sm,
+            href: journal_entry_path(@entry, client_code: @client_code),
+            method: :delete,
+            form: {
+              data: {
+                controller: "double-confirm",
+                action: "submit->double-confirm#confirm",
+                "double-confirm-first-message-value": "この仕訳を削除してよろしいですか？",
+                "double-confirm-second-message-value": "本当に削除しますか？元に戻せません。"
+              }
+            } %>
     </div>
   </div>
 

--- a/rails/platform/app/views/shared/_button.html.erb
+++ b/rails/platform/app/views/shared/_button.html.erb
@@ -37,13 +37,13 @@
   base += " disabled:bg-gray-600 disabled:cursor-not-allowed" if disabled
   css = [base, variant_classes[variant], size_classes[size], local_assigns[:class]].compact.join(" ")
 %>
-<% if local_assigns[:href] %>
+<% if local_assigns[:method] %>
+  <%= button_to label, local_assigns[:href] || url_for, method: local_assigns[:method],
+        form: local_assigns[:form], class: css, data: local_assigns[:data] %>
+<% elsif local_assigns[:href] %>
   <%= link_to local_assigns[:href], class: css, data: local_assigns[:data] do %>
     <%= sanitize(local_assigns[:icon], tags: %w[svg path circle rect line polyline polygon g use defs clipPath], attributes: %w[viewBox d fill stroke stroke-width stroke-linecap stroke-linejoin class xmlns width height cx cy r x y x1 y1 x2 y2 points transform clip-path]) if local_assigns[:icon] %><%= label %>
   <% end %>
-<% elsif local_assigns[:method] %>
-  <%= button_to label, local_assigns[:href] || url_for, method: local_assigns[:method],
-        form: local_assigns[:form], class: css, data: local_assigns[:data] %>
 <% else %>
   <%= tag.button type: local_assigns.fetch(:type, "button"), class: css,
         disabled: disabled || nil, data: local_assigns[:data] do %>

--- a/rails/platform/app/views/statement_batches/show.html.erb
+++ b/rails/platform/app/views/statement_batches/show.html.erb
@@ -25,21 +25,24 @@
 
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold"><%= source_label %>処理状況</h1>
-    <% je_count = @batch.journal_entries.count %>
-    <%= render "shared/button",
-          label: "バッチごと削除",
-          variant: :danger,
-          size: :sm,
-          href: statement_batch_path(@batch),
-          method: :delete,
-          form: {
-            data: {
-              controller: "double-confirm",
-              action: "submit->double-confirm#confirm",
-              "double-confirm-first-message-value": "このバッチと関連する仕訳 #{je_count} 件を削除します。よろしいですか？",
-              "double-confirm-second-message-value": "本当に削除しますか？元に戻せません。"
-            }
-          } %>
+    <%# 処理中は非同期ジョブとの削除レースを避けるため削除ボタンを表示しない %>
+    <% unless @batch.status == "processing" %>
+      <% je_count = @batch.journal_entries.count %>
+      <%= render "shared/button",
+            label: "バッチごと削除",
+            variant: :danger,
+            size: :sm,
+            href: statement_batch_path(@batch, client_code: @client.code),
+            method: :delete,
+            form: {
+              data: {
+                controller: "double-confirm",
+                action: "submit->double-confirm#confirm",
+                "double-confirm-first-message-value": "このバッチと関連する仕訳 #{je_count} 件を削除します。よろしいですか？",
+                "double-confirm-second-message-value": "本当に削除しますか？元に戻せません。"
+              }
+            } %>
+    <% end %>
   </div>
 
   <%# ローディング（処理中のみ表示） %>

--- a/rails/platform/app/views/statement_batches/show.html.erb
+++ b/rails/platform/app/views/statement_batches/show.html.erb
@@ -23,7 +23,24 @@
      data-batch-progress-status-url-value="<%= status_url %>"
      data-batch-progress-status-value="<%= @batch.status %>">
 
-  <h1 class="text-2xl font-bold mb-6"><%= source_label %>処理状況</h1>
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold"><%= source_label %>処理状況</h1>
+    <% je_count = @batch.journal_entries.count %>
+    <%= render "shared/button",
+          label: "バッチごと削除",
+          variant: :danger,
+          size: :sm,
+          href: statement_batch_path(@batch),
+          method: :delete,
+          form: {
+            data: {
+              controller: "double-confirm",
+              action: "submit->double-confirm#confirm",
+              "double-confirm-first-message-value": "このバッチと関連する仕訳 #{je_count} 件を削除します。よろしいですか？",
+              "double-confirm-second-message-value": "本当に削除しますか？元に戻せません。"
+            }
+          } %>
+  </div>
 
   <%# ローディング（処理中のみ表示） %>
   <div data-batch-progress-target="loading" class="<%= @batch.status == 'processing' ? '' : 'hidden' %> mt-8 text-center">

--- a/rails/platform/config/routes.rb
+++ b/rails/platform/config/routes.rb
@@ -83,8 +83,8 @@ Rails.application.routes.draw do
   resources :amex_statements, only: [ :new ]
   resources :bank_statements, only: [ :new ]
   resources :invoices, only: [ :new ]
-  resources :statement_batches, only: [ :show ]
-  resources :journal_entries, only: [ :index, :show, :edit, :update ] do
+  resources :statement_batches, only: [ :show, :destroy ]
+  resources :journal_entries, only: [ :index, :show, :edit, :update, :destroy ] do
     collection do
       get :export
     end

--- a/rails/platform/spec/models/statement_batch_spec.rb
+++ b/rails/platform/spec/models/statement_batch_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe StatementBatch, type: :model do
       expect(batch.journal_entries).to contain_exactly(entry)
     end
 
-    it "削除時にjournal_entriesのstatement_batch_idがnullになる" do
+    it "削除時に紐づく journal_entries と journal_entry_lines も一緒に削除される (dependent: :destroy)" do
       batch = create(:statement_batch)
-      entry = create(:journal_entry, client: batch.client, statement_batch: batch)
+      create(:journal_entry, client: batch.client, statement_batch: batch,
+             debit_amount: 1000, credit_amount: 1000)
 
-      batch.destroy
-
-      entry.reload
-      expect(entry.statement_batch_id).to be_nil
+      expect { batch.destroy }
+        .to change(JournalEntry, :count).by(-1)
+        .and change(JournalEntryLine, :count).by(-2)
     end
   end
 

--- a/rails/platform/spec/requests/web/journal_entries_spec.rb
+++ b/rails/platform/spec/requests/web/journal_entries_spec.rb
@@ -238,4 +238,42 @@ RSpec.describe "Web::JournalEntries", type: :request do
       end
     end
   end
+
+  describe "DELETE /journal_entries/:id" do
+    let!(:entry) { create(:journal_entry, client: client, debit_amount: 1000, credit_amount: 1000) }
+
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        delete journal_entry_path(entry, client_code: client.code)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "仕訳と関連 journal_entry_lines が削除されること" do
+        expect {
+          delete journal_entry_path(entry, client_code: client.code)
+        }.to change(JournalEntry, :count).by(-1)
+         .and change(JournalEntryLine, :count).by(-2)
+      end
+
+      it "削除後は仕訳一覧にリダイレクトすること" do
+        delete journal_entry_path(entry, client_code: client.code)
+        expect(response).to redirect_to(journal_entries_path(client_code: client.code))
+        expect(flash[:notice]).to include("削除")
+      end
+
+      it "他テナントの仕訳は削除できないこと" do
+        other_client = create(:client, code: "other_client")
+        other_entry = create(:journal_entry, client: other_client, debit_amount: 1000, credit_amount: 1000)
+
+        expect {
+          delete journal_entry_path(other_entry, client_code: client.code)
+        }.not_to change(JournalEntry, :count)
+        expect(response).to redirect_to(clients_path)
+      end
+    end
+  end
 end

--- a/rails/platform/spec/requests/web/statement_batches_spec.rb
+++ b/rails/platform/spec/requests/web/statement_batches_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Web::StatementBatches", type: :request do
 
     context "未認証の場合" do
       it "ログイン画面にリダイレクトすること" do
-        delete statement_batch_path(batch)
+        delete statement_batch_path(batch, client_code: client.code)
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -23,14 +23,14 @@ RSpec.describe "Web::StatementBatches", type: :request do
 
       it "バッチ・紐づく仕訳・仕訳行をまとめて削除すること (dependent: :destroy)" do
         expect {
-          delete statement_batch_path(batch)
+          delete statement_batch_path(batch, client_code: client.code)
         }.to change(StatementBatch, :count).by(-1)
          .and change(JournalEntry, :count).by(-1)
          .and change(JournalEntryLine, :count).by(-2)
       end
 
       it "削除後は仕訳一覧にリダイレクトすること" do
-        delete statement_batch_path(batch)
+        delete statement_batch_path(batch, client_code: client.code)
         expect(response).to redirect_to(journal_entries_path(client_code: client.code))
         expect(flash[:notice]).to include("削除")
       end
@@ -42,9 +42,36 @@ RSpec.describe "Web::StatementBatches", type: :request do
                debit_amount: 3000, credit_amount: 3000)
 
         expect {
-          delete statement_batch_path(batch)
+          delete statement_batch_path(batch, client_code: client.code)
         }.to change(JournalEntry, :count).by(-3)
          .and change(JournalEntryLine, :count).by(-6)
+      end
+
+      it "別テナントの client_code では削除できないこと" do
+        other_client = create(:client, code: "other_client")
+
+        expect {
+          delete statement_batch_path(batch, client_code: other_client.code)
+        }.not_to change(StatementBatch, :count)
+        expect(response).to redirect_to(clients_path)
+      end
+    end
+  end
+
+  describe "GET /statement_batches/:id" do
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "処理中(processing)は削除ボタンを表示しないこと（非同期ジョブとの削除レース防止）" do
+        batch = create(:statement_batch, :processing, client: client)
+        get statement_batch_path(batch)
+        expect(response.body).not_to include("バッチごと削除")
+      end
+
+      it "処理完了(completed)は削除ボタンを表示すること" do
+        batch = create(:statement_batch, :completed, client: client)
+        get statement_batch_path(batch)
+        expect(response.body).to include("バッチごと削除")
       end
     end
   end

--- a/rails/platform/spec/requests/web/statement_batches_spec.rb
+++ b/rails/platform/spec/requests/web/statement_batches_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Web::StatementBatches", type: :request do
+  let(:user) { create(:user) }
+  let(:client) { create(:client, code: "test_client", name: "テスト社") }
+
+  describe "DELETE /statement_batches/:id" do
+    let(:batch) { create(:statement_batch, client: client) }
+    let!(:entry) do
+      create(:journal_entry, client: client, statement_batch: batch,
+             debit_amount: 1000, credit_amount: 1000)
+    end
+
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        delete statement_batch_path(batch)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "バッチ・紐づく仕訳・仕訳行をまとめて削除すること (dependent: :destroy)" do
+        expect {
+          delete statement_batch_path(batch)
+        }.to change(StatementBatch, :count).by(-1)
+         .and change(JournalEntry, :count).by(-1)
+         .and change(JournalEntryLine, :count).by(-2)
+      end
+
+      it "削除後は仕訳一覧にリダイレクトすること" do
+        delete statement_batch_path(batch)
+        expect(response).to redirect_to(journal_entries_path(client_code: client.code))
+        expect(flash[:notice]).to include("削除")
+      end
+
+      it "紐づく仕訳が複数あっても全部削除すること" do
+        create(:journal_entry, client: client, statement_batch: batch,
+               debit_amount: 2000, credit_amount: 2000)
+        create(:journal_entry, client: client, statement_batch: batch,
+               debit_amount: 3000, credit_amount: 3000)
+
+        expect {
+          delete statement_batch_path(batch)
+        }.to change(JournalEntry, :count).by(-3)
+         .and change(JournalEntryLine, :count).by(-6)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **仕訳1件削除** / **バッチ単位削除** の両方を実装（Web版）
- **二重confirm** で誤削除防止（Stimulus `double_confirm_controller`）
- StatementBatch の `has_many :journal_entries` を `dependent: :nullify` → `:destroy` に変更し、**issue#285 の孤児化問題を解決**
- `shared/_button.html.erb` partial の `href + method` 同時指定バグも修正（partialが link_to を返してしまっていた → 修正後は button_to を返す）

## Test plan

- [x] `make test ARGS="spec/models/statement_batch_spec.rb spec/models/journal_entry_spec.rb spec/requests/web/journal_entries_spec.rb spec/requests/web/statement_batches_spec.rb"` パス (82 examples, 0 failures)
- [x] `make test` 全体パス (610 examples, 0 failures)
- [x] **DELETE /journal_entries/:id**: 開発環境UIで仕訳1件削除 → DB上で JE -1, JEL -2、flash「仕訳を削除しました」表示
- [x] **DELETE /statement_batches/:id**: SB削除 → 紐づくJE 2件・JEL 4件 もcascadeで削除、flash「処理バッチを削除しました（仕訳 N 件もあわせて削除）」表示 (**issue#285解決確認**)
- [x] **マルチテナント分離**: 他テナントのJE id を verify_test の client_code で参照すると、rescue_from → 「仕訳が見つかりません」表示 + clients_path リダイレクト、削除されない
- [x] UI: 削除ボタンHTMLに `data-controller="double-confirm"` / `data-action="submit->double-confirm#confirm"` / first/second-message-value 正しく付与
- [x] Stimulus controller (double_confirm_controller.js): importmap.rb の `pin_all_from "app/javascript/controllers"` で自動pin、HTMLからロードされる

## verifyで発見したバグと修正

verify中に `shared/_button.html.erb` partial の判定順バグを発見：

- 旧: `if href then link_to elsif method then button_to`
- 問題: `href + method` 同時指定時に link_to が優先され、削除ボタンが `<a href>` になり button_to で生成されるべき form が出ない
- 修正: `if method then button_to elsif href then link_to`（method優先）
- 影響範囲調査: 既存の `shared/button` 使用箇所は全て `href`のみ / `method`のみ / `type:`のみ で `href + method` の組み合わせは今回の削除ボタン追加が初。回帰なし

## 設計判断

- バッチ単位削除では JE/JEL を cascade で削除（issue#285 で議論された A案: cascade削除）
- 二重confirm: 1段目「削除してよろしいですか？」→ 2段目「本当に削除しますか？元に戻せません。」
- バッチ削除のメッセージは仕訳件数を含む（例: 「このバッチと関連する仕訳 2 件を削除します。よろしいですか？」）

Closes #313
Closes #285

## 関連

- ADR 0009-B（仕訳台帳: 削除機能）
- 後続: #314 編集履歴（リビジョン保存方式の設計判断は別途）