### PR TITLE
chore(platform): 本番storageの.gitignore追加とworker healthcheck整備 (issue#301)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@
 tmp/
 temp/
 
+# Production storage (compose.production.yaml が ./storage を bind mount する。
+# クライアントの PDF/画像が乗るため、誤って git add しないよう丸ごと無視する)
+/storage/
+
 # Node modules and build artifacts
 node_modules/
 /rails/*/app/assets/builds/*

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -57,6 +57,14 @@ services:
     depends_on:
       platform:
         condition: service_healthy
+    healthcheck:
+      # storage マウントが破損（権限変更・RO化）すると docker compose ps では
+      # running 表示のまま見逃すため、書き込み可否を直接確認する
+      test: ["CMD-SHELL", "test -w /platform/storage || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     networks:
       - internal
       - web-proxy-net


### PR DESCRIPTION
## 概要

#297 で導入した本番 `./storage` bind mount に伴うストレージ運用整備のうち、低リスクで効果の大きい2点を対応する（#301 の課題1・課題3）。

## 変更内容

### 1. ルート `.gitignore` に `/storage/` を追加（課題1）
`rails/platform/.gitignore` には `/storage/*` があるが、`compose.production.yaml` が bind mount する**リポジトリルートの** `./storage/` はカバーされていなかった。開発者がローカルで本番 compose を実行した際に、クライアントPDF/画像を誤って `git add .` する事故リスクを防止する。

- 検証: `git check-ignore -v storage/dummy.pdf` → `.gitignore:/storage/` でヒットすることを確認

### 2. worker に storage healthcheck を追加（課題3）
ストレージマウントが破損（権限変更・RO化）しても `docker compose ps` では running 表示のまま見逃すため、`test -w /platform/storage` で書き込み可否を直接確認する healthcheck を worker に追加。interval 等は platform に合わせた。

- 検証: `docker compose -f compose.production.yaml config` で healthcheck が正しく反映、構文エラーなしを確認

## スコープ外（別PRで対応）

#301 の残課題は本PRに含めない:
- 課題2: `ActiveStorage::Blob.unattached` の orphan blob 掃除Rakeタスク
- 課題4: rsync/restic 等によるバックアップ運用ドキュメント整備

## テスト

compose/gitignore のみの変更で Rails のテストには影響しないため `make test` は省略。compose config と git check-ignore で動作確認済み。

Closes #301 の一部（課題1・3）