### PR TITLE
fix(platform): 取込時のupload失敗でStatementBatchがprocessing孤児として残るロックを解消 (issue#302)

### DIFF
--- a/rails/platform/app/controllers/api/v1/amex_statements_controller.rb
+++ b/rails/platform/app/controllers/api/v1/amex_statements_controller.rb
@@ -31,20 +31,18 @@ module Api
           end
         end
 
-        batch = @current_client.statement_batches.new(
+        batch = StatementBatch.ingest!(
+          client: @current_client,
           source_type: "amex",
-          status: "processing",
-          pdf_fingerprint: fingerprint
+          fingerprint: fingerprint,
+          attachable: pdf
         )
 
-        batch.pdf.attach(pdf)
-
-        if batch.save
-          AmexStatementProcessJob.perform_later(batch.id)
-          render json: { id: batch.id, status: "processing" }, status: :accepted
-        else
-          render_error(batch.errors.full_messages.join(", "))
-        end
+        AmexStatementProcessJob.perform_later(batch.id)
+        render json: { id: batch.id, status: "processing" }, status: :accepted
+      rescue StatementBatch::IngestError => e
+        Rails.logger.error("[AmexStatementsController] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
+        render_error("ファイルの保存に失敗しました。もう一度お試しください。")
       end
 
       def status

--- a/rails/platform/app/controllers/api/v1/amex_statements_controller.rb
+++ b/rails/platform/app/controllers/api/v1/amex_statements_controller.rb
@@ -40,9 +40,6 @@ module Api
 
         AmexStatementProcessJob.perform_later(batch.id)
         render json: { id: batch.id, status: "processing" }, status: :accepted
-      rescue StatementBatch::IngestError => e
-        Rails.logger.error("[AmexStatementsController] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
-        render_error("ファイルの保存に失敗しました。もう一度お試しください。")
       end
 
       def status

--- a/rails/platform/app/controllers/api/v1/bank_statements_controller.rb
+++ b/rails/platform/app/controllers/api/v1/bank_statements_controller.rb
@@ -31,20 +31,18 @@ module Api
           end
         end
 
-        batch = @current_client.statement_batches.new(
+        batch = StatementBatch.ingest!(
+          client: @current_client,
           source_type: "bank",
-          status: "processing",
-          pdf_fingerprint: fingerprint
+          fingerprint: fingerprint,
+          attachable: pdf
         )
 
-        batch.pdf.attach(pdf)
-
-        if batch.save
-          BankStatementProcessJob.perform_later(batch.id)
-          render json: { id: batch.id, status: "processing" }, status: :accepted
-        else
-          render_error(batch.errors.full_messages.join(", "))
-        end
+        BankStatementProcessJob.perform_later(batch.id)
+        render json: { id: batch.id, status: "processing" }, status: :accepted
+      rescue StatementBatch::IngestError => e
+        Rails.logger.error("[BankStatementsController] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
+        render_error("ファイルの保存に失敗しました。もう一度お試しください。")
       end
 
       def status

--- a/rails/platform/app/controllers/api/v1/bank_statements_controller.rb
+++ b/rails/platform/app/controllers/api/v1/bank_statements_controller.rb
@@ -40,9 +40,6 @@ module Api
 
         BankStatementProcessJob.perform_later(batch.id)
         render json: { id: batch.id, status: "processing" }, status: :accepted
-      rescue StatementBatch::IngestError => e
-        Rails.logger.error("[BankStatementsController] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
-        render_error("ファイルの保存に失敗しました。もう一度お試しください。")
       end
 
       def status

--- a/rails/platform/app/controllers/api/v1/base_controller.rb
+++ b/rails/platform/app/controllers/api/v1/base_controller.rb
@@ -4,6 +4,12 @@ module Api
       before_action :authenticate_request!
       before_action :set_current_client
 
+      # ファイルの upload/attach 失敗（StatementBatch.ingest!）は全経路でここに集約して返す。
+      rescue_from StatementBatch::IngestError do |e|
+        Rails.logger.error("[#{controller_name}] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
+        render_error("ファイルの保存に失敗しました。もう一度お試しください。")
+      end
+
       private
 
       def authenticate_request!

--- a/rails/platform/app/controllers/api/v1/invoices_controller.rb
+++ b/rails/platform/app/controllers/api/v1/invoices_controller.rb
@@ -31,20 +31,18 @@ module Api
           end
         end
 
-        batch = @current_client.statement_batches.new(
+        batch = StatementBatch.ingest!(
+          client: @current_client,
           source_type: "invoice",
-          status: "processing",
-          pdf_fingerprint: fingerprint
+          fingerprint: fingerprint,
+          attachable: pdf
         )
 
-        batch.pdf.attach(pdf)
-
-        if batch.save
-          InvoiceProcessJob.perform_later(batch.id)
-          render json: { id: batch.id, status: "processing" }, status: :accepted
-        else
-          render_error(batch.errors.full_messages.join(", "))
-        end
+        InvoiceProcessJob.perform_later(batch.id)
+        render json: { id: batch.id, status: "processing" }, status: :accepted
+      rescue StatementBatch::IngestError => e
+        Rails.logger.error("[InvoicesController] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
+        render_error("ファイルの保存に失敗しました。もう一度お試しください。")
       end
 
       def status

--- a/rails/platform/app/controllers/api/v1/invoices_controller.rb
+++ b/rails/platform/app/controllers/api/v1/invoices_controller.rb
@@ -40,9 +40,6 @@ module Api
 
         InvoiceProcessJob.perform_later(batch.id)
         render json: { id: batch.id, status: "processing" }, status: :accepted
-      rescue StatementBatch::IngestError => e
-        Rails.logger.error("[InvoicesController] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
-        render_error("ファイルの保存に失敗しました。もう一度お試しください。")
       end
 
       def status

--- a/rails/platform/app/jobs/receipt_line_process_job.rb
+++ b/rails/platform/app/jobs/receipt_line_process_job.rb
@@ -41,17 +41,26 @@ class ReceiptLineProcessJob < ApplicationJob
       return
     end
 
-    batch = client.statement_batches.create!(
-      source_type: "receipt",
-      status: "processing",
-      pdf_fingerprint: fingerprint
-    )
-
-    batch.pdf.attach(
-      io: StringIO.new(image_binary),
-      filename: "receipt_#{message_id}.jpg",
-      content_type: detect_content_type(image_binary)
-    )
+    # 取り込みは共有ヘルパに委譲する。upload は after_commit で走るため、失敗時は
+    # コミット済みの processing 孤児が残りうる。ヘルパが孤児を failed 化して IngestError を
+    # 投げるので、ここでは LINE 通知して終了する (issue#302)。
+    batch =
+      begin
+        StatementBatch.ingest!(
+          client: client,
+          source_type: "receipt",
+          fingerprint: fingerprint,
+          attachable: {
+            io: StringIO.new(image_binary),
+            filename: "receipt_#{message_id}.jpg",
+            content_type: detect_content_type(image_binary)
+          }
+        )
+      rescue StatementBatch::IngestError => e
+        Rails.logger.error("[ReceiptLineProcessJob] ingest failed: #{e.cause_error.class}: #{e.cause_error.message}")
+        @line_service.push(line_user_id, "画像の保存に失敗しました。もう一度お試しください。")
+        return
+      end
 
     @line_service.push(line_user_id, "領収書を受け付けました。処理中です...")
 

--- a/rails/platform/app/models/statement_batch.rb
+++ b/rails/platform/app/models/statement_batch.rb
@@ -1,6 +1,16 @@
 class StatementBatch < ApplicationRecord
   STATUSES = %w[processing completed failed duplicate].freeze
 
+  # 取り込み（new → attach → save）が失敗したときに raise する。cause_error に元例外を保持する。
+  class IngestError < StandardError
+    attr_reader :cause_error
+
+    def initialize(message, cause_error:)
+      super(message)
+      @cause_error = cause_error
+    end
+  end
+
   belongs_to :client
   has_many :journal_entries, dependent: :destroy
   has_one_attached :pdf
@@ -10,4 +20,34 @@ class StatementBatch < ApplicationRecord
 
   scope :for_client, ->(code) { where(client: Client.where(code: code)) }
   scope :recent, -> { order(created_at: :desc) }
+
+  # 全取り込み経路（receipt-LINE / invoice / amex / bank）共通の取り込みヘルパ。
+  #
+  # ActiveStorage は実ファイルの upload を after_commit で行う（activestorage model.rb:144）。
+  # そのため new → attach → save! でも、upload が ENOSPC/EACCES 等で失敗したときには
+  # batch 行が status=processing で「先にコミット済み」になり、ファイル不在の孤児が残る。
+  # 再送するとその processing 孤児が dedup にヒットして空ファイルを読み続けるロックになる (issue#302)。
+  #
+  # ここで save 失敗を捕捉し、コミット済みの孤児を failed に確定する。failed は receipt の
+  # dedup(processing/completed/duplicate) にも invoice 系(processing/completed) にも含まれないため、
+  # 再送で新しい batch が立ちロックしない。
+  #
+  # 成功: 永続化済みの batch を返す / 失敗: 孤児を failed 化したうえで IngestError を raise する。
+  # attachable は ActiveStorage の attach が受け付ける形（Hash{io:,filename:,content_type:} か UploadedFile）。
+  def self.ingest!(client:, source_type:, fingerprint:, attachable:)
+    batch = client.statement_batches.new(
+      source_type: source_type,
+      status: "processing",
+      pdf_fingerprint: fingerprint
+    )
+    batch.pdf.attach(attachable)
+    batch.save!
+    batch
+  rescue => e
+    if batch&.persisted?
+      batch.update_columns(status: "failed", error_message: "取り込み失敗: #{e.message.presence || e.class}")
+      batch.pdf.purge rescue nil
+    end
+    raise IngestError.new("取り込みに失敗しました", cause_error: e)
+  end
 end

--- a/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
@@ -193,6 +193,35 @@ RSpec.describe ReceiptLineProcessJob, type: :job do
       end
     end
 
+    context "取り込み失敗 (issue#302)" do
+      # 取り込みの堅牢化（孤児を残さない等）は StatementBatch.ingest! 側で検証する。
+      # ここでは ingest! が IngestError を投げた時のジョブの振る舞いだけを見る。
+      before do
+        allow(ReceiptProcessorService).to receive(:new)
+        allow(StatementBatch).to receive(:ingest!).and_raise(
+          StatementBatch::IngestError.new(
+            "取り込みに失敗しました",
+            cause_error: Errno::ENOSPC.new("No space left on device")
+          )
+        )
+      end
+
+      it "保存失敗メッセージをLINEで送信すること" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).to have_received(:push).with(
+          line_user_id,
+          "画像の保存に失敗しました。もう一度お試しください。"
+        )
+      end
+
+      it "処理に進まないこと（ReceiptProcessorService を呼ばない）" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(ReceiptProcessorService).not_to have_received(:new)
+      end
+    end
+
     context "重複画像" do
       before do
         create(:statement_batch, :completed, client: client, source_type: "receipt", pdf_fingerprint: fingerprint)

--- a/rails/platform/spec/models/statement_batch_spec.rb
+++ b/rails/platform/spec/models/statement_batch_spec.rb
@@ -105,4 +105,63 @@ RSpec.describe StatementBatch, type: :model do
       expect(described_class.for_client("client_b").count).to eq(1)
     end
   end
+
+  describe ".ingest! (issue#302)" do
+    let(:client) { create(:client) }
+    let(:attachable) do
+      { io: StringIO.new("\xFF\xD8\xFFreceipt_image".b), filename: "r.jpg", content_type: "image/jpeg" }
+    end
+
+    context "成功時" do
+      it "永続化済みの processing バッチを返し、pdf が添付される" do
+        batch = described_class.ingest!(
+          client: client, source_type: "receipt", fingerprint: "fp_ok", attachable: attachable
+        )
+
+        expect(batch).to be_persisted
+        expect(batch.status).to eq("processing")
+        expect(batch.source_type).to eq("receipt")
+        expect(batch.pdf_fingerprint).to eq("fp_ok")
+        expect(batch.pdf).to be_attached
+      end
+    end
+
+    # ActiveStorage は実 upload を after_commit で行うため、upload 失敗時には
+    # batch 行が先に processing でコミットされる。その孤児を残さないことを検証する。
+    context "after_commit の upload が失敗する時" do
+      before do
+        allow_any_instance_of(ActiveStorage::Blob)
+          .to receive(:upload_without_unfurling).and_raise(Errno::ENOSPC, "No space left on device")
+      end
+
+      it "IngestError を raise し、元例外を cause_error に保持する" do
+        expect {
+          described_class.ingest!(client: client, source_type: "receipt", fingerprint: "fp_ng", attachable: attachable)
+        }.to raise_error(StatementBatch::IngestError) { |e| expect(e.cause_error).to be_a(Errno::ENOSPC) }
+      end
+
+      it "processing のままロックされる孤児バッチを残さない" do
+        expect {
+          begin
+            described_class.ingest!(client: client, source_type: "receipt", fingerprint: "fp_ng", attachable: attachable)
+          rescue StatementBatch::IngestError
+            nil
+          end
+        }.not_to change { described_class.where(status: "processing").count }
+      end
+
+      it "コミット済みのバッチを failed に確定する（dedup から外れ再送ロックしない）" do
+        begin
+          described_class.ingest!(client: client, source_type: "receipt", fingerprint: "fp_ng", attachable: attachable)
+        rescue StatementBatch::IngestError
+          nil
+        end
+
+        batch = described_class.where(client: client, pdf_fingerprint: "fp_ng").first
+        expect(batch).to be_present
+        expect(batch.status).to eq("failed")
+        expect(batch.error_message).to include("取り込み失敗")
+      end
+    end
+  end
 end

--- a/rails/platform/spec/models/statement_batch_spec.rb
+++ b/rails/platform/spec/models/statement_batch_spec.rb
@@ -163,5 +163,28 @@ RSpec.describe StatementBatch, type: :model do
         expect(batch.error_message).to include("取り込み失敗")
       end
     end
+
+    # issue#302 の核心保証: 取り込み失敗で残った failed 孤児が、再送時に dedup へ
+    # 再ヒットしてロックすることがないこと。
+    context "失敗後の再送（回帰防止）" do
+      it "failed 孤児は dedup に含まれず、同一 fingerprint の再取り込みが新しい processing バッチで成功する" do
+        # 取り込み失敗で残る failed 孤児を模す（failed になること自体は上の context で実証済み）
+        create(:statement_batch, :failed, client: client, source_type: "receipt", pdf_fingerprint: "fp_retry")
+
+        # 呼び出し側の dedup（receipt: processing/completed/duplicate）が failed 孤児にヒットしない
+        dedup_hit = described_class
+          .where(client: client, pdf_fingerprint: "fp_retry", status: %w[processing completed duplicate])
+          .exists?
+        expect(dedup_hit).to be(false)
+
+        # 再取り込みが成功し、新しい processing バッチが立つ（ロックしない）
+        batch = described_class.ingest!(
+          client: client, source_type: "receipt", fingerprint: "fp_retry", attachable: attachable
+        )
+        expect(batch).to be_persisted
+        expect(batch.status).to eq("processing")
+        expect(described_class.where(client: client, pdf_fingerprint: "fp_retry").count).to eq(2)
+      end
+    end
   end
 end

--- a/rails/platform/spec/requests/api/v1/invoices_spec.rb
+++ b/rails/platform/spec/requests/api/v1/invoices_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe "Api::V1::Invoices", type: :request do
       expect(response).to have_http_status(:not_found)
     end
 
+    context "取り込み失敗 (issue#302)" do
+      it "ingest! が IngestError を投げた場合、BaseController の rescue_from で422を返すこと" do
+        allow(StatementBatch).to receive(:ingest!).and_raise(
+          StatementBatch::IngestError.new("取り込みに失敗しました", cause_error: Errno::ENOSPC.new("No space left on device"))
+        )
+
+        post "/api/v1/invoices/process_statement", params: valid_params, headers: authorization_header
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to include("保存に失敗")
+        expect(InvoiceProcessJob).not_to have_received(:perform_later)
+      end
+    end
+
     context "重複PDF検知" do
       it "同一PDFが処理済みの場合409を返すこと" do
         pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))


### PR DESCRIPTION
## 概要

ActiveStorage は実ファイルの upload を after_commit で行うため、取り込み（new→attach→save）で
upload が ENOSPC 等で失敗すると、StatementBatch が status=processing・ファイル不在の孤児として
残り、再送時に dedup へ再ヒットして空ファイルを読み続ける永久ロックになっていた。invoice/amex/bank
の Web 経路にも同じ潜在バグがあった。

取り込みを共有ヘルパ `StatementBatch.ingest!` に集約し、save 失敗時はコミット済みの孤児を failed に
確定（dedup から外れ再送ロックしない）したうえで `IngestError` を raise する形に統一。
receipt(LINE)/invoice/amex/bank の4経路を差し替えた。実 upload を失敗させて孤児が残らないことを
モデル spec で検証（#303 方針準拠）。

Closes #302
