### PR TITLE
feat(platform): 仕訳詳細に証憑PDFリンクを表示 (issue#315)

### DIFF
--- a/rails/platform/app/controllers/journal_entries_controller.rb
+++ b/rails/platform/app/controllers/journal_entries_controller.rb
@@ -16,7 +16,9 @@ class JournalEntriesController < ApplicationController
   end
 
   def show
-    @entry = JournalEntry.for_client(@client_code).includes(:journal_entry_lines).find(params[:id])
+    @entry = JournalEntry.for_client(@client_code)
+                         .includes(:journal_entry_lines, statement_batch: { pdf_attachment: :blob })
+                         .find(params[:id])
   end
 
   def edit

--- a/rails/platform/app/views/journal_entries/show.html.erb
+++ b/rails/platform/app/views/journal_entries/show.html.erb
@@ -77,6 +77,21 @@
       </dl>
     <% end %>
 
+    <!-- 証憑 -->
+    <% if @entry.statement_batch&.pdf&.attached? %>
+      <%= render "shared/card" do %>
+        <h2 class="text-lg font-semibold mb-4 border-b pb-2">証憑</h2>
+        <%= link_to rails_blob_path(@entry.statement_batch.pdf, disposition: "inline"),
+              target: "_blank", rel: "noopener",
+              class: "inline-flex items-center gap-2 text-sm font-medium text-teal-400 hover:underline" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <span>証憑を開く（<%= @entry.statement_batch.pdf.filename %>）</span>
+        <% end %>
+      <% end %>
+    <% end %>
+
     <!-- 借方 -->
     <%= render "shared/card" do %>
       <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-teal-400">借方</h2>

--- a/rails/platform/spec/requests/web/journal_entries_spec.rb
+++ b/rails/platform/spec/requests/web/journal_entries_spec.rb
@@ -126,6 +126,34 @@ RSpec.describe "Web::JournalEntries", type: :request do
         expect(response.body).to include("テスト社")
         expect(response.body).to include("仕訳一覧")
       end
+
+      context "証憑（statement_batch.pdf）が添付されている場合" do
+        let(:batch) do
+          create(:statement_batch, :completed, client: client).tap do |b|
+            b.pdf.attach(
+              io: File.open(Rails.root.join("spec/fixtures/files/test_statement.pdf")),
+              filename: "test_statement.pdf",
+              content_type: "application/pdf"
+            )
+          end
+        end
+        let(:entry) { create(:journal_entry, client: client, statement_batch: batch) }
+
+        it "証憑へのリンクが表示されること" do
+          get journal_entry_path(entry, client_code: client.code)
+          expect(response.body).to include("証憑を開く")
+          expect(response.body).to include(rails_blob_path(batch.pdf, disposition: "inline"))
+        end
+      end
+
+      context "証憑が添付されていない場合" do
+        let(:entry) { create(:journal_entry, client: client, statement_batch: nil) }
+
+        it "証憑へのリンクが表示されないこと" do
+          get journal_entry_path(entry, client_code: client.code)
+          expect(response.body).not_to include("証憑を開く")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 概要

仕訳詳細画面に、紐づく statement_batch の PDF（証憑）への別タブリンクを表示する。証憑が添付されている場合のみ「証憑」カードを表示し、N+1 を避けるため show で blob まで eager load する。

Closes #315
