### PR TITLE
feat(platform): dev環境にsolid_queue workerを追加し本番相当のジョブ実行を再現 (issue#300)

### DIFF
--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -100,6 +100,15 @@ services:
     depends_on:
       platform:
         condition: service_healthy
+    # 本番(compose.production.yaml)の worker 同様、storage マウントが破損（権限変更・RO化）
+    # しても docker compose ps では running 表示のまま見逃すため、書き込み可否を直接確認する。
+    # storage 共有の回帰を dev でも検出するという issue#300 課題3 の狙いと対。
+    healthcheck:
+      test: ["CMD-SHELL", "test -w /platform/storage || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
 volumes:
   postgres_data:

--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -66,8 +66,40 @@ services:
     depends_on:
       db-suite:
         condition: service_healthy
+    # worker が platform の db:prepare 完了後に起動できるよう healthcheck を持たせる。
+    # /up が応答する = bin/setup(db:prepare) 完了後に server が立った状態。
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/up || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
     stdin_open: true
     tty: true
+
+  # 本番(compose.production.yaml)相当の solid_queue worker を別コンテナで起動する。
+  # platform と同じ ./rails/platform をマウントすることで storage(/platform/storage)を
+  # 共有し、worker からの storage 読み取り回帰を dev でも検出できる (issue#300 課題3)。
+  worker:
+    build:
+      context: ./rails
+      dockerfile: Dockerfile.platform
+      target: development
+      args:
+        RUBY_VERSION: ${RUBY_VERSION}
+        RAILS_VERSION: ${RAILS_VERSION}
+    # DB準備は platform(bin/setup の db:prepare)に一任し、worker は solid_queue 起動のみ。
+    # platform が healthy になってから起動するため queue DB は準備済み（db:prepare の競合回避）。
+    command: bash -c "bin/rails solid_queue:start"
+    volumes:
+      - ./rails/platform:/platform
+      - platform_bundle_cache:/usr/local/bundle
+    env_file:
+      - .env.development
+      - .env.local
+    depends_on:
+      platform:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/rails/platform/config/database.yml
+++ b/rails/platform/config/database.yml
@@ -20,36 +20,24 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 
+# 本番(production)と同型の multi-database 構成。solid_queue を別 worker コンテナで
+# 動かすため、queue を専用DB(platform_development_queue)に分離する。
+# cache/cable は dev では分離不要(:memory_store / デフォルト)のため primary のみ追加。
+#
+# host 等を primary に明示し queue へ継承させる。DATABASE_URL は primary にしか
+# 適用されないため、queue を *default(host無し)にするとソケット接続で失敗する。
 development:
-  <<: *default
-  database: platform_development
-
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: platform
-
-  # The password associated with the PostgreSQL role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+  primary: &primary_development
+    <<: *default
+    host: <%= ENV.fetch("POSTGRES_HOST", "localhost") %>
+    port: <%= ENV.fetch("POSTGRES_PORT", 5432) %>
+    database: platform_development
+    username: <%= ENV.fetch("POSTGRES_USER", "platform") %>
+    password: <%= ENV["POSTGRES_PASSWORD"] %>
+  queue:
+    <<: *primary_development
+    database: platform_development_queue
+    migrations_paths: db/queue_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/rails/platform/config/environments/development.rb
+++ b/rails/platform/config/environments/development.rb
@@ -55,6 +55,12 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # 本番(production.rb)と同じく solid_queue を使い、別 worker コンテナでジョブを実行する。
+  # これにより platform/worker 間の storage(/platform/storage) 共有の回帰を dev でも検出できる。
+  # queue は専用DB(platform_development_queue)へ。compose の worker サービスと対 (issue#300)。
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
## 概要

#300 課題3。dev は `:async`（同一プロセス即時実行）でジョブが完結し、本番の **platform/worker 間 storage 共有の回帰が dev/CI で捕まらなかった**。本番同型の solid_queue 構成を dev に導入する。

これにより #300 の3課題がすべて完了する（課題1・2は #332）。

## 変更内容

### `config/environments/development.rb`
本番(`production.rb`)と同じ2行を追加:
```ruby
config.active_job.queue_adapter = :solid_queue
config.solid_queue.connects_to = { database: { writing: :queue } }
```

### `config/database.yml`（development を multi-DB 化）
queue を専用DB `platform_development_queue` に分離（本番同型）。cache/cable は dev では分離不要（`:memory_store` / デフォルト）のため primary のみ追加。

**ハマりポイント**: `DATABASE_URL`（n8n/mattermost と共有の `POSTGRES_*` から生成）は **primary 設定にのみ適用**される。queue を `<<: *default`（host 無し）にするとソケット接続で失敗するため、本番同様 host/port/user/password を primary に明示し queue へ継承させた。

### `compose.development.yaml`
- worker サービスを追加（`./rails/platform:/platform` マウントで `/platform/storage` を共有）
- platform に healthcheck（`/up`）を追加し、worker は `platform: service_healthy` 後に起動
- これにより worker は `solid_queue:start` のみ（DB準備は platform の `bin/setup` に一任）で、**db:prepare の競合を回避**

## 検証（dev 実機）

| 項目 | 結果 |
|---|---|
| queue_adapter | `:solid_queue` |
| multi-DB | `queue => platform_development_queue`（host=db-suite で接続）|
| worker 稼働 | `SolidQueue::Process` に Supervisor/Worker/Dispatcher が登録（worker コンテナ）|
| **storage 共有** | platform が書いた ActiveStorage blob を worker が `/platform/storage` 経由で読取り成功 |

## 影響範囲

- **本番デプロイ対象外**: `compose.production.yaml` は不変。dev/compose のみの変更
- dev 日常開発で worker 起動が前提になる（`make up` なら自動起動）。`:async` のように同一プロセスでジョブ即時実行はされなくなる
- test 環境は `:test` adapter のまま（既存テストに影響なし）

Closes #300