### PR TITLE
feat(platform): PDF保存後にYYYYMMDD_支払先_内容形式にリネーム (issue#316)

### DIFF
--- a/rails/platform/app/jobs/amex_statement_process_job.rb
+++ b/rails/platform/app/jobs/amex_statement_process_job.rb
@@ -32,6 +32,7 @@ class AmexStatementProcessJob < ApplicationJob
             error_message: nil
           )
         end
+        rename_batch_pdf(batch, result.data)
       rescue ActiveRecord::RecordInvalid => e
         batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end

--- a/rails/platform/app/jobs/bank_statement_process_job.rb
+++ b/rails/platform/app/jobs/bank_statement_process_job.rb
@@ -32,6 +32,7 @@ class BankStatementProcessJob < ApplicationJob
             error_message: nil
           )
         end
+        rename_batch_pdf(batch, result.data)
       rescue ActiveRecord::RecordInvalid => e
         batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end

--- a/rails/platform/app/jobs/concerns/journal_entry_creator.rb
+++ b/rails/platform/app/jobs/concerns/journal_entry_creator.rb
@@ -112,10 +112,11 @@ module JournalEntryCreator
     return unless batch.pdf.attached?
 
     date, vendor, description, ext = extract_pdf_rename_parts(batch, data)
-    filename = StatementBatch.build_pdf_filename(date: date, vendor: vendor, description: description, ext: ext)
+    original  = batch.pdf.filename.to_s
+    filename  = StatementBatch.build_pdf_filename(date: date, vendor: vendor, description: description, ext: ext)
     batch.pdf.blob.update!(filename: filename)
-  rescue => e
-    Rails.logger.warn("[PdfRenamer] batch #{batch.id}: #{e.message}")
+  rescue ActiveRecord::ActiveRecordError, ActiveStorage::Error => e
+    Rails.logger.warn("[PdfRenamer] batch #{batch.id} rename failed (#{original.inspect} → #{filename.inspect}): #{e.class}: #{e.message}")
   end
 
   def extract_pdf_rename_parts(batch, data)

--- a/rails/platform/app/jobs/concerns/journal_entry_creator.rb
+++ b/rails/platform/app/jobs/concerns/journal_entry_creator.rb
@@ -105,4 +105,55 @@ module JournalEntryCreator
       scope.where(journal_entry_lines: { partner: partner }).first
     end
   end
+
+  # AI処理成功後に batch.pdf の blob.filename を命名規約に揃える（ADR 0009-G）。
+  # blob 更新失敗は警告ログのみ。仕訳保存とは独立してトランザクション外で呼ぶこと。
+  def rename_batch_pdf(batch, data)
+    return unless batch.pdf.attached?
+
+    date, vendor, description, ext = extract_pdf_rename_parts(batch, data)
+    filename = StatementBatch.build_pdf_filename(date: date, vendor: vendor, description: description, ext: ext)
+    batch.pdf.blob.update!(filename: filename)
+  rescue => e
+    Rails.logger.warn("[PdfRenamer] batch #{batch.id}: #{e.message}")
+  end
+
+  def extract_pdf_rename_parts(batch, data)
+    ext = batch.pdf.filename.extension_without_delimiter
+    first_txn = data[:transactions]&.first || {}
+
+    case batch.source_type
+    when "amex"
+      date   = parse_statement_period_to_yyyymm(data[:statement_period])
+      vendor = "アメックス"
+      desc   = "明細"
+    when "bank"
+      date   = parse_statement_period_to_yyyymm(data[:statement_period])
+      vendor = first_txn[:debit_partner].to_s.presence || "銀行"
+      desc   = "明細"
+    when "invoice"
+      date   = data[:invoice_date].to_s
+      vendor = data[:vendor_name].to_s
+      desc   = first_txn[:description].to_s.presence || "請求書"
+    when "receipt"
+      date   = data[:receipt_date].to_s
+      vendor = data[:vendor_name].to_s.presence || first_txn[:debit_partner].to_s
+      desc   = first_txn[:description].to_s.presence || "領収書"
+    else
+      return ["000000", batch.source_type, "", ext]
+    end
+
+    [date, vendor, desc, ext]
+  end
+
+  def parse_statement_period_to_yyyymm(period)
+    return "000000" if period.blank?
+
+    # "2026年5月" → "202605"
+    if period =~ /(\d{4})年(\d{1,2})月/
+      format("%04d%02d", $1.to_i, $2.to_i)
+    else
+      period.gsub(/[^\d]/, "").first(6).presence || "000000"
+    end
+  end
 end

--- a/rails/platform/app/jobs/invoice_process_job.rb
+++ b/rails/platform/app/jobs/invoice_process_job.rb
@@ -32,6 +32,7 @@ class InvoiceProcessJob < ApplicationJob
             error_message: nil
           )
         end
+        rename_batch_pdf(batch, result.data)
       rescue ActiveRecord::RecordInvalid => e
         batch.update(status: "failed", error_message: "仕訳データの保存に失敗: #{e.message}")
       end

--- a/rails/platform/app/jobs/receipt_line_process_job.rb
+++ b/rails/platform/app/jobs/receipt_line_process_job.rb
@@ -84,6 +84,7 @@ class ReceiptLineProcessJob < ApplicationJob
           create_journal_entries(batch, result.data)
           batch.update!(status: "completed", summary: result.data[:summary] || {})
         end
+        rename_batch_pdf(batch, result.data)
 
         @line_service.push(line_user_id, format_success_message(result.data))
       rescue DuplicateFound => e

--- a/rails/platform/app/jobs/receipt_process_job.rb
+++ b/rails/platform/app/jobs/receipt_process_job.rb
@@ -32,6 +32,7 @@ class ReceiptProcessJob < ApplicationJob
             error_message: nil
           )
         end
+        rename_batch_pdf(batch, result.data)
       rescue DuplicateFound => e
         batch.update!(status: "duplicate", error_message: "重複検知: 既存 JE id=#{e.existing_entry.id}")
       rescue ActiveRecord::RecordInvalid => e

--- a/rails/platform/app/models/statement_batch.rb
+++ b/rails/platform/app/models/statement_batch.rb
@@ -1,6 +1,21 @@
 class StatementBatch < ApplicationRecord
   STATUSES = %w[processing completed failed duplicate].freeze
 
+  VENDOR_MAX_LEN = 30
+  DESCRIPTION_MAX_LEN = 30
+
+  # ファイル名規約: YYYYMMDD_支払先_内容.ext（ADR 0009-G）
+  # date は "YYYY-MM-DD" / "YYYYMM" / "YYYYMMDD" のいずれでも可（ハイフンを除去して使用）。
+  def self.build_pdf_filename(date:, vendor:, description:, ext:)
+    sanitize = ->(s) { s.to_s.unicode_normalize(:nfc).gsub(/[\/\\\:\*\?"<>\|　]/, "_").gsub(/\s+/, "_").strip }
+    date_str   = date.to_s.gsub("-", "").first(8).presence || "000000"
+    vendor_str = sanitize.(vendor).first(VENDOR_MAX_LEN).presence
+    desc_str   = sanitize.(description).first(DESCRIPTION_MAX_LEN).presence
+    ext_str    = ext.to_s.sub(/\A\./, "").presence || "pdf"
+    parts      = [date_str, vendor_str, desc_str].compact
+    "#{parts.join("_")}.#{ext_str}"
+  end
+
   # 取り込み（new → attach → save）が失敗したときに raise する。cause_error に元例外を保持する。
   class IngestError < StandardError
     attr_reader :cause_error

--- a/rails/platform/spec/models/statement_batch_spec.rb
+++ b/rails/platform/spec/models/statement_batch_spec.rb
@@ -106,6 +106,61 @@ RSpec.describe StatementBatch, type: :model do
     end
   end
 
+  describe ".build_pdf_filename (ADR 0009-G)" do
+    it "基本パターン: YYYYMMDD_支払先_内容.ext を返す" do
+      result = described_class.build_pdf_filename(
+        date: "2026-06-20", vendor: "サンプル商会", description: "消耗品費", ext: "pdf"
+      )
+      expect(result).to eq("20260620_サンプル商会_消耗品費.pdf")
+    end
+
+    it "YYYYMM形式の日付もそのまま使う" do
+      result = described_class.build_pdf_filename(
+        date: "202606", vendor: "アメックス", description: "明細", ext: "pdf"
+      )
+      expect(result).to eq("202606_アメックス_明細.pdf")
+    end
+
+    it "ファイル名禁止文字をアンダースコアに置換する" do
+      result = described_class.build_pdf_filename(
+        date: "20260620", vendor: "A/B社", description: "請求:書", ext: "pdf"
+      )
+      expect(result).to include("A_B社")
+      expect(result).to include("請求_書")
+    end
+
+    it "vendor・descriptionを30文字でトランケートする" do
+      long_vendor = "あ" * 40
+      result = described_class.build_pdf_filename(
+        date: "20260620", vendor: long_vendor, description: "内容", ext: "pdf"
+      )
+      parts = result.split("_")
+      expect(parts[1].length).to be <= 30
+    end
+
+    it "vendorが空の場合はdescriptionのみ付与する" do
+      result = described_class.build_pdf_filename(
+        date: "20260620", vendor: "", description: "明細", ext: "pdf"
+      )
+      expect(result).to eq("20260620_明細.pdf")
+    end
+
+    it "vendor・descriptionが両方空の場合は日付のみ" do
+      result = described_class.build_pdf_filename(
+        date: "20260620", vendor: "", description: "", ext: "pdf"
+      )
+      expect(result).to eq("20260620.pdf")
+    end
+
+    it "extにドットが付いていても正規化する" do
+      result = described_class.build_pdf_filename(
+        date: "20260620", vendor: "商会", description: "領収書", ext: ".jpg"
+      )
+      expect(result).to end_with(".jpg")
+      expect(result).not_to include("..jpg")
+    end
+  end
+
   describe ".ingest! (issue#302)" do
     let(:client) { create(:client) }
     let(:attachable) do


### PR DESCRIPTION
## 概要

amex/bank/invoice/receipt の全処理経路で、AI 処理成功後に `batch.pdf.blob.filename` を `YYYYMMDD_支払先_内容.ext` 形式にリネームする。`StatementBatch.build_pdf_filename` に命名ロジックを集約し、`JournalEntryCreator` concern に `rename_batch_pdf` を追加して各 Job から呼び出す。リネーム失敗は警告ログのみでジャーナル保存に影響しない。

Closes #316
