### PR TITLE
fix(platform): ストレージ系エラーを:storage_errorで非リトライ分類しメッセージのクラス名漏れを修正 (issue#299)

### DIFF
--- a/rails/platform/app/jobs/receipt_line_process_job.rb
+++ b/rails/platform/app/jobs/receipt_line_process_job.rb
@@ -100,6 +100,8 @@ class ReceiptLineProcessJob < ApplicationJob
         "領収書またはレシートの画像を送信してください。"
       when :file_not_found
         "画像ファイルの読み込みに失敗しました。もう一度送信してください。"
+      when :storage_error
+        "サーバー側で画像を読み込めませんでした。時間をおいて再度お試しください。"
       else
         "処理中にエラーが発生しました。もう一度お試しください。"
       end

--- a/rails/platform/app/services/amex_statement_processor_service.rb
+++ b/rails/platform/app/services/amex_statement_processor_service.rb
@@ -1,7 +1,9 @@
 require "combine_pdf"
 
 class AmexStatementProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
+  include StorageErrorHandling
+
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found storage_error].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -174,8 +176,10 @@ class AmexStatementProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
-  rescue ActiveStorage::FileNotFoundError => e
-    Result.new(success: false, data: {}, error: "PDFファイルが見つかりません: #{e.message}", reason: :file_not_found)
+  rescue ActiveStorage::FileNotFoundError
+    Result.new(success: false, data: {}, error: file_not_found_message("PDFファイル"), reason: :file_not_found)
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+    Result.new(success: false, data: {}, error: storage_system_error_message("PDFファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/bank_statement_processor_service.rb
+++ b/rails/platform/app/services/bank_statement_processor_service.rb
@@ -1,7 +1,9 @@
 require "combine_pdf"
 
 class BankStatementProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
+  include StorageErrorHandling
+
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found storage_error].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -179,8 +181,10 @@ class BankStatementProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
-  rescue ActiveStorage::FileNotFoundError => e
-    Result.new(success: false, data: {}, error: "PDFファイルが見つかりません: #{e.message}", reason: :file_not_found)
+  rescue ActiveStorage::FileNotFoundError
+    Result.new(success: false, data: {}, error: file_not_found_message("PDFファイル"), reason: :file_not_found)
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+    Result.new(success: false, data: {}, error: storage_system_error_message("PDFファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/cleaning_manual_generator_service.rb
+++ b/rails/platform/app/services/cleaning_manual_generator_service.rb
@@ -1,7 +1,9 @@
 require "image_processing/vips"
 
 class CleaningManualGeneratorService
-  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
+  include StorageErrorHandling
+
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found storage_error].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -87,8 +89,10 @@ class CleaningManualGeneratorService
       return merged unless merged.success?
       Result.new(success: true, data: merged.data, error: nil, reason: nil)
     end
-  rescue ActiveStorage::FileNotFoundError => e
-    Result.new(success: false, data: {}, error: "画像ファイルが見つかりません: #{e.message}", reason: :file_not_found)
+  rescue ActiveStorage::FileNotFoundError
+    Result.new(success: false, data: {}, error: file_not_found_message("画像ファイル"), reason: :file_not_found)
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+    Result.new(success: false, data: {}, error: storage_system_error_message("画像ファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/invoice_processor_service.rb
+++ b/rails/platform/app/services/invoice_processor_service.rb
@@ -1,7 +1,9 @@
 require "combine_pdf"
 
 class InvoiceProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error file_not_found].freeze
+  include StorageErrorHandling
+
+  NON_RETRYABLE_REASONS = %i[config_error file_not_found storage_error].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -179,8 +181,10 @@ class InvoiceProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
-  rescue ActiveStorage::FileNotFoundError => e
-    Result.new(success: false, data: {}, error: "PDFファイルが見つかりません: #{e.message}", reason: :file_not_found)
+  rescue ActiveStorage::FileNotFoundError
+    Result.new(success: false, data: {}, error: file_not_found_message("PDFファイル"), reason: :file_not_found)
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+    Result.new(success: false, data: {}, error: storage_system_error_message("PDFファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/receipt_processor_service.rb
+++ b/rails/platform/app/services/receipt_processor_service.rb
@@ -1,5 +1,7 @@
 class ReceiptProcessorService
-  NON_RETRYABLE_REASONS = %i[config_error non_receipt unsupported_format file_not_found].freeze
+  include StorageErrorHandling
+
+  NON_RETRYABLE_REASONS = %i[config_error non_receipt unsupported_format file_not_found storage_error].freeze
 
   Result = Data.define(:success, :data, :error, :reason) do
     alias_method :success?, :success
@@ -180,8 +182,10 @@ class ReceiptProcessorService
     end
 
     Result.new(success: true, data: data, error: nil, reason: nil)
-  rescue ActiveStorage::FileNotFoundError => e
-    Result.new(success: false, data: {}, error: "画像ファイルが見つかりません: #{e.message}", reason: :file_not_found)
+  rescue ActiveStorage::FileNotFoundError
+    Result.new(success: false, data: {}, error: file_not_found_message("画像ファイル"), reason: :file_not_found)
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+    Result.new(success: false, data: {}, error: storage_system_error_message("画像ファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)
   rescue JSON::ParserError => e

--- a/rails/platform/app/services/storage_error_handling.rb
+++ b/rails/platform/app/services/storage_error_handling.rb
@@ -1,0 +1,23 @@
+# download(読み取り)時のストレージ系エラーを全 *ProcessorService / generator で
+# 一貫して分類・メッセージ化するための共有ポリシー (issue#299)。
+#
+# 本番は ActiveStorage Disk service + worker/platform 間の共有ボリューム(issue#297)のため、
+# 権限ミス・ディスクフル・読取専用化が現実的に起きうる。これらはリトライしても回復しないので
+# 非リトライ(:storage_error)として扱い、ユーザーにはクラス名を漏らさない固定文言を返す。
+module StorageErrorHandling
+  # ホスト側ストレージの読み取りで起きうるシステムコールエラー。
+  STORAGE_SYSTEM_ERRORS = [Errno::EACCES, Errno::ENOSPC, Errno::EROFS].freeze
+
+  private
+
+  # 引数なしで raise される ActiveStorage::FileNotFoundError は e.message が
+  # クラス名("ActiveStorage::FileNotFoundError")になり、UI/DB にそのまま漏れる。
+  # クラス名を出さない固定文言を返す。kind は "PDFファイル" / "画像ファイル" 等。
+  def file_not_found_message(kind)
+    "#{kind}が見つかりません。もう一度アップロードしてください。"
+  end
+
+  def storage_system_error_message(kind)
+    "#{kind}をサーバー側で読み込めませんでした。時間をおいて再度お試しください。"
+  end
+end

--- a/rails/platform/app/services/storage_error_handling.rb
+++ b/rails/platform/app/services/storage_error_handling.rb
@@ -5,8 +5,18 @@
 # 権限ミス・ディスクフル・読取専用化が現実的に起きうる。これらはリトライしても回復しないので
 # 非リトライ(:storage_error)として扱い、ユーザーにはクラス名を漏らさない固定文言を返す。
 module StorageErrorHandling
-  # ホスト側ストレージの読み取りで起きうるシステムコールエラー。
-  STORAGE_SYSTEM_ERRORS = [Errno::EACCES, Errno::ENOSPC, Errno::EROFS].freeze
+  # ホスト側ストレージの読み取りで起きうるシステムコールエラー。いずれもリトライで回復しない。
+  # ActiveStorage 経由の不在は FileNotFoundError で別途扱うが、生ファイル読み取り
+  # (File.binread / vips の tempfile 経路) では ENOENT/EIO が直接上がるため含める。
+  # 注意: 一律 SystemCallError で握ると EAGAIN/EINTR 等の一時的エラーまで非リトライ化して
+  # しまうため、非リトライが妥当なものだけを明示列挙する。
+  STORAGE_SYSTEM_ERRORS = [
+    Errno::EACCES,  # 権限なし
+    Errno::ENOSPC,  # ディスクフル
+    Errno::EROFS,   # 読み取り専用FS
+    Errno::ENOENT,  # ファイル/パスが存在しない
+    Errno::EIO      # 入出力エラー（ディスク障害等）
+  ].freeze
 
   private
 

--- a/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
+++ b/rails/platform/spec/jobs/receipt_line_process_job_spec.rb
@@ -293,6 +293,38 @@ RSpec.describe ReceiptLineProcessJob, type: :job do
       end
     end
 
+    context "storage_error (issue#299)" do
+      let(:storage_error_result) do
+        ReceiptProcessorService::Result.new(
+          success: false, data: {}, error: "画像ファイルをサーバー側で読み込めませんでした。時間をおいて再度お試しください。", reason: :storage_error
+        )
+      end
+
+      before do
+        allow(ReceiptProcessorService).to receive(:new).and_return(
+          instance_double(ReceiptProcessorService, call: storage_error_result)
+        )
+      end
+
+      it "ストレージ専用メッセージをLINEで送信すること" do
+        described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+
+        expect(line_service).to have_received(:push).with(
+          line_user_id,
+          "サーバー側で画像を読み込めませんでした。時間をおいて再度お試しください。"
+        )
+      end
+
+      it "リトライせずStatementBatchをfailedにすること" do
+        expect {
+          described_class.new.perform(client_id: client.id, message_id: message_id, line_user_id: line_user_id)
+        }.not_to raise_error
+
+        batch = StatementBatch.last
+        expect(batch.status).to eq("failed")
+      end
+    end
+
     context "非領収書画像" do
       let(:non_receipt_result) do
         ReceiptProcessorService::Result.new(

--- a/rails/platform/spec/services/amex_statement_processor_service_spec.rb
+++ b/rails/platform/spec/services/amex_statement_processor_service_spec.rb
@@ -517,5 +517,20 @@ RSpec.describe AmexStatementProcessorService do
         expect(result.retryable?).to be false
       end
     end
+
+    context "ストレージ系エラー (issue#299)" do
+      it "EACCES等のシステムエラーは storage_error で非リトライ、クラス名を漏らさないこと" do
+        broken_pdf = double("BrokenAttachment")
+        allow(broken_pdf).to receive(:download).and_raise(Errno::EACCES, "Permission denied")
+
+        result = described_class.new(pdf: broken_pdf, client_code: client.code).call
+
+        expect(result.success?).to be false
+        expect(result.reason).to eq(:storage_error)
+        expect(result.retryable?).to be false
+        expect(result.error).not_to include("Errno")
+        expect(result.error).to include("読み込めませんでした")
+      end
+    end
   end
 end

--- a/rails/platform/spec/services/bank_statement_processor_service_spec.rb
+++ b/rails/platform/spec/services/bank_statement_processor_service_spec.rb
@@ -506,6 +506,26 @@ RSpec.describe BankStatementProcessorService do
         result = described_class::Result.new(success: false, data: {}, error: "error", reason: :file_not_found)
         expect(result.retryable?).to be false
       end
+
+      it "storage_errorはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :storage_error)
+        expect(result.retryable?).to be false
+      end
+    end
+
+    context "ストレージ系エラー (issue#299)" do
+      it "EACCES等のシステムエラーは storage_error で非リトライ、クラス名を漏らさないこと" do
+        broken_pdf = double("BrokenAttachment")
+        allow(broken_pdf).to receive(:download).and_raise(Errno::EACCES, "Permission denied")
+
+        result = described_class.new(pdf: broken_pdf, client_code: client.code).call
+
+        expect(result.success?).to be false
+        expect(result.reason).to eq(:storage_error)
+        expect(result.retryable?).to be false
+        expect(result.error).not_to include("Errno")
+        expect(result.error).to include("読み込めませんでした")
+      end
     end
   end
 end

--- a/rails/platform/spec/services/cleaning_manual_generator_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_manual_generator_service_spec.rb
@@ -85,6 +85,23 @@ RSpec.describe CleaningManualGeneratorService do
       expect(result.success?).to be true
     end
 
+    it "画像読み取りのシステムエラー(EACCES等)は storage_error で非リトライ、クラス名を漏らさないこと (issue#299)" do
+      service = described_class.new(
+        images: [image_file],
+        property_name: "テスト施設",
+        room_type: "スタンダード"
+      )
+      allow(service).to receive(:resize_image).and_raise(Errno::EACCES, "Permission denied")
+
+      result = service.call
+
+      expect(result.success?).to be false
+      expect(result.reason).to eq(:storage_error)
+      expect(result.retryable?).to be false
+      expect(result.error).not_to include("Errno")
+      expect(result.error).to include("読み込めませんでした")
+    end
+
     context "JSONがコードブロックで囲まれている場合" do
       let(:mock_response) do
         double("Response",

--- a/rails/platform/spec/services/invoice_processor_service_spec.rb
+++ b/rails/platform/spec/services/invoice_processor_service_spec.rb
@@ -520,6 +520,26 @@ RSpec.describe InvoiceProcessorService do
         result = described_class::Result.new(success: true, data: {}, error: nil, reason: nil)
         expect(result.retryable?).to be false
       end
+
+      it "storage_errorはretryableでないこと" do
+        result = described_class::Result.new(success: false, data: {}, error: "error", reason: :storage_error)
+        expect(result.retryable?).to be false
+      end
+    end
+
+    context "ストレージ系エラー (issue#299)" do
+      it "EACCES等のシステムエラーは storage_error で非リトライ、クラス名を漏らさないこと" do
+        broken_pdf = double("BrokenAttachment")
+        allow(broken_pdf).to receive(:download).and_raise(Errno::EACCES, "Permission denied")
+
+        result = described_class.new(pdf: broken_pdf, client_code: client.code).call
+
+        expect(result.success?).to be false
+        expect(result.reason).to eq(:storage_error)
+        expect(result.retryable?).to be false
+        expect(result.error).not_to include("Errno")
+        expect(result.error).to include("読み込めませんでした")
+      end
     end
   end
 end

--- a/rails/platform/spec/services/invoice_processor_service_spec.rb
+++ b/rails/platform/spec/services/invoice_processor_service_spec.rb
@@ -540,6 +540,16 @@ RSpec.describe InvoiceProcessorService do
         expect(result.error).not_to include("Errno")
         expect(result.error).to include("読み込めませんでした")
       end
+
+      it "ENOENT(ファイル不在)も storage_error として非リトライで扱うこと" do
+        broken_pdf = double("BrokenAttachment")
+        allow(broken_pdf).to receive(:download).and_raise(Errno::ENOENT, "No such file or directory")
+
+        result = described_class.new(pdf: broken_pdf, client_code: client.code).call
+
+        expect(result.reason).to eq(:storage_error)
+        expect(result.retryable?).to be false
+      end
     end
   end
 end

--- a/rails/platform/spec/services/receipt_processor_service_spec.rb
+++ b/rails/platform/spec/services/receipt_processor_service_spec.rb
@@ -400,5 +400,31 @@ RSpec.describe ReceiptProcessorService do
         expect(result.retryable?).to be false
       end
     end
+
+    context "ストレージ系エラー (issue#299)" do
+      it "EACCES等のシステムエラーは storage_error で非リトライ、クラス名を漏らさないこと" do
+        broken_image = double("BrokenAttachment")
+        allow(broken_image).to receive(:download).and_raise(Errno::EACCES, "Permission denied")
+
+        result = described_class.new(image: broken_image, client_code: client.code).call
+
+        expect(result.success?).to be false
+        expect(result.reason).to eq(:storage_error)
+        expect(result.retryable?).to be false
+        expect(result.error).not_to include("Errno")
+        expect(result.error).to include("読み込めませんでした")
+      end
+
+      it "FileNotFoundError のメッセージが空でもクラス名を漏らさないこと" do
+        broken_image = double("BrokenAttachment")
+        allow(broken_image).to receive(:download).and_raise(ActiveStorage::FileNotFoundError)
+
+        result = described_class.new(image: broken_image, client_code: client.code).call
+
+        expect(result.reason).to eq(:file_not_found)
+        expect(result.error).not_to include("ActiveStorage")
+        expect(result.error).to include("画像ファイルが見つかりません")
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要

download(読み取り)時のホスト側ストレージ障害が握りつぶされ、UX が悪化していた問題を修正。
本番は Disk service + worker/platform 間の共有ボリューム(#297)のため、権限ミス・ディスクフル・
読取専用化が現実的に起きうる。

- `Errno::EACCES/ENOSPC/EROFS` が `rescue StandardError` に落ちて `:unexpected_error`(retryable)
  となり、2回無駄リトライ後に「予期しないエラー」しか出なかった → `:storage_error` として
  非リトライ分類し、即座に固定文言で失敗させる。
- 引数なしで raise される `ActiveStorage::FileNotFoundError` は `e.message` がクラス名になり
  「…が見つかりません: ActiveStorage::FileNotFoundError」と UI/DB に漏れていた → クラス名を
  出さない固定文言へ。
- 分類ポリシー（対象 Errno・文言）を共有モジュール `StorageErrorHandling` に集約し、
  receipt/amex/bank/invoice processor + cleaning_manual_generator の5サービスで利用。
- LINE 経由の受信ジョブに `:storage_error` 向けの返信文言を追加。

#302（write 側の取り込みヘルパ）で切り出したシームの read 側対応。テストは各サービスで
EACCES → `:storage_error`・非リトライ・クラス名非漏洩を検証（全 631 緑）。

Closes #299
