### PR TITLE
feat(platform): Client業種をindustries配列でマルチ選択化 (issue#312)

### DIFF
--- a/rails/platform/app/controllers/clients_controller.rb
+++ b/rails/platform/app/controllers/clients_controller.rb
@@ -44,11 +44,11 @@ class ClientsController < ApplicationController
   private
 
   def create_params
-    params.require(:client).permit(:code, :name, :industry, :status)
+    params.require(:client).permit(:code, :name, :industry, :status, industries: [])
   end
 
   def update_params
-    params.require(:client).permit(:name, :industry, :status)
+    params.require(:client).permit(:name, :industry, :status, industries: [])
   end
 
   def record_not_found

--- a/rails/platform/app/models/client.rb
+++ b/rails/platform/app/models/client.rb
@@ -6,6 +6,13 @@ class Client < ApplicationRecord
     "inactive" => "無効"
   }.freeze
 
+  INDUSTRY_CODES = %w[restaurant hotel tour].freeze
+  INDUSTRY_LABELS = {
+    "restaurant" => "飲食業",
+    "hotel"      => "ホテル",
+    "tour"       => "ツアー",
+  }.freeze
+
   INDUSTRY_FEATURES = {
     "hotel"      => %w[cleaning_manuals],
     "restaurant" => %w[],
@@ -24,7 +31,8 @@ class Client < ApplicationRecord
   validates :code, presence: true, uniqueness: true
   validates :name, presence: true
   validates :status, inclusion: { in: STATUSES.keys }
-  validates :industry, inclusion: { in: %w[restaurant hotel tour] }, allow_nil: true
+  validates :industry, inclusion: { in: INDUSTRY_CODES }, allow_nil: true
+  validate :industries_must_be_valid
 
   # === スコープ ===
   scope :active, -> { where(status: "active") }
@@ -46,12 +54,23 @@ class Client < ApplicationRecord
     STATUSES[status]
   end
 
+  def industry_codes
+    industries.presence || Array(industry)
+  end
+
   def feature_available?(feature)
     key = feature.to_s
     if services.key?(key)
       services[key]
     else
-      INDUSTRY_FEATURES.fetch(industry.to_s, []).include?(key)
+      industry_codes.any? { |code| INDUSTRY_FEATURES.fetch(code, []).include?(key) }
     end
+  end
+
+  private
+
+  def industries_must_be_valid
+    invalid = industries - INDUSTRY_CODES
+    errors.add(:industries, "に無効な値が含まれています: #{invalid.join(', ')}") if invalid.any?
   end
 end

--- a/rails/platform/app/views/clients/_form.html.erb
+++ b/rails/platform/app/views/clients/_form.html.erb
@@ -22,11 +22,18 @@
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-gray-300 mb-1">業種</label>
-        <%= f.select :industry,
-              [["飲食業", "restaurant"], ["ホテル", "hotel"], ["ツアー", "tour"]],
-              { include_blank: "-- 選択してください --" },
-              class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
+        <label class="block text-sm font-medium text-gray-300 mb-2">業種（複数選択可）</label>
+        <%= f.hidden_field :industries, value: "" %>
+        <div class="space-y-2">
+          <% Client::INDUSTRY_LABELS.each do |code, label| %>
+            <label class="flex items-center gap-2 cursor-pointer">
+              <%= check_box_tag "client[industries][]", code, @client.industry_codes.include?(code),
+                    id: "client_industries_#{code}",
+                    class: "rounded border-gray-600 text-teal-500 focus:ring-teal-500" %>
+              <span class="text-sm text-gray-300"><%= label %></span>
+            </label>
+          <% end %>
+        </div>
       </div>
 
       <div>

--- a/rails/platform/app/views/clients/index.html.erb
+++ b/rails/platform/app/views/clients/index.html.erb
@@ -27,7 +27,7 @@
         <tr class="hover:bg-gray-800 cursor-pointer" onclick="window.location='<%= client_path(client) %>'">
           <td class="px-6 py-4 text-sm font-mono text-gray-100"><%= client.code %></td>
           <td class="px-6 py-4 text-sm font-medium text-gray-100"><%= client.name %></td>
-          <td class="px-6 py-4 text-sm text-gray-400"><%= client.industry.presence || "—" %></td>
+          <td class="px-6 py-4 text-sm text-gray-400"><%= client.industry_codes.map { |c| Client::INDUSTRY_LABELS[c] }.compact.join(" / ").presence || "—" %></td>
           <td class="px-6 py-4">
             <% if client.status == "active" %>
               <%= render "shared/badge", label: client.status_label, variant: :success %>

--- a/rails/platform/app/views/clients/show.html.erb
+++ b/rails/platform/app/views/clients/show.html.erb
@@ -8,8 +8,8 @@
         <p class="text-sm font-mono text-gray-400 mt-1"><%= @client.code %></p>
       </div>
       <div class="flex items-center gap-3">
-        <% if @client.industry.present? %>
-          <span class="text-sm text-gray-400"><%= @client.industry %></span>
+        <% if @client.industry_codes.any? %>
+          <span class="text-sm text-gray-400"><%= @client.industry_codes.map { |c| Client::INDUSTRY_LABELS[c] }.compact.join(" / ") %></span>
         <% end %>
         <% if @client.status == "active" %>
           <%= render "shared/badge", label: @client.status_label, variant: :success, size: :md %>

--- a/rails/platform/db/migrate/20260620014648_add_industries_to_clients.rb
+++ b/rails/platform/db/migrate/20260620014648_add_industries_to_clients.rb
@@ -1,0 +1,16 @@
+class AddIndustriesToClients < ActiveRecord::Migration[8.0]
+  def up
+    add_column :clients, :industries, :string, array: true, default: [], null: false,
+               comment: "業種（複数選択可）: restaurant / hotel / tour"
+
+    # 既存の単一 industry 値を 1 要素配列に移行
+    Client.reset_column_information
+    Client.where.not(industry: nil).find_each do |client|
+      client.update_columns(industries: [client.industry])
+    end
+  end
+
+  def down
+    remove_column :clients, :industries
+  end
+end

--- a/rails/platform/db/queue_schema.rb
+++ b/rails/platform/db/queue_schema.rb
@@ -1,4 +1,19 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
@@ -6,24 +21,24 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key", null: false
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
-    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
@@ -37,17 +52,17 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
-    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
-    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
-    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
     t.string "queue_name", null: false
     t.datetime "created_at", null: false
-    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
@@ -59,9 +74,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.text "metadata"
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
@@ -69,9 +84,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
-    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
@@ -79,8 +94,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "task_key", null: false
     t.datetime "run_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
@@ -95,8 +110,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
@@ -105,8 +120,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
@@ -115,9 +130,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/rails/platform/db/schema.rb
+++ b/rails/platform/db/schema.rb
@@ -10,8 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_11_105306) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_20_014648) do
+  create_schema "n8n"
+
   # These are extensions that must be enabled in order to support this database
+  enable_extension "n8n.uuid-ossp"
   enable_extension "pg_catalog.plpgsql"
 
   create_table "account_masters", force: :cascade do |t|
@@ -68,6 +71,32 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_105306) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["token_digest"], name: "index_api_tokens_on_token_digest", unique: true
+  end
+
+  create_table "audits", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.string "userid", limit: 26
+    t.string "action", limit: 512
+    t.string "extrainfo", limit: 1024
+    t.string "ipaddress", limit: 64
+    t.string "sessionid", limit: 26
+    t.index ["userid"], name: "idx_audits_user_id"
+  end
+
+  create_table "bots", primary_key: "userid", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "description", limit: 1024
+    t.string "ownerid", limit: 190
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.bigint "lasticonupdate"
+  end
+
+  create_table "channelmemberhistory", primary_key: ["channelid", "userid", "jointime"], force: :cascade do |t|
+    t.string "channelid", limit: 26, null: false
+    t.string "userid", limit: 26, null: false
+    t.bigint "jointime", null: false
+    t.bigint "leavetime"
   end
 
   create_table "cleaning_manuals", force: :cascade do |t|
@@ -137,8 +166,149 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_105306) do
     t.string "status", default: "active", comment: "ステータス: active / trial / inactive"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "industries", default: [], null: false, comment: "業種（複数選択可）: restaurant / hotel / tour", array: true
     t.index ["code"], name: "idx_clients_code", unique: true
     t.index ["services"], name: "idx_clients_services", using: :gin
+  end
+
+  create_table "clusterdiscovery", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "type", limit: 64
+    t.string "clustername", limit: 64
+    t.string "hostname", limit: 512
+    t.integer "gossipport"
+    t.integer "port"
+    t.bigint "createat"
+    t.bigint "lastpingat"
+  end
+
+  create_table "commands", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "token", limit: 26
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "creatorid", limit: 26
+    t.string "teamid", limit: 26
+    t.string "trigger", limit: 128
+    t.string "method", limit: 1
+    t.string "username", limit: 64
+    t.string "iconurl", limit: 1024
+    t.boolean "autocomplete"
+    t.string "autocompletedesc", limit: 1024
+    t.string "autocompletehint", limit: 1024
+    t.string "displayname", limit: 64
+    t.string "description", limit: 128
+    t.string "url", limit: 1024
+    t.string "pluginid", limit: 190
+    t.index ["createat"], name: "idx_command_create_at"
+    t.index ["deleteat"], name: "idx_command_delete_at"
+    t.index ["teamid"], name: "idx_command_team_id"
+    t.index ["updateat"], name: "idx_command_update_at"
+  end
+
+  create_table "commandwebhooks", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.string "commandid", limit: 26
+    t.string "userid", limit: 26
+    t.string "channelid", limit: 26
+    t.string "rootid", limit: 26
+    t.string "parentid", limit: 26
+    t.integer "usecount"
+    t.index ["createat"], name: "idx_command_webhook_create_at"
+  end
+
+  create_table "compliances", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.string "userid", limit: 26
+    t.string "status", limit: 64
+    t.integer "count"
+    t.string "desc", limit: 512
+    t.string "type", limit: 64
+    t.bigint "startat"
+    t.bigint "endat"
+    t.string "keywords", limit: 512
+    t.string "emails", limit: 1024
+  end
+
+  create_table "db_lock", id: { type: :string, limit: 64 }, force: :cascade do |t|
+    t.bigint "expireat"
+  end
+
+  create_table "db_migrations", primary_key: "version", id: :bigint, default: nil, force: :cascade do |t|
+    t.string "name", null: false
+  end
+
+  create_table "emoji", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "creatorid", limit: 26
+    t.string "name", limit: 64
+    t.index ["createat"], name: "idx_emoji_create_at"
+    t.index ["deleteat"], name: "idx_emoji_delete_at"
+    t.index ["updateat"], name: "idx_emoji_update_at"
+    t.unique_constraint ["name", "deleteat"], name: "emoji_name_deleteat_key"
+  end
+
+  create_table "groupchannels", primary_key: ["groupid", "channelid"], force: :cascade do |t|
+    t.string "groupid", limit: 26, null: false
+    t.boolean "autoadd"
+    t.boolean "schemeadmin"
+    t.bigint "createat"
+    t.bigint "deleteat"
+    t.bigint "updateat"
+    t.string "channelid", limit: 26, null: false
+    t.index ["channelid"], name: "idx_groupchannels_channelid"
+  end
+
+  create_table "groupmembers", primary_key: ["groupid", "userid"], force: :cascade do |t|
+    t.string "groupid", limit: 26, null: false
+    t.string "userid", limit: 26, null: false
+    t.bigint "createat"
+    t.bigint "deleteat"
+    t.index ["createat"], name: "idx_groupmembers_create_at"
+  end
+
+  create_table "groupteams", primary_key: ["groupid", "teamid"], force: :cascade do |t|
+    t.string "groupid", limit: 26, null: false
+    t.boolean "autoadd"
+    t.boolean "schemeadmin"
+    t.bigint "createat"
+    t.bigint "deleteat"
+    t.bigint "updateat"
+    t.string "teamid", limit: 26, null: false
+    t.index ["schemeadmin"], name: "idx_groupteams_schemeadmin"
+    t.index ["teamid"], name: "idx_groupteams_teamid"
+  end
+
+  create_table "incomingwebhooks", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "userid", limit: 26
+    t.string "channelid", limit: 26
+    t.string "teamid", limit: 26
+    t.string "displayname", limit: 64
+    t.string "description", limit: 500
+    t.string "username", limit: 255
+    t.string "iconurl", limit: 1024
+    t.boolean "channellocked"
+    t.index ["createat"], name: "idx_incoming_webhook_create_at"
+    t.index ["deleteat"], name: "idx_incoming_webhook_delete_at"
+    t.index ["teamid"], name: "idx_incoming_webhook_team_id"
+    t.index ["updateat"], name: "idx_incoming_webhook_update_at"
+    t.index ["userid"], name: "idx_incoming_webhook_user_id"
+  end
+
+  create_table "jobs", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "type", limit: 32
+    t.bigint "priority"
+    t.bigint "createat"
+    t.bigint "startat"
+    t.bigint "lastactivityat"
+    t.string "status", limit: 32
+    t.bigint "progress"
+    t.string "data", limit: 1024
+    t.index ["type"], name: "idx_jobs_type"
   end
 
   create_table "journal_entries", force: :cascade do |t|
@@ -165,15 +335,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_105306) do
     t.index ["status"], name: "idx_journal_entries_review_required", where: "((status)::text = 'review_required'::text)"
   end
 
-  create_table "line_followers", force: :cascade do |t|
-    t.bigint "client_id", null: false
-    t.string "line_user_id", null: false, comment: "LINE user ID"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["client_id"], name: "index_line_followers_on_client_id"
-    t.index ["line_user_id"], name: "index_line_followers_on_line_user_id", unique: true
-  end
-
   create_table "journal_entry_lines", force: :cascade do |t|
     t.bigint "journal_entry_id", null: false, comment: "仕訳"
     t.string "side", null: false, comment: "借方/貸方: debit / credit"
@@ -188,6 +349,273 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_105306) do
     t.datetime "updated_at", null: false
     t.index ["journal_entry_id", "side"], name: "idx_journal_entry_lines_entry_side"
     t.index ["journal_entry_id"], name: "index_journal_entry_lines_on_journal_entry_id"
+  end
+
+  create_table "licenses", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.string "bytes", limit: 10000
+  end
+
+  create_table "line_followers", force: :cascade do |t|
+    t.bigint "client_id", null: false
+    t.string "line_user_id", null: false, comment: "LINE user ID"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_id"], name: "index_line_followers_on_client_id"
+    t.index ["line_user_id"], name: "index_line_followers_on_line_user_id", unique: true
+  end
+
+  create_table "linkmetadata", primary_key: "hash", id: :bigint, default: nil, force: :cascade do |t|
+    t.string "url", limit: 2048
+    t.bigint "timestamp"
+    t.string "type", limit: 16
+    t.string "data", limit: 4096
+    t.index ["url", "timestamp"], name: "idx_link_metadata_url_timestamp"
+  end
+
+  create_table "oauthaccessdata", primary_key: "token", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "refreshtoken", limit: 26
+    t.string "redirecturi", limit: 256
+    t.string "clientid", limit: 26
+    t.string "userid", limit: 26
+    t.bigint "expiresat"
+    t.string "scope", limit: 128
+    t.index ["refreshtoken"], name: "idx_oauthaccessdata_refresh_token"
+    t.index ["userid"], name: "idx_oauthaccessdata_user_id"
+    t.unique_constraint ["clientid", "userid"], name: "oauthaccessdata_clientid_userid_key"
+  end
+
+  create_table "oauthauthdata", primary_key: "code", id: { type: :string, limit: 128 }, force: :cascade do |t|
+    t.string "clientid", limit: 26
+    t.string "userid", limit: 26
+    t.integer "expiresin"
+    t.bigint "createat"
+    t.string "redirecturi", limit: 256
+    t.string "state", limit: 1024
+    t.string "scope", limit: 128
+  end
+
+  create_table "outgoingwebhooks", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "token", limit: 26
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "creatorid", limit: 26
+    t.string "channelid", limit: 26
+    t.string "teamid", limit: 26
+    t.string "triggerwords", limit: 1024
+    t.string "callbackurls", limit: 1024
+    t.string "displayname", limit: 64
+    t.string "contenttype", limit: 128
+    t.integer "triggerwhen"
+    t.string "username", limit: 64
+    t.string "iconurl", limit: 1024
+    t.string "description", limit: 500
+    t.index ["createat"], name: "idx_outgoing_webhook_create_at"
+    t.index ["deleteat"], name: "idx_outgoing_webhook_delete_at"
+    t.index ["teamid"], name: "idx_outgoing_webhook_team_id"
+    t.index ["updateat"], name: "idx_outgoing_webhook_update_at"
+  end
+
+  create_table "pluginkeyvaluestore", primary_key: ["pluginid", "pkey"], force: :cascade do |t|
+    t.string "pluginid", limit: 190, null: false
+    t.string "pkey", limit: 50, null: false
+    t.binary "pvalue"
+    t.bigint "expireat"
+  end
+
+  create_table "posts", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "userid", limit: 26
+    t.string "channelid", limit: 26
+    t.string "rootid", limit: 26
+    t.string "parentid", limit: 26
+    t.string "originalid", limit: 26
+    t.string "message", limit: 65535
+    t.string "type", limit: 26
+    t.string "props", limit: 8000
+    t.string "hashtags", limit: 1000
+    t.string "filenames", limit: 4000
+    t.string "fileids", limit: 300
+    t.boolean "hasreactions"
+    t.bigint "editat"
+    t.boolean "ispinned"
+    t.string "remoteid", limit: 26
+    t.index "to_tsvector('english'::regconfig, (hashtags)::text)", name: "idx_posts_hashtags_txt", using: :gin
+    t.index "to_tsvector('english'::regconfig, (message)::text)", name: "idx_posts_message_txt", using: :gin
+    t.index ["channelid", "deleteat", "createat"], name: "idx_posts_channel_id_delete_at_create_at"
+    t.index ["channelid", "updateat"], name: "idx_posts_channel_id_update_at"
+    t.index ["createat"], name: "idx_posts_create_at"
+    t.index ["deleteat"], name: "idx_posts_delete_at"
+    t.index ["ispinned"], name: "idx_posts_is_pinned"
+    t.index ["rootid"], name: "idx_posts_root_id"
+    t.index ["updateat"], name: "idx_posts_update_at"
+    t.index ["userid"], name: "idx_posts_user_id"
+  end
+
+  create_table "preferences", primary_key: ["userid", "category", "name"], force: :cascade do |t|
+    t.string "userid", limit: 26, null: false
+    t.string "category", limit: 32, null: false
+    t.string "name", limit: 32, null: false
+    t.string "value", limit: 2000
+    t.index ["category"], name: "idx_preferences_category"
+    t.index ["name"], name: "idx_preferences_name"
+  end
+
+  create_table "productnoticeviewstate", primary_key: ["userid", "noticeid"], force: :cascade do |t|
+    t.string "userid", limit: 26, null: false
+    t.string "noticeid", limit: 26, null: false
+    t.integer "viewed"
+    t.bigint "timestamp"
+    t.index ["noticeid"], name: "idx_notice_views_notice_id"
+    t.index ["timestamp"], name: "idx_notice_views_timestamp"
+  end
+
+  create_table "reactions", primary_key: ["postid", "userid", "emojiname"], force: :cascade do |t|
+    t.string "userid", limit: 26, null: false
+    t.string "postid", limit: 26, null: false
+    t.string "emojiname", limit: 64, null: false
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "remoteid", limit: 26
+  end
+
+  create_table "remoteclusters", primary_key: ["remoteid", "name"], force: :cascade do |t|
+    t.string "remoteid", limit: 26, null: false
+    t.string "remoteteamid", limit: 26
+    t.string "name", limit: 64, null: false
+    t.string "displayname", limit: 64
+    t.string "siteurl", limit: 512
+    t.bigint "createat"
+    t.bigint "lastpingat"
+    t.string "token", limit: 26
+    t.string "remotetoken", limit: 26
+    t.string "topics", limit: 512
+    t.string "creatorid", limit: 26
+    t.index ["siteurl", "remoteteamid"], name: "remote_clusters_site_url_unique", unique: true
+  end
+
+  create_table "roles", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "name", limit: 64
+    t.string "displayname", limit: 128
+    t.string "description", limit: 1024
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.text "permissions"
+    t.boolean "schememanaged"
+    t.boolean "builtin"
+
+    t.unique_constraint ["name"], name: "roles_name_key"
+  end
+
+  create_table "schemes", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "name", limit: 64
+    t.string "displayname", limit: 128
+    t.string "description", limit: 1024
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "scope", limit: 32
+    t.string "defaultteamadminrole", limit: 64
+    t.string "defaultteamuserrole", limit: 64
+    t.string "defaultchanneladminrole", limit: 64
+    t.string "defaultchanneluserrole", limit: 64
+    t.string "defaultteamguestrole", limit: 64
+    t.string "defaultchannelguestrole", limit: 64
+    t.index ["defaultchanneladminrole"], name: "idx_schemes_channel_admin_role"
+    t.index ["defaultchannelguestrole"], name: "idx_schemes_channel_guest_role"
+    t.index ["defaultchanneluserrole"], name: "idx_schemes_channel_user_role"
+    t.unique_constraint ["name"], name: "schemes_name_key"
+  end
+
+  create_table "sessions", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "token", limit: 26
+    t.bigint "createat"
+    t.bigint "expiresat"
+    t.bigint "lastactivityat"
+    t.string "userid", limit: 26
+    t.string "deviceid", limit: 512
+    t.string "roles", limit: 64
+    t.boolean "isoauth"
+    t.string "props", limit: 1000
+    t.boolean "expirednotify"
+    t.index ["createat"], name: "idx_sessions_create_at"
+    t.index ["expiresat"], name: "idx_sessions_expires_at"
+    t.index ["lastactivityat"], name: "idx_sessions_last_activity_at"
+    t.index ["token"], name: "idx_sessions_token"
+    t.index ["userid"], name: "idx_sessions_user_id"
+  end
+
+  create_table "sharedchannelattachments", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "fileid", limit: 26
+    t.string "remoteid", limit: 26
+    t.bigint "createat"
+    t.bigint "lastsyncat"
+
+    t.unique_constraint ["fileid", "remoteid"], name: "sharedchannelattachments_fileid_remoteid_key"
+  end
+
+  create_table "sharedchannelremotes", primary_key: ["id", "channelid"], force: :cascade do |t|
+    t.string "id", limit: 26, null: false
+    t.string "channelid", limit: 26, null: false
+    t.string "creatorid", limit: 26
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.boolean "isinviteaccepted"
+    t.boolean "isinviteconfirmed"
+    t.string "remoteid", limit: 26
+    t.bigint "lastpostupdateat"
+    t.string "lastpostid", limit: 26
+
+    t.unique_constraint ["channelid", "remoteid"], name: "sharedchannelremotes_channelid_remoteid_key"
+  end
+
+  create_table "sharedchannels", primary_key: "channelid", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "teamid", limit: 26
+    t.boolean "home"
+    t.boolean "readonly"
+    t.string "sharename", limit: 64
+    t.string "sharedisplayname", limit: 64
+    t.string "sharepurpose", limit: 250
+    t.string "shareheader", limit: 1024
+    t.string "creatorid", limit: 26
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.string "remoteid", limit: 26
+
+    t.unique_constraint ["sharename", "teamid"], name: "sharedchannels_sharename_teamid_key"
+  end
+
+  create_table "sharedchannelusers", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "userid", limit: 26
+    t.string "remoteid", limit: 26
+    t.bigint "createat"
+    t.bigint "lastsyncat"
+    t.string "channelid", limit: 26
+    t.index ["remoteid"], name: "idx_sharedchannelusers_remote_id"
+    t.unique_constraint ["userid", "channelid", "remoteid"], name: "sharedchannelusers_userid_channelid_remoteid_key"
+  end
+
+  create_table "sidebarcategories", id: { type: :string, limit: 128 }, force: :cascade do |t|
+    t.string "userid", limit: 26
+    t.string "teamid", limit: 26
+    t.bigint "sortorder"
+    t.string "sorting", limit: 64
+    t.string "type", limit: 64
+    t.string "displayname", limit: 64
+    t.boolean "muted"
+    t.boolean "collapsed"
+  end
+
+  create_table "sidebarchannels", primary_key: ["channelid", "userid", "categoryid"], force: :cascade do |t|
+    t.string "channelid", limit: 26, null: false
+    t.string "userid", limit: 26, null: false
+    t.string "categoryid", limit: 128, null: false
+    t.bigint "sortorder"
   end
 
   create_table "statement_batches", force: :cascade do |t|
@@ -205,6 +633,128 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_105306) do
     t.index ["status"], name: "index_statement_batches_on_status"
   end
 
+  create_table "status", primary_key: "userid", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "status", limit: 32
+    t.boolean "manual"
+    t.bigint "lastactivityat"
+    t.bigint "dndendtime"
+    t.string "prevstatus", limit: 32
+    t.index ["status"], name: "idx_status_status"
+  end
+
+  create_table "systems", primary_key: "name", id: { type: :string, limit: 64 }, force: :cascade do |t|
+    t.string "value", limit: 1024
+  end
+
+  create_table "teammembers", primary_key: ["teamid", "userid"], force: :cascade do |t|
+    t.string "teamid", limit: 26, null: false
+    t.string "userid", limit: 26, null: false
+    t.string "roles", limit: 64
+    t.bigint "deleteat"
+    t.boolean "schemeuser"
+    t.boolean "schemeadmin"
+    t.boolean "schemeguest"
+    t.index ["deleteat"], name: "idx_teammembers_delete_at"
+    t.index ["userid"], name: "idx_teammembers_user_id"
+  end
+
+  create_table "teams", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.string "displayname", limit: 64
+    t.string "name", limit: 64
+    t.string "description", limit: 255
+    t.string "email", limit: 128
+    t.string "type", limit: 255
+    t.string "companyname", limit: 64
+    t.string "alloweddomains", limit: 1000
+    t.string "inviteid", limit: 32
+    t.string "schemeid", limit: 26
+    t.boolean "allowopeninvite"
+    t.bigint "lastteamiconupdate"
+    t.boolean "groupconstrained"
+    t.index ["createat"], name: "idx_teams_create_at"
+    t.index ["deleteat"], name: "idx_teams_delete_at"
+    t.index ["inviteid"], name: "idx_teams_invite_id"
+    t.index ["schemeid"], name: "idx_teams_scheme_id"
+    t.index ["updateat"], name: "idx_teams_update_at"
+    t.unique_constraint ["name"], name: "teams_name_key"
+  end
+
+  create_table "termsofservice", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.string "userid", limit: 26
+    t.string "text", limit: 65535
+  end
+
+  create_table "threadmemberships", primary_key: ["postid", "userid"], force: :cascade do |t|
+    t.string "postid", limit: 26, null: false
+    t.string "userid", limit: 26, null: false
+    t.boolean "following"
+    t.bigint "lastviewed"
+    t.bigint "lastupdated"
+    t.bigint "unreadmentions"
+    t.index ["lastupdated"], name: "idx_thread_memberships_last_update_at"
+    t.index ["lastviewed"], name: "idx_thread_memberships_last_view_at"
+    t.index ["userid"], name: "idx_thread_memberships_user_id"
+  end
+
+  create_table "threads", primary_key: "postid", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.bigint "replycount"
+    t.bigint "lastreplyat"
+    t.text "participants"
+    t.string "channelid", limit: 26
+    t.index ["channelid"], name: "idx_threads_channel_id"
+  end
+
+  create_table "tokens", primary_key: "token", id: { type: :string, limit: 64 }, force: :cascade do |t|
+    t.bigint "createat"
+    t.string "type", limit: 64
+    t.string "extra", limit: 2048
+  end
+
+  create_table "uploadsessions", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "type", limit: 32
+    t.bigint "createat"
+    t.string "userid", limit: 26
+    t.string "channelid", limit: 26
+    t.string "filename", limit: 256
+    t.string "path", limit: 512
+    t.bigint "filesize"
+    t.bigint "fileoffset"
+    t.string "remoteid", limit: 26
+    t.string "reqfileid", limit: 26
+    t.index ["createat"], name: "idx_uploadsessions_create_at"
+    t.index ["type"], name: "idx_uploadsessions_type"
+    t.index ["userid"], name: "idx_uploadsessions_user_id"
+  end
+
+  create_table "useraccesstokens", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "token", limit: 26
+    t.string "userid", limit: 26
+    t.string "description", limit: 512
+    t.boolean "isactive"
+    t.index ["userid"], name: "idx_user_access_tokens_user_id"
+    t.unique_constraint ["token"], name: "useraccesstokens_token_key"
+  end
+
+  create_table "usergroups", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "name", limit: 64
+    t.string "displayname", limit: 128
+    t.string "description", limit: 1024
+    t.string "source", limit: 64
+    t.string "remoteid", limit: 48
+    t.bigint "createat"
+    t.bigint "updateat"
+    t.bigint "deleteat"
+    t.boolean "allowreference"
+    t.index ["deleteat"], name: "idx_usergroups_delete_at"
+    t.index ["remoteid"], name: "idx_usergroups_remote_id"
+    t.unique_constraint ["name"], name: "usergroups_name_key"
+    t.unique_constraint ["source", "remoteid"], name: "usergroups_source_remoteid_key"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -215,6 +765,11 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_105306) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "usertermsofservice", primary_key: "userid", id: { type: :string, limit: 26 }, force: :cascade do |t|
+    t.string "termsofserviceid", limit: 26
+    t.bigint "createat"
   end
 
   add_foreign_key "account_masters", "clients"

--- a/rails/platform/spec/factories/clients.rb
+++ b/rails/platform/spec/factories/clients.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     trait :hotel do
       industry { "hotel" }
+      industries { %w[hotel] }
     end
 
     trait :inactive do

--- a/rails/platform/spec/models/client_spec.rb
+++ b/rails/platform/spec/models/client_spec.rb
@@ -65,6 +65,29 @@ RSpec.describe Client, type: :model do
         expect(subject.errors[:industry]).to be_present
       end
     end
+
+    describe "industries" do
+      it "空配列は有効" do
+        subject.industries = []
+        expect(subject).to be_valid
+      end
+
+      it "有効な業種コードの配列は有効" do
+        subject.industries = %w[restaurant hotel]
+        expect(subject).to be_valid
+      end
+
+      it "全業種コードの配列は有効" do
+        subject.industries = %w[restaurant hotel tour]
+        expect(subject).to be_valid
+      end
+
+      it "無効なコードが含まれる場合エラー" do
+        subject.industries = %w[restaurant invalid]
+        expect(subject).not_to be_valid
+        expect(subject.errors[:industries]).to be_present
+      end
+    end
   end
 
   describe "#to_param" do
@@ -160,25 +183,47 @@ RSpec.describe Client, type: :model do
     end
   end
 
+  describe "#industry_codes" do
+    it "industriesが設定されている場合はindustriesを返す" do
+      client = build(:client, industries: %w[restaurant hotel], industry: "restaurant")
+      expect(client.industry_codes).to eq(%w[restaurant hotel])
+    end
+
+    it "industriesが空の場合はindustryを1要素配列で返す" do
+      client = build(:client, industries: [], industry: "hotel")
+      expect(client.industry_codes).to eq(%w[hotel])
+    end
+
+    it "industriesもindustryもない場合は空配列を返す" do
+      client = build(:client, industries: [], industry: nil)
+      expect(client.industry_codes).to eq([])
+    end
+  end
+
   describe "#feature_available?" do
-    describe "業種デフォルト" do
-      it "hotelクライアントはcleaning_manualsが利用可能" do
-        client = build(:client, :hotel, services: {})
+    describe "業種デフォルト（industries利用）" do
+      it "hotel入りのクライアントはcleaning_manualsが利用可能" do
+        client = build(:client, industries: %w[hotel], industry: nil, services: {})
         expect(client.feature_available?(:cleaning_manuals)).to be true
       end
 
-      it "restaurantクライアントはcleaning_manualsが利用不可" do
-        client = build(:client, industry: "restaurant", services: {})
+      it "hotel+restaurantのマルチ業種はcleaning_manualsが利用可能（OR集約）" do
+        client = build(:client, industries: %w[restaurant hotel], industry: nil, services: {})
+        expect(client.feature_available?(:cleaning_manuals)).to be true
+      end
+
+      it "restaurant・tourのみはcleaning_manualsが利用不可" do
+        client = build(:client, industries: %w[restaurant tour], industry: nil, services: {})
         expect(client.feature_available?(:cleaning_manuals)).to be false
       end
 
-      it "tourクライアントはcleaning_manualsが利用不可" do
-        client = build(:client, industry: "tour", services: {})
-        expect(client.feature_available?(:cleaning_manuals)).to be false
+      it "industriesが空の場合はindustryにフォールバック" do
+        client = build(:client, :hotel, industries: [], services: {})
+        expect(client.feature_available?(:cleaning_manuals)).to be true
       end
 
       it "industry未設定のクライアントはcleaning_manualsが利用不可" do
-        client = build(:client, industry: nil, services: {})
+        client = build(:client, industries: [], industry: nil, services: {})
         expect(client.feature_available?(:cleaning_manuals)).to be false
       end
     end

--- a/rails/platform/spec/requests/web/clients_spec.rb
+++ b/rails/platform/spec/requests/web/clients_spec.rb
@@ -133,14 +133,20 @@ RSpec.describe "Web::Clients", type: :request do
 
       it "正常なパラメータで作成できること" do
         expect {
-          post clients_path, params: { client: { code: "new_client", name: "新規社", industry: "hotel", status: "active" } }
+          post clients_path, params: { client: { code: "new_client", name: "新規社", industries: %w[hotel], status: "active" } }
         }.to change(Client, :count).by(1)
 
         client = Client.find_by(code: "new_client")
         expect(response).to redirect_to(client_path(client))
         expect(client.name).to eq("新規社")
-        expect(client.industry).to eq("hotel")
+        expect(client.industries).to eq(%w[hotel])
         expect(client.status).to eq("active")
+      end
+
+      it "複数業種を同時に作成できること" do
+        post clients_path, params: { client: { code: "multi_ind", name: "複合社", industries: %w[hotel restaurant], status: "active" } }
+        client = Client.find_by(code: "multi_ind")
+        expect(client.industries).to contain_exactly("hotel", "restaurant")
       end
 
       it "バリデーションエラー時にフォームが再表示されること" do
@@ -202,11 +208,17 @@ RSpec.describe "Web::Clients", type: :request do
       before { sign_in user }
 
       it "正常に更新できること" do
-        patch client_path(client), params: { client: { name: "更新後社", industry: "tour" } }
+        patch client_path(client), params: { client: { name: "更新後社", industries: %w[tour] } }
         expect(response).to redirect_to(client_path(client))
         client.reload
         expect(client.name).to eq("更新後社")
-        expect(client.industry).to eq("tour")
+        expect(client.industries).to eq(%w[tour])
+      end
+
+      it "複数業種に更新できること" do
+        patch client_path(client), params: { client: { industries: %w[hotel tour] } }
+        client.reload
+        expect(client.industries).to contain_exactly("hotel", "tour")
       end
 
       it "codeが変更されないこと" do


### PR DESCRIPTION
## 概要

`clients.industry`（単一 string）を `clients.industries`（PostgreSQL string 配列）に拡張し、複数業種の同時選択を可能にする。既存の `industry` 値は 1 要素配列に移行し、`INDUSTRY_FEATURES` の機能判定は OR 集約方式（いずれかの業種が対象機能を持てば利用可）に変更。フォームをチェックボックス形式のマルチセレクトに変更。

Closes #312
