### PR TITLE
feat(platform): 仕訳台帳にステータス絞り込みを追加 (issue#342)

### DIFF
--- a/rails/platform/app/controllers/journal_entries_controller.rb
+++ b/rails/platform/app/controllers/journal_entries_controller.rb
@@ -10,9 +10,11 @@ class JournalEntriesController < ApplicationController
   def index
     @source_type = params[:source_type] || ""
     @csv_export_status = params[:csv_export_status] || ""
+    @status_filter = params[:status] || ""
     scope = JournalEntry.for_client(@client_code).includes(:journal_entry_lines)
     scope = scope.by_source(@source_type) if @source_type.present?
     scope = apply_csv_export_filter(scope, @csv_export_status)
+    scope = apply_status_filter(scope, @status_filter)
     @entries = scope.order(date: :desc, transaction_no: :asc).page(params[:page]).per(25)
   end
 
@@ -47,6 +49,7 @@ class JournalEntriesController < ApplicationController
     entries = entries.by_source(params[:source_type]) if params[:source_type].present?
     entries = entries.where(statement_batch_id: params[:statement_batch_id]) if params[:statement_batch_id].present?
     entries = apply_csv_export_filter(entries, params[:csv_export_status])
+    entries = apply_status_filter(entries, params[:status])
     if params[:date_from].present? && params[:date_to].present?
       begin
         entries = entries.in_period(Date.parse(params[:date_from]), Date.parse(params[:date_to]))
@@ -66,6 +69,14 @@ class JournalEntriesController < ApplicationController
     case status
     when "unexported" then scope.csv_unexported
     when "exported"   then scope.csv_exported
+    else scope
+    end
+  end
+
+  def apply_status_filter(scope, status)
+    case status
+    when "review_required" then scope.review_required
+    when "ok"              then scope.where(status: "ok")
     else scope
     end
   end

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -33,6 +33,15 @@
       </select>
       <p class="mt-1 text-xs text-gray-500">弥生CSV等でエクスポート済みの仕訳は「出力済み」になります</p>
     </div>
+    <div>
+      <label for="status" class="block text-sm font-medium text-gray-300 mb-1">ステータス</label>
+      <select name="status" id="status"
+              class="rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border">
+        <option value="">全て</option>
+        <option value="review_required" <%= "selected" if @status_filter == "review_required" %>>要確認のみ</option>
+        <option value="ok" <%= "selected" if @status_filter == "ok" %>>OKのみ</option>
+      </select>
+    </div>
     <%= render "shared/button", label: "検索", variant: :neutral, type: "submit" %>
     <div class="relative inline-block" data-controller="dropdown">
       <button type="button" data-action="click->dropdown#toggle" class="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors inline-flex items-center gap-1">

--- a/rails/platform/spec/requests/web/journal_entries_spec.rb
+++ b/rails/platform/spec/requests/web/journal_entries_spec.rb
@@ -66,6 +66,49 @@ RSpec.describe "Web::JournalEntries", type: :request do
         expect(response.body).to include("—")
       end
 
+      describe "status フィルタ" do
+        let!(:ok_entry) do
+          create(:journal_entry, client: client, status: "ok",
+                 debit_account: "旅費交通費", debit_amount: 1000, credit_amount: 1000)
+        end
+        let!(:review_entry) do
+          create(:journal_entry, client: client, status: "review_required",
+                 debit_account: "消耗品費", debit_amount: 2000, credit_amount: 2000)
+        end
+
+        it "review_required指定で要確認のみ表示すること" do
+          get journal_entries_path(client_code: client.code, status: "review_required")
+          expect(response.body).to include("消耗品費")
+          expect(response.body).not_to include("旅費交通費")
+        end
+
+        it "ok指定でOKのみ表示すること" do
+          get journal_entries_path(client_code: client.code, status: "ok")
+          expect(response.body).to include("旅費交通費")
+          expect(response.body).not_to include("消耗品費")
+        end
+
+        it "未指定で両方表示すること" do
+          get journal_entries_path(client_code: client.code)
+          expect(response.body).to include("旅費交通費")
+          expect(response.body).to include("消耗品費")
+        end
+
+        it "不正値は silent acceptance で全件表示すること" do
+          get journal_entries_path(client_code: client.code, status: "invalid")
+          expect(response.body).to include("旅費交通費")
+          expect(response.body).to include("消耗品費")
+        end
+
+        it "source_typeと併用できること" do
+          receipt_review = create(:journal_entry, :receipt, client: client, status: "review_required",
+                                  debit_account: "仕入高", debit_amount: 3000, credit_amount: 3000)
+          get journal_entries_path(client_code: client.code, status: "review_required", source_type: "receipt")
+          expect(response.body).to include("仕入高")
+          expect(response.body).not_to include("消耗品費")
+        end
+      end
+
       describe "クレジットカード警告ラベル" do
         before { create(:payment_card, client: client, last_four: "1234") }
 
@@ -277,6 +320,19 @@ RSpec.describe "Web::JournalEntries", type: :request do
 
         csv = CSV.parse(response.body.sub("\uFEFF", ""), headers: true)
         expect(csv.size).to eq(1)
+      end
+
+      it "status=review_requiredで要確認のみエクスポートできること" do
+        create(:journal_entry, client: client, status: "ok",
+               debit_account: "旅費交通費", debit_amount: 1000, credit_amount: 1000)
+        create(:journal_entry, client: client, status: "review_required",
+               debit_account: "消耗品費", debit_amount: 2000, credit_amount: 2000)
+
+        get export_journal_entries_path(client_code: client.code, status: "review_required", format_type: "csv")
+
+        csv = CSV.parse(response.body.sub("\uFEFF", ""), headers: true)
+        expect(csv.size).to eq(1)
+        expect(csv.first["借方勘定科目"]).to eq("消耗品費")
       end
     end
   end


### PR DESCRIPTION
## 概要

仕訳一覧・CSV出力に `status`（`ok` / `review_required`）フィルタを追加し、要確認の仕訳だけをワンクリックで抽出できるようにする。

Closes #342
