### PR TITLE
test(platform): ActiveStorage spec の respond_to? stub を廃しdownload直接stubに (issue#303)

### DIFF
--- a/rails/platform/spec/services/amex_statement_processor_service_spec.rb
+++ b/rails/platform/spec/services/amex_statement_processor_service_spec.rb
@@ -501,9 +501,10 @@ RSpec.describe AmexStatementProcessorService do
 
     context "ActiveStorage::FileNotFoundError が発生した場合" do
       it "file_not_found reasonで失敗し、retryableでないこと" do
+        # download を直接 stub することで read_pdf_binary の respond_to?(:download) は
+        # RSpec double のネイティブ挙動で true を返す。respond_to? 自体は stub しない
+        # (将来分岐が増えても未知の引数で MockExpectationError にならない / issue#303)。
         broken_pdf = double("BrokenAttachment")
-        allow(broken_pdf).to receive(:respond_to?).with(:download).and_return(true)
-        allow(broken_pdf).to receive(:respond_to?).with(:read).and_return(false)
         allow(broken_pdf).to receive(:download).and_raise(
           ActiveStorage::FileNotFoundError, "missing file"
         )

--- a/rails/platform/spec/services/receipt_processor_service_spec.rb
+++ b/rails/platform/spec/services/receipt_processor_service_spec.rb
@@ -384,9 +384,10 @@ RSpec.describe ReceiptProcessorService do
 
     context "ActiveStorage::FileNotFoundError が発生した場合" do
       it "file_not_found reasonで失敗し、retryableでないこと" do
+        # download を直接 stub することで read_image_binary の respond_to?(:download) は
+        # RSpec double のネイティブ挙動で true を返す。respond_to? 自体は stub しない
+        # (将来分岐が増えても未知の引数で MockExpectationError にならない / issue#303)。
         broken_image = double("BrokenAttachment")
-        allow(broken_image).to receive(:respond_to?).with(:download).and_return(true)
-        allow(broken_image).to receive(:respond_to?).with(:read).and_return(false)
         allow(broken_image).to receive(:download).and_raise(
           ActiveStorage::FileNotFoundError, "missing file"
         )


### PR DESCRIPTION
## 概要

**結論**: ActiveStorage のエラー系 spec で `respond_to?` を stub していた箇所を `download` の直接 stub に統一し、将来の分岐追加に強くしたテストリファクタ。

#303。#297 のコードレビュー LOW 指摘の解消。`spec/services/amex_statement_processor_service_spec.rb` と `spec/services/receipt_processor_service_spec.rb` の `ActiveStorage::FileNotFoundError` テストで、`double + allow(...).to receive(:respond_to?).with(...)` パターンを使っていた。

将来 `read_pdf_binary`/`read_image_binary` に新分岐（`:open` 等）が追加されると、stub が無い引数で `respond_to?` が呼ばれ **MockExpectationError** でテストが落ちる/想定外分岐に入る懸念があった。

## 変更内容

両 spec の `broken_pdf`/`broken_image` について:

- `allow(...).to receive(:respond_to?).with(:download)` / `.with(:read)` の明示 stub を**削除**
- `download` を直接 stub するのみに変更

`download` を stub すれば `respond_to?(:download)` は RSpec double のネイティブ挙動で `true` を返し、本体ロジックは `download` 分岐に入る。`respond_to?` 自体を stub しないため、将来分岐が増えても未知の引数で壊れない。ストレージ系エラー（#299）テストと同じパターンに揃えた。

## 補足：instance_double を見送った理由

issue の第一案 `instance_double(ActiveStorage::Attached::One)` を試したが、`ActiveStorage::Attached::One#download` は `delegate_missing_to :attachment` 経由で**実メソッドが定義されていない**ため、verifying double では `the ActiveStorage::Attached::One class does not implement the instance method: download` となり使えなかった。issue 本文の第二案（download を直接 stub）を採用。

## 検証

| 項目 | 結果 |
|---|---|
| `make test`（amex + receipt 両 spec 全体） | 39 examples, 0 failures |

Closes #303
