### PR TITLE
chore(platform): ストレージ系エラーの元例外を運用ログに残す (issue#327)

### DIFF
--- a/rails/platform/app/services/amex_statement_processor_service.rb
+++ b/rails/platform/app/services/amex_statement_processor_service.rb
@@ -176,9 +176,11 @@ class AmexStatementProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
-  rescue ActiveStorage::FileNotFoundError
+  rescue ActiveStorage::FileNotFoundError => e
+    log_storage_error(e, level: :warn)
     Result.new(success: false, data: {}, error: file_not_found_message("PDFファイル"), reason: :file_not_found)
-  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS => e
+    log_storage_error(e)
     Result.new(success: false, data: {}, error: storage_system_error_message("PDFファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)

--- a/rails/platform/app/services/bank_statement_processor_service.rb
+++ b/rails/platform/app/services/bank_statement_processor_service.rb
@@ -181,9 +181,11 @@ class BankStatementProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
-  rescue ActiveStorage::FileNotFoundError
+  rescue ActiveStorage::FileNotFoundError => e
+    log_storage_error(e, level: :warn)
     Result.new(success: false, data: {}, error: file_not_found_message("PDFファイル"), reason: :file_not_found)
-  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS => e
+    log_storage_error(e)
     Result.new(success: false, data: {}, error: storage_system_error_message("PDFファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)

--- a/rails/platform/app/services/cleaning_manual_generator_service.rb
+++ b/rails/platform/app/services/cleaning_manual_generator_service.rb
@@ -89,9 +89,11 @@ class CleaningManualGeneratorService
       return merged unless merged.success?
       Result.new(success: true, data: merged.data, error: nil, reason: nil)
     end
-  rescue ActiveStorage::FileNotFoundError
+  rescue ActiveStorage::FileNotFoundError => e
+    log_storage_error(e, level: :warn)
     Result.new(success: false, data: {}, error: file_not_found_message("画像ファイル"), reason: :file_not_found)
-  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS => e
+    log_storage_error(e)
     Result.new(success: false, data: {}, error: storage_system_error_message("画像ファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)

--- a/rails/platform/app/services/cleaning_photo_judge_service.rb
+++ b/rails/platform/app/services/cleaning_photo_judge_service.rb
@@ -69,9 +69,10 @@ class CleaningPhotoJudgeService
     Result.new(success: false, result: nil, feedback: nil, error: "Anthropic API エラー: #{e.message}")
   rescue JSON::ParserError => e
     Result.new(success: false, result: nil, feedback: nil, error: "JSON パースエラー: #{e.message}")
-  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS => e
     # 写真の読み取り(File.binread / vips の tempfile 経路)で起きるストレージ系エラーは
     # IOError ではないため従来は素通りしていた。クラス名を漏らさず失敗として返す (issue#325)。
+    log_storage_error(e)
     Result.new(success: false, result: nil, feedback: nil, error: storage_system_error_message("画像"))
   rescue IOError, Vips::Error => e
     Result.new(success: false, result: nil, feedback: nil, error: "画像処理エラー: #{e.message}")

--- a/rails/platform/app/services/invoice_processor_service.rb
+++ b/rails/platform/app/services/invoice_processor_service.rb
@@ -181,9 +181,11 @@ class InvoiceProcessorService
     pages = parse_pdf_pages(pdf_binary)
 
     process_with_adaptive_batch_size(pages, user_prompt)
-  rescue ActiveStorage::FileNotFoundError
+  rescue ActiveStorage::FileNotFoundError => e
+    log_storage_error(e, level: :warn)
     Result.new(success: false, data: {}, error: file_not_found_message("PDFファイル"), reason: :file_not_found)
-  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS => e
+    log_storage_error(e)
     Result.new(success: false, data: {}, error: storage_system_error_message("PDFファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)

--- a/rails/platform/app/services/receipt_processor_service.rb
+++ b/rails/platform/app/services/receipt_processor_service.rb
@@ -182,9 +182,11 @@ class ReceiptProcessorService
     end
 
     Result.new(success: true, data: data, error: nil, reason: nil)
-  rescue ActiveStorage::FileNotFoundError
+  rescue ActiveStorage::FileNotFoundError => e
+    log_storage_error(e, level: :warn)
     Result.new(success: false, data: {}, error: file_not_found_message("画像ファイル"), reason: :file_not_found)
-  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS
+  rescue *StorageErrorHandling::STORAGE_SYSTEM_ERRORS => e
+    log_storage_error(e)
     Result.new(success: false, data: {}, error: storage_system_error_message("画像ファイル"), reason: :storage_error)
   rescue Anthropic::Errors::APIError => e
     Result.new(success: false, data: {}, error: "Anthropic API エラー: #{e.message}", reason: :api_error)

--- a/rails/platform/app/services/storage_error_handling.rb
+++ b/rails/platform/app/services/storage_error_handling.rb
@@ -10,6 +10,10 @@ module StorageErrorHandling
   # (File.binread / vips の tempfile 経路) では ENOENT/EIO が直接上がるため含める。
   # 注意: 一律 SystemCallError で握ると EAGAIN/EINTR 等の一時的エラーまで非リトライ化して
   # しまうため、非リトライが妥当なものだけを明示列挙する。
+  #
+  # このリストは「何をインフラ障害(非リトライ)とみなすか」のポリシー定義であり、追加は運用方針の
+  # 変更にあたる。将来ストレージ実装を変える場合（例: Disk service → S3）、Aws::S3 系の例外を
+  # ここに足すかは、リトライ可否・誤検知の影響を運用と合意の上で判断する。
   STORAGE_SYSTEM_ERRORS = [
     Errno::EACCES,  # 権限なし
     Errno::ENOSPC,  # ディスクフル
@@ -31,10 +35,13 @@ module StorageErrorHandling
     "#{kind}をサーバー側で読み込めませんでした。時間をおいて再度お試しください。"
   end
 
-  # ユーザーにはクラス名を漏らさない一方、運用トリアージのため元例外を記録する (issue#327)。
-  # ディスクフル/権限なのか単なるファイル不在なのかを切り分けられるよう、クラス名と message を残す。
+  # 運用/SRE 向けのログ（ユーザー向け文言は *_message 側）。クラス名を漏らさない一方で、
+  # トリアージのため元例外を記録する (issue#327)。ディスクフル/権限なのか単なるファイル不在
+  # なのかを切り分けられるよう、クラス名と message を残す。
   # level は呼び出し側で使い分ける: システムコール系(EACCES/ENOSPC 等)= :error、
   # ファイル不在(FileNotFoundError) = :warn。
+  # 規約: storage 系の rescue を追加する際は、文言を返す前に必ず本メソッドを呼ぶ（呼び漏れると
+  # その経路だけログが落ちる）。
   def log_storage_error(error, level: :error)
     Rails.logger.public_send(level, "[#{self.class.name}] storage error: #{error.class}: #{error.message}")
   end

--- a/rails/platform/app/services/storage_error_handling.rb
+++ b/rails/platform/app/services/storage_error_handling.rb
@@ -30,4 +30,12 @@ module StorageErrorHandling
   def storage_system_error_message(kind)
     "#{kind}をサーバー側で読み込めませんでした。時間をおいて再度お試しください。"
   end
+
+  # ユーザーにはクラス名を漏らさない一方、運用トリアージのため元例外を記録する (issue#327)。
+  # ディスクフル/権限なのか単なるファイル不在なのかを切り分けられるよう、クラス名と message を残す。
+  # level は呼び出し側で使い分ける: システムコール系(EACCES/ENOSPC 等)= :error、
+  # ファイル不在(FileNotFoundError) = :warn。
+  def log_storage_error(error, level: :error)
+    Rails.logger.public_send(level, "[#{self.class.name}] storage error: #{error.class}: #{error.message}")
+  end
 end

--- a/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
+++ b/rails/platform/spec/services/cleaning_photo_judge_service_spec.rb
@@ -148,6 +148,13 @@ RSpec.describe CleaningPhotoJudgeService do
           expect(result.error).to include("読み込めませんでした")
         end
       end
+
+      it "元例外を ERROR ログに残すこと (issue#327)" do
+        allow(service).to receive(:resize_image).and_raise(Errno::ENOSPC, "No space left on device")
+        expect(Rails.logger).to receive(:error).with(/CleaningPhotoJudgeService.*Errno::ENOSPC/)
+
+        service.call
+      end
     end
   end
 end

--- a/rails/platform/spec/services/receipt_processor_service_spec.rb
+++ b/rails/platform/spec/services/receipt_processor_service_spec.rb
@@ -425,6 +425,22 @@ RSpec.describe ReceiptProcessorService do
         expect(result.error).not_to include("ActiveStorage")
         expect(result.error).to include("画像ファイルが見つかりません")
       end
+
+      it "FileNotFoundError は元例外を WARN ログに残すこと (issue#327)" do
+        broken_image = double("BrokenAttachment")
+        allow(broken_image).to receive(:download).and_raise(ActiveStorage::FileNotFoundError)
+        expect(Rails.logger).to receive(:warn).with(/ReceiptProcessorService.*ActiveStorage::FileNotFoundError/)
+
+        described_class.new(image: broken_image, client_code: client.code).call
+      end
+
+      it "システムエラーは元例外を ERROR ログに残すこと (issue#327)" do
+        broken_image = double("BrokenAttachment")
+        allow(broken_image).to receive(:download).and_raise(Errno::ENOSPC, "No space left on device")
+        expect(Rails.logger).to receive(:error).with(/ReceiptProcessorService.*Errno::ENOSPC/)
+
+        described_class.new(image: broken_image, client_code: client.code).call
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

ユーザーにはクラス名を漏らさないクリーン文言を返す一方、ディスクフル(ENOSPC)・権限(EACCES)・
ファイル不在等の切り分けがログから追えなかった問題を解消（#299 / #325 のレビューで挙がった運用観点）。

- `StorageErrorHandling` に `log_storage_error` を追加し、サービス名タグ + 例外クラス + message を記録。
- レベルを使い分け: `STORAGE_SYSTEM_ERRORS`(EACCES/ENOSPC/EROFS/ENOENT/EIO)=**ERROR**(インフラ障害)、
  `FileNotFoundError`=**WARN**(ファイル不在は孤児/再アップロードで benign なこともある)。
- `StorageErrorHandling` 利用の全6サービス（receipt/amex/bank/invoice processor +
  cleaning_manual_generator + cleaning_photo_judge）の storage 系 rescue から呼ぶ。
- **ユーザー向け文言・分類(reason)は変更なし**（純粋にログ追加）。

WARN/ERROR 両レベルを receipt / cleaning_photo_judge のテストで検証（全 640 緑）。

Closes #327
