### PR TITLE
chore(platform): railsユーザーのUID/GIDを999に固定しstorage chownの意図を明記 (issue#300)

### DIFF
--- a/rails/Dockerfile.platform
+++ b/rails/Dockerfile.platform
@@ -81,9 +81,16 @@ FROM base AS production
 COPY --from=production-builder /usr/local/bundle /usr/local/bundle
 COPY --from=production-builder /platform /platform
 
-# 非 root ユーザーを作成
-RUN groupadd --system rails \
-    && useradd --system --gid rails --create-home --shell /bin/bash rails \
+# 非 root ユーザーを作成（UID/GID を 999 に固定）
+# --system のみだと Debian は system UID を降順に自動採番するため、base image の
+# 変更で 998 等にずれ得る。本番ホスト側 ./storage を 999:999 で chown している前提が
+# 崩れると全アップロードが EACCES で失敗するため、明示的に 999 へ固定する。
+#
+# storage への chown は本番では ./storage の bind mount で上書きされ実質 no-op になる。
+# 本番ではホスト側で `chown -R 999:999 ./storage` を実行しておくこと（issue#300）。
+# ここでの chown は bind mount を使わない実行（COPY されたディレクトリ）向けに残す。
+RUN groupadd --system --gid 999 rails \
+    && useradd --system --uid 999 --gid 999 --create-home --shell /bin/bash rails \
     && chown -R rails:rails db log storage tmp
 USER rails
 

--- a/rails/Dockerfile.platform
+++ b/rails/Dockerfile.platform
@@ -85,6 +85,8 @@ COPY --from=production-builder /platform /platform
 # --system のみだと Debian は system UID を降順に自動採番するため、base image の
 # 変更で 998 等にずれ得る。本番ホスト側 ./storage を 999:999 で chown している前提が
 # 崩れると全アップロードが EACCES で失敗するため、明示的に 999 へ固定する。
+# この 999 は Makefile の prod-storage-check が強制するホスト側 ./storage の
+# 所有者(999:999)と対。どちらかを変える時は必ず両方を揃えること。
 #
 # storage への chown は本番では ./storage の bind mount で上書きされ実質 no-op になる。
 # 本番ではホスト側で `chown -R 999:999 ./storage` を実行しておくこと（issue#300）。


### PR DESCRIPTION
## 概要

#300 のうち課題1（UID固定）・課題2（chownコメント明記）を対応する。Dockerfileのみの変更。

## 背景

#297 で本番に `./storage` の bind mount を導入し、#329 で worker に storage healthcheck を追加した。これらは **ホスト側 `./storage` を 999:999 で chown し、コンテナ内 rails ユーザーが 999 で動く**ことを暗黙の前提にしている。

しかし現状の `Dockerfile.platform` は `useradd --system`（UID未指定）で、Debian の system UID は降順自動採番されるため、**base image の変更で 998 等にずれ得る**。ずれると本番アップロードが全て EACCES で失敗する。

## 変更内容

### 課題1: UID/GID を 999 に固定
```dockerfile
RUN groupadd --system --gid 999 rails \
    && useradd --system --uid 999 --gid 999 --create-home --shell /bin/bash rails \
    && chown -R rails:rails db log storage tmp
```

### 課題2: storage chown の意図をコメント明記
storage への chown は本番では bind mount で上書きされ実質 no-op。コメントで「本番ではホスト側で `chown -R 999:999 ./storage` が必要」「ここでの chown は bind mount を使わない実行向けの保険」と明示した。

## 検証（実ビルド）

- `docker build --target production` 成功
- `docker run --rm <image> id rails` → `uid=999(rails) gid=999(rails)`
- base image `ruby:3.4.6-slim` で UID/GID 999 は空き（衝突なし）。現状の自動採番がたまたま 999 で、ずれるリスクが実在することを確認
- `storage/db/log/tmp` が `rails:rails` 所有（chown が効いていることを確認）

## スコープ外（別PR）

#300 課題3（compose.development への worker 追加 / dev の `:async` queue adapter を solid_queue 相当にする）は影響範囲が大きいため別PRで対応。

## デプロイ注意

Dockerfile 変更のため本番反映には image 再ビルドが必要（`make prod-deploy`）。マージ後にデプロイする。

関連: #297, #329, #301