### PR TITLE
fix(platform): CleaningPhotoJudgeServiceのストレージ読み取りエラーを分類 (issue#325)

### DIFF
--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -1,6 +1,8 @@
 require "image_processing/vips"
 
 class CleaningPhotoJudgeService
+  include StorageErrorHandling
+
   Result = Data.define(:success, :result, :feedback, :error) do
     alias_method :success?, :success
   end
@@ -67,6 +69,10 @@ class CleaningPhotoJudgeService
     Result.new(success: false, result: nil, feedback: nil, error: "Anthropic API エラー: #{e.message}")
   rescue JSON::ParserError => e
     Result.new(success: false, result: nil, feedback: nil, error: "JSON パースエラー: #{e.message}")
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+    # 写真の読み取り(File.binread / vips の tempfile 経路)で起きるストレージ系エラーは
+    # IOError ではないため従来は素通りしていた。クラス名を漏らさず失敗として返す (issue#325)。
+    Result.new(success: false, result: nil, feedback: nil, error: storage_system_error_message("画像"))
   rescue IOError, Vips::Error => e
     Result.new(success: false, result: nil, feedback: nil, error: "画像処理エラー: #{e.message}")
   end

--- a/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
@@ -130,5 +130,28 @@ RSpec.describe CleaningPhotoJudgeService do
         expect(result.error).to include("パースエラー")
       end
     end
+
+    context "画像読み取りのストレージ系エラー (issue#325)" do
+      let(:mock_response) { nil }
+
+      it "EACCES等のシステムエラーは失敗として返し、クラス名を漏らさないこと" do
+        allow(service).to receive(:resize_image).and_raise(Errno::EACCES, "Permission denied")
+
+        result = service.call
+
+        expect(result.success?).to be false
+        expect(result.error).not_to include("Errno")
+        expect(result.error).to include("読み込めませんでした")
+      end
+
+      it "ENOENT(ファイル不在)も失敗として返すこと" do
+        allow(service).to receive(:resize_image).and_raise(Errno::ENOENT, "No such file or directory")
+
+        result = service.call
+
+        expect(result.success?).to be false
+        expect(result.error).not_to include("Errno")
+      end
+    end
   end
 end

--- a/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
@@ -134,23 +134,19 @@ RSpec.describe CleaningPhotoJudgeService do
     context "画像読み取りのストレージ系エラー (issue#325)" do
       let(:mock_response) { nil }
 
-      it "EACCES等のシステムエラーは失敗として返し、クラス名を漏らさないこと" do
-        allow(service).to receive(:resize_image).and_raise(Errno::EACCES, "Permission denied")
+      # STORAGE_SYSTEM_ERRORS の全メンバーを一律にマスクすることを検証する。
+      # リストに Errno を追加した場合も自動でカバーされる。
+      StorageErrorHandling::STORAGE_SYSTEM_ERRORS.each do |error_class|
+        it "#{error_class} は失敗として返し、クラス名を漏らさないこと" do
+          allow(service).to receive(:resize_image).and_raise(error_class)
 
-        result = service.call
+          result = service.call
 
-        expect(result.success?).to be false
-        expect(result.error).not_to include("Errno")
-        expect(result.error).to include("読み込めませんでした")
-      end
-
-      it "ENOENT(ファイル不在)も失敗として返すこと" do
-        allow(service).to receive(:resize_image).and_raise(Errno::ENOENT, "No such file or directory")
-
-        result = service.call
-
-        expect(result.success?).to be false
-        expect(result.error).not_to include("Errno")
+          expect(result.success?).to be false
+          expect(result.error).not_to include("Errno")
+          expect(result.error).not_to include(error_class.name)
+          expect(result.error).to include("読み込めませんでした")
+        end
       end
     end
   end


### PR DESCRIPTION
## 概要

#299 のレビュー横断で発見したギャップの対応。`CleaningPhotoJudgeService` は写真を
`File.binread` / vips の tempfile 経路で読むが、`call` の rescue が `IOError/Vips::Error/
APIError/JSON::ParserError` のみで、`Errno::EACCES/ENOSPC/EROFS/ENOENT/EIO` が素通りし
呼び出し元（`CleaningSessionService`）へ未捕捉例外として伝播していた。

- #299 で導入した共有モジュール `StorageErrorHandling` を `include` し、`STORAGE_SYSTEM_ERRORS`
  を rescue してクラス名を漏らさないクリーン文言で失敗を返す。
- 本サービスの `Result` は `reason`/`retryable?` を持たない別契約で、呼び出し元は
  `success?`/`error` のみ参照するため、`success: false` + クリーン `error` に寄せる最小対応。

EACCES/ENOENT → 失敗・クラス名非漏洩をテストで検証（全 634 緑）。

Closes #325
