### PR TITLE
feat(platform): storage健全性をhealthcheckで監視し実書き込みでディスクフルも検知 (issue#330, issue#331)

### DIFF
--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -67,9 +67,10 @@ services:
       db-suite:
         condition: service_healthy
     # worker が platform の db:prepare 完了後に起動できるよう healthcheck を持たせる。
-    # /up が応答する = bin/setup(db:prepare) 完了後に server が立った状態。
+    # /health/storage が応答する = bin/setup(db:prepare) 完了後に server が立ち、かつ
+    # storage 書き込み可否まで確認できた状態 (issue#330。本番 compose と同じエンドポイント)。
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/up || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/health/storage || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -100,11 +101,12 @@ services:
     depends_on:
       platform:
         condition: service_healthy
-    # 本番(compose.production.yaml)の worker 同様、storage マウントが破損（権限変更・RO化）
-    # しても docker compose ps では running 表示のまま見逃すため、書き込み可否を直接確認する。
-    # storage 共有の回帰を dev でも検出するという issue#300 課題3 の狙いと対。
+    # 本番(compose.production.yaml)の worker 同様、storage マウント破損(権限変更/マウント消失/
+    # RO化)に加え、実書き込みするためディスクフル/I-Oエラーも検知する (issue#331)。
+    # docker compose ps では running 表示のまま見逃すため書き込み可否を直接確認する。
+    # platform(.healthcheck.platform)とファイル名を分け書き込み/削除の競合による誤検知を避ける。
     healthcheck:
-      test: ["CMD-SHELL", "test -w /platform/storage || exit 1"]
+      test: ["CMD-SHELL", "touch /platform/storage/.healthcheck.worker && rm -f /platform/storage/.healthcheck.worker || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -36,7 +36,9 @@ services:
       db-suite:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/up || exit 1"]
+      # /up(boot確認)ではなく storage 書き込み可否まで見る /health/storage を叩く。
+      # storage 破損(権限/マウント消失/RO/ディスクフル/I-O)時に unhealthy になる (issue#330)。
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/health/storage || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -58,9 +60,10 @@ services:
       platform:
         condition: service_healthy
     healthcheck:
-      # storage マウントが破損（権限変更・RO化）すると docker compose ps では
-      # running 表示のまま見逃すため、書き込み可否を直接確認する
-      test: ["CMD-SHELL", "test -w /platform/storage || exit 1"]
+      # storage マウント破損(権限変更/マウント消失/RO化)に加え、実書き込みするため
+      # ディスクフル/I-Oエラーも検知する。test -w はパーミッションしか見ず取りこぼす (issue#331)。
+      # platform(.healthcheck.platform)とファイル名を分け書き込み/削除の競合による誤検知を避ける。
+      test: ["CMD-SHELL", "touch /platform/storage/.healthcheck.worker && rm -f /platform/storage/.healthcheck.worker || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/rails/platform/app/controllers/health_controller.rb
+++ b/rails/platform/app/controllers/health_controller.rb
@@ -1,0 +1,29 @@
+# storage(ActiveStorage の保存先)の書き込み可否を実際に試す healthcheck エンドポイント。
+# Rails 標準の /up は boot 確認のみで storage の破損(権限不一致・マウント消失・RO化・
+# ディスクフル・I/Oエラー)を検知できない。実書き込み→削除を行うことで、test -w では
+# 拾えないディスクフル/I/Oエラーも含めて storage 健全性を検出する (issue#330, issue#331)。
+#
+# ApplicationController を継承せず ActionController::Base 直下にすることで
+# authenticate_user! を回避する(LB/compose からの無認証アクセスを許可)。
+class HealthController < ActionController::Base
+  def storage
+    path = storage_healthcheck_path
+    File.write(path, "ok")
+    File.delete(path)
+    head :ok
+  rescue => e
+    Rails.logger.error("[health/storage] storage write check failed: #{e.class}: #{e.message}")
+    head :service_unavailable
+  end
+
+  private
+
+  # ActiveStorage Disk service の保存先直下の隠しファイルを使う。
+  # ドット始まりにすることで ActiveStorage のキー(hex)スキャン対象と衝突しない。
+  # platform/worker が同じ storage を共有するため、worker(.healthcheck.worker)と
+  # ファイル名を分離して書き込み/削除の競合による誤検知を避ける。
+  def storage_healthcheck_path
+    root = ActiveStorage::Blob.service.try(:root) || Rails.root.join("storage")
+    File.join(root, ".healthcheck.platform")
+  end
+end

--- a/rails/platform/app/controllers/health_controller.rb
+++ b/rails/platform/app/controllers/health_controller.rb
@@ -3,17 +3,26 @@
 # ディスクフル・I/Oエラー)を検知できない。実書き込み→削除を行うことで、test -w では
 # 拾えないディスクフル/I/Oエラーも含めて storage 健全性を検出する (issue#330, issue#331)。
 #
+# 現状 dev/prod とも ActiveStorage は :local(Disk service)前提。S3 等の外部サービスへ
+# 移行した場合、ローカルファイルへの write では健全性を判定できないため要見直し。
+#
 # ApplicationController を継承せず ActionController::Base 直下にすることで
-# authenticate_user! を回避する(LB/compose からの無認証アクセスを許可)。
+# authenticate_user! を回避する(LB/compose からの無認証アクセスを許可)。GET のみのため
+# CSRF 対策は不要(Rails の forgery protection は非 GET のみ対象)。
 class HealthController < ActionController::Base
   def storage
     path = storage_healthcheck_path
+    # 実書き込みの成否が storage 健全性の本体。delete はあくまで後始末であり、
+    # 連続実行時の削除レース(既に消えている等)を 503 と誤判定しないよう cleanup 側で握りつぶす。
     File.write(path, "ok")
-    File.delete(path)
     head :ok
-  rescue => e
+  rescue SystemCallError, IOError => e
+    # File への write 失敗は Errno::*(SystemCallError) / IOError として上がる。
+    # storage 無関係の例外まで 503 に丸めないよう、storage 起因の例外型に絞る。
     Rails.logger.error("[health/storage] storage write check failed: #{e.class}: #{e.message}")
     head :service_unavailable
+  ensure
+    cleanup(path)
   end
 
   private
@@ -25,5 +34,12 @@ class HealthController < ActionController::Base
   def storage_healthcheck_path
     root = ActiveStorage::Blob.service.try(:root) || Rails.root.join("storage")
     File.join(root, ".healthcheck.platform")
+  end
+
+  # 後始末はベストエフォート。削除失敗(既に消えている等)は健全性判定に影響させない。
+  def cleanup(path)
+    File.delete(path) if path && File.exist?(path)
+  rescue SystemCallError
+    nil
   end
 end

--- a/rails/platform/config/routes.rb
+++ b/rails/platform/config/routes.rb
@@ -6,6 +6,11 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # storage(ActiveStorage 保存先)の書き込み可否まで確認する healthcheck。
+  # /up は boot 確認のみのため、storage 破損(権限/マウント/RO/ディスクフル/I-O)を
+  # 検知する用途で compose の platform healthcheck から叩く (issue#330)。
+  get "health/storage" => "health#storage", as: :storage_health_check
+
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/rails/platform/spec/requests/health_spec.rb
+++ b/rails/platform/spec/requests/health_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Health", type: :request do
+  describe "GET /health/storage" do
+    it "storage への書き込みに成功すると 200 を返す（認証不要）" do
+      get "/health/storage"
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "healthcheck 用の一時ファイルを残さない" do
+      get "/health/storage"
+
+      root = ActiveStorage::Blob.service.try(:root) || Rails.root.join("storage")
+      expect(File.exist?(File.join(root, ".healthcheck.platform"))).to be(false)
+    end
+
+    it "storage への書き込みが失敗すると 503 を返す（ディスクフル等）" do
+      allow(File).to receive(:write).and_raise(Errno::ENOSPC, "No space left on device")
+
+      get "/health/storage"
+
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+end

--- a/rails/platform/spec/requests/health_spec.rb
+++ b/rails/platform/spec/requests/health_spec.rb
@@ -22,5 +22,17 @@ RSpec.describe "Health", type: :request do
 
       expect(response).to have_http_status(:service_unavailable)
     end
+
+    it "後始末の削除が失敗（連続実行で既に削除済み等）でも 200 を返す" do
+      root = ActiveStorage::Blob.service.try(:root) || Rails.root.join("storage")
+      path = File.join(root, ".healthcheck.platform")
+      allow(File).to receive(:delete).with(path).and_raise(Errno::ENOENT)
+
+      get "/health/storage"
+
+      expect(response).to have_http_status(:ok)
+    ensure
+      FileUtils.rm_f(path)
+    end
   end
 end


### PR DESCRIPTION
## 概要

#330 / #331。storage の破損を docker healthcheck で確実に検知できるよう強化する。

- **#330**: `platform` コンテナの healthcheck は `/up`（Rails標準=boot確認のみ）で、storage の書き込み可否を一切見ていなかった。worker(#329)だけ守るのは片手落ち。
- **#331**: worker の `test -w` はパーミッションしか見ず、**ディスクフル/I-Oエラー**を取りこぼす。

## 変更内容

### `app/controllers/health_controller.rb`（新規）
- `GET /health/storage`。`ActiveStorage::Blob.service` の保存先へ**実書き込み→削除**を試し、成功で `200` / 例外で `503` を返す。
- 実書き込みなので `test -w` では拾えない**ディスクフル/I-Oエラーも検知**（#331 の platform 分を内包）。
- `ApplicationController` を継承せず `ActionController::Base` 直下とし、`authenticate_user!` を回避（LB/compose からの無認証アクセス用）。

### `config/routes.rb`
- `get "health/storage" => "health#storage"` 追加。`/up` は Rails 標準のまま据え置き（boot確認/LB用と storage 健全性をレイヤー分離）。

### `compose.production.yaml` / `compose.development.yaml`
- **platform** healthcheck: `/up` → `/health/storage`（#330）
- **worker** healthcheck: `test -w` → `touch/rm` 方式（#331。HTTPを持たないため）
- platform(`.healthcheck.platform`)と worker(`.healthcheck.worker`)で**ファイル名を分離**し、共有 storage 上での書き込み/削除競合による誤検知を回避。
- 隠しファイル（ドット始まり）にし、ActiveStorage のキー(hex)スキャン対象と衝突しないようにした。

## 検証

| 項目 | 結果 |
|---|---|
| RSpec (`spec/requests/health_spec.rb`) | 3 examples, 0 failures（正常200 / 一時ファイル残存なし / 書き込み失敗時503）|
| compose 構文 (dev/prod) | 両方 OK |
| `/health/storage` 実機 (dev) | HTTP 200 |
| 一時ファイル残存 | なし |
| worker touch/rm 実機 (dev) | 書き込み OK |

## 補足・注意

- `/health/storage` は `ActiveStorage::Blob.service.try(:root)` を使い、Disk service の root 直下に書く（現状 dev/prod とも `:local`）。将来 S3 等に移行する場合は別途検討が必要。
- **非root前提**: `test -w` は root 実行だと `CAP_DAC_OVERRIDE` で権限チェックを飛ばすが、本PRの実書き込み方式は非root(`USER rails`)前提で機能（#300 と依存、#330 補足どおり）。
- **本番反映**: `compose.production.yaml` の healthcheck 変更を含むため、本番の docker healthcheck 定義反映にはコンテナ再作成が必要。storage/Docker運用系の一括反映トラッキング **#333** の対象。

Closes #330
Closes #331