### PR TITLE
feat(platform): 仕訳台帳に編集履歴（リビジョン保存・履歴タブ）を追加 (issue#314)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .AppleDouble
 .LSOverride
 
+# Playwright MCP（ブラウザ確認時の一時スナップショット/ログ）
+.playwright-mcp/
+
 # Logs
 *.log
 *.tmp

--- a/rails/platform/app/controllers/journal_entries_controller.rb
+++ b/rails/platform/app/controllers/journal_entries_controller.rb
@@ -20,8 +20,9 @@ class JournalEntriesController < ApplicationController
 
   def show
     @entry = JournalEntry.for_client(@client_code)
-                         .includes(:journal_entry_lines, statement_batch: { pdf_attachment: :blob })
+                         .includes(:journal_entry_lines, { revisions: :user }, statement_batch: { pdf_attachment: :blob })
                          .find(params[:id])
+    @revisions = @entry.revisions.recent_first
   end
 
   def edit
@@ -30,8 +31,20 @@ class JournalEntriesController < ApplicationController
 
   def update
     @entry = JournalEntry.for_client(@client_code).includes(:journal_entry_lines).find(params[:id])
+    before_snapshot = @entry.revision_snapshot
 
-    if @entry.update(entry_params)
+    updated = false
+    ActiveRecord::Base.transaction do
+      updated = @entry.update(entry_params)
+      raise ActiveRecord::Rollback unless updated
+
+      JournalEntryRevision.record!(
+        entry: @entry, before: before_snapshot,
+        user: current_user, reason: params[:revision_reason]
+      )
+    end
+
+    if updated
       redirect_to journal_entry_path(@entry, client_code: @client_code), notice: "仕訳を更新しました"
     else
       render :edit, status: :unprocessable_entity

--- a/rails/platform/app/controllers/journal_entries_controller.rb
+++ b/rails/platform/app/controllers/journal_entries_controller.rb
@@ -40,7 +40,7 @@ class JournalEntriesController < ApplicationController
 
       JournalEntryRevision.record!(
         entry: @entry, before: before_snapshot,
-        user: current_user, reason: params[:revision_reason]
+        user: current_user, reason: revision_reason_param
       )
     end
 
@@ -101,6 +101,10 @@ class JournalEntriesController < ApplicationController
 
   def set_client
     @client = Client.find_by!(code: @client_code)
+  end
+
+  def revision_reason_param
+    params.permit(:revision_reason)[:revision_reason]
   end
 
   def entry_params

--- a/rails/platform/app/javascript/controllers/tabs_controller.js
+++ b/rails/platform/app/javascript/controllers/tabs_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 詳細ページ内のタブ切り替え（仕訳詳細 / 編集履歴）。
+// data-controller="tabs" 下に data-tabs-target="tab"（data-tab-name 付き）と
+// data-tabs-target="panel"（data-tab-name 付き）を配置する。
+export default class extends Controller {
+  static targets = ["tab", "panel"]
+
+  connect() {
+    this.showTab(this.tabTargets[0]?.dataset.tabName)
+  }
+
+  switch(event) {
+    event.preventDefault()
+    this.showTab(event.currentTarget.dataset.tabName)
+  }
+
+  showTab(name) {
+    if (!name) return
+
+    this.panelTargets.forEach((panel) => {
+      panel.classList.toggle("hidden", panel.dataset.tabName !== name)
+    })
+
+    this.tabTargets.forEach((tab) => {
+      const active = tab.dataset.tabName === name
+      tab.classList.toggle("border-teal-500", active)
+      tab.classList.toggle("text-teal-400", active)
+      tab.classList.toggle("border-transparent", !active)
+      tab.classList.toggle("text-gray-400", !active)
+    })
+  }
+}

--- a/rails/platform/app/models/journal_entry.rb
+++ b/rails/platform/app/models/journal_entry.rb
@@ -5,6 +5,7 @@ class JournalEntry < ApplicationRecord
   belongs_to :client
   belongs_to :statement_batch, optional: true
   has_many :journal_entry_lines, -> { order(:id) }, dependent: :destroy
+  has_many :revisions, class_name: "JournalEntryRevision", dependent: :destroy
   accepts_nested_attributes_for :journal_entry_lines, allow_destroy: true
 
   # === バリデーション ===
@@ -41,6 +42,34 @@ class JournalEntry < ApplicationRecord
 
   def simple_entry?
     journal_entry_lines.size == 2
+  end
+
+  STATUS_LABELS = { "ok" => "OK", "review_required" => "要確認" }.freeze
+
+  LINE_FIELD_LABELS = {
+    account: "勘定科目", sub_account: "補助科目", department: "部門",
+    partner: "取引先", tax_category: "税区分", invoice: "インボイス", amount: "金額"
+  }.freeze
+
+  # 編集履歴の差分計算・表示に使うフラットなスナップショット。
+  # 会計記録として読みやすいよう日本語ラベルをキーにする。
+  def revision_snapshot
+    snapshot = {
+      "摘要" => description.to_s,
+      "タグ" => tag.to_s,
+      "メモ" => memo.to_s,
+      "カード利用者" => cardholder.to_s,
+      "ステータス" => STATUS_LABELS.fetch(status, status.to_s)
+    }
+    [ [ "借方", debit_lines ], [ "貸方", credit_lines ] ].each do |side_label, lines|
+      lines.each_with_index do |line, idx|
+        prefix = lines.size > 1 ? "#{side_label}#{idx + 1}" : side_label
+        LINE_FIELD_LABELS.each do |attr, field_label|
+          snapshot["#{prefix}_#{field_label}"] = line.public_send(attr).to_s
+        end
+      end
+    end
+    snapshot
   end
 
   # === CSVエクスポート ===

--- a/rails/platform/app/models/journal_entry.rb
+++ b/rails/platform/app/models/journal_entry.rb
@@ -53,6 +53,9 @@ class JournalEntry < ApplicationRecord
 
   # 編集履歴の差分計算・表示に使うフラットなスナップショット。
   # 会計記録として読みやすいよう日本語ラベルをキーにする。
+  # NOTE: 複数行の借方/貸方は journal_entry_lines の order(:id) 順を前提に
+  # "借方N_..." のキーを採番する。将来ライン順序の並べ替え機能を入れる場合は
+  # position 等の明示的な順序カラムへ切り替えること（キーがズレて diff が崩れるため）。
   def revision_snapshot
     snapshot = {
       "摘要" => description.to_s,

--- a/rails/platform/app/models/journal_entry_revision.rb
+++ b/rails/platform/app/models/journal_entry_revision.rb
@@ -1,0 +1,38 @@
+class JournalEntryRevision < ApplicationRecord
+  belongs_to :journal_entry
+  belongs_to :user, optional: true
+
+  validates :changes_diff, presence: true
+
+  scope :recent_first, -> { order(created_at: :desc) }
+
+  # 2 つのスナップショット（フラット hash）を比較し、変化したキーだけ
+  # { key => [before, after] } 形式で返す。
+  def self.diff_snapshots(before, after)
+    (before.keys | after.keys).each_with_object({}) do |key, diff|
+      old_value = before[key]
+      new_value = after[key]
+      diff[key] = [ old_value, new_value ] if old_value != new_value
+    end
+  end
+
+  # 編集前スナップショット before を受け取り、entry の現在値と差分を取って
+  # リビジョンを記録する。差分が無ければ何もしない（理由のみの保存は不要）。
+  def self.record!(entry:, before:, user: nil, reason: nil)
+    after = entry.revision_snapshot
+    diff = diff_snapshots(before, after)
+    return nil if diff.empty?
+
+    create!(
+      journal_entry: entry,
+      user: user,
+      changes_diff: diff,
+      snapshot: after,
+      reason: reason.presence
+    )
+  end
+
+  def editor_label
+    user&.email || "（不明な編集者）"
+  end
+end

--- a/rails/platform/app/views/journal_entries/edit.html.erb
+++ b/rails/platform/app/views/journal_entries/edit.html.erb
@@ -151,6 +151,15 @@
       </div>
     <% end %>
 
+    <!-- 変更理由（編集履歴に記録） -->
+    <%= render "shared/card" do %>
+      <h2 class="text-lg font-semibold mb-4">変更理由（任意）</h2>
+      <%= text_field_tag :revision_reason, nil,
+            placeholder: "例: 税区分を修正、勘定科目を訂正 など",
+            class: "w-full rounded-md border-gray-600 shadow-sm focus:border-teal-500 focus:ring-teal-500 px-3 py-2 border" %>
+      <p class="mt-2 text-xs text-gray-500">変更内容は編集履歴として記録されます。理由は任意です。</p>
+    <% end %>
+
     <div class="flex justify-end gap-4">
       <%= render "shared/button", label: "キャンセル", href: journal_entry_path(@entry, client_code: @client_code), variant: :secondary, size: :lg %>
       <%= f.submit "保存", class: "bg-teal-600 text-white px-6 py-2 rounded-md hover:bg-teal-700 transition-colors cursor-pointer" %>

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -144,9 +144,7 @@
               </td>
               <td class="sticky right-0 z-10 bg-gray-900 group-hover:bg-gray-800 px-3 py-2 text-right whitespace-nowrap space-x-1 border-l border-gray-700">
                 <%= link_to "詳細", journal_entry_path(entry, client_code: @client_code), class: "text-teal-400 hover:text-teal-300" %>
-                <% if entry.status == "review_required" %>
-                  <%= link_to "編集", edit_journal_entry_path(entry, client_code: @client_code), class: "text-amber-500 hover:text-amber-400" %>
-                <% end %>
+                <%= link_to "編集", edit_journal_entry_path(entry, client_code: @client_code), class: "text-amber-500 hover:text-amber-400" %>
                 <%= button_to "削除",
                       journal_entry_path(entry, client_code: @client_code),
                       method: :delete,

--- a/rails/platform/app/views/journal_entries/show.html.erb
+++ b/rails/platform/app/views/journal_entries/show.html.erb
@@ -25,10 +25,10 @@
     <div class="flex items-center gap-3">
       <% if @entry.status == "review_required" %>
         <%= render "shared/badge", label: "要確認", variant: :warning, size: :md %>
-        <%= render "shared/button", label: "編集", href: edit_journal_entry_path(@entry, client_code: @client_code), variant: :edit, class: "text-sm" %>
       <% else %>
         <%= render "shared/badge", label: "OK", variant: :success, size: :md %>
       <% end %>
+      <%= render "shared/button", label: "編集", href: edit_journal_entry_path(@entry, client_code: @client_code), variant: :edit, class: "text-sm" %>
       <%= render "shared/button",
             label: "削除",
             variant: :danger,
@@ -46,142 +46,198 @@
     </div>
   </div>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <!-- 基本情報 -->
-    <%= render "shared/card" do %>
-      <h2 class="text-lg font-semibold mb-4 border-b pb-2">基本情報</h2>
-      <dl class="space-y-3">
-        <div class="flex justify-between">
-          <dt class="text-sm text-gray-400">取引日</dt>
-          <dd class="text-sm font-medium"><%= @entry.date %></dd>
-        </div>
-        <div class="flex justify-between">
-          <dt class="text-sm text-gray-400">ソースタイプ</dt>
-          <dd class="text-sm font-medium"><%= @entry.source_type %></dd>
-        </div>
-        <div class="flex justify-between">
-          <dt class="text-sm text-gray-400">明細期間</dt>
-          <dd class="text-sm font-medium"><%= @entry.source_period %></dd>
-        </div>
-        <div class="flex justify-between">
-          <dt class="text-sm text-gray-400">カード利用者</dt>
-          <dd class="text-sm font-medium"><%= @entry.cardholder.presence || "-" %></dd>
-        </div>
-        <div class="flex justify-between">
-          <dt class="text-sm text-gray-400">タグ</dt>
-          <dd class="text-sm font-medium"><%= @entry.tag.presence || "-" %></dd>
-        </div>
-      </dl>
-    <% end %>
+  <div data-controller="tabs">
+    <%# タブナビ %>
+    <div class="flex border-b border-gray-700 mb-6">
+      <button type="button" data-tabs-target="tab" data-tab-name="detail" data-action="click->tabs#switch"
+              class="px-4 py-2 border-b-2 border-transparent text-sm font-medium text-gray-400 cursor-pointer">
+        仕訳詳細
+      </button>
+      <button type="button" data-tabs-target="tab" data-tab-name="history" data-action="click->tabs#switch"
+              class="px-4 py-2 border-b-2 border-transparent text-sm font-medium text-gray-400 cursor-pointer">
+        編集履歴 (<%= @revisions.size %>)
+      </button>
+    </div>
 
-    <!-- 摘要・メモ -->
-    <%= render "shared/card" do %>
-      <h2 class="text-lg font-semibold mb-4 border-b pb-2">摘要・メモ</h2>
-      <dl class="space-y-3">
-        <div>
-          <dt class="text-sm text-gray-400">摘要</dt>
-          <dd class="text-sm font-medium mt-1"><%= @entry.description.presence || "-" %></dd>
-        </div>
-        <div>
-          <dt class="text-sm text-gray-400">メモ</dt>
-          <dd class="text-sm font-medium mt-1"><%= @entry.memo.presence || "-" %></dd>
-        </div>
-      </dl>
-    <% end %>
-
-    <!-- 証憑 -->
-    <% if @entry.statement_batch&.pdf&.attached? %>
-      <%= render "shared/card" do %>
-        <h2 class="text-lg font-semibold mb-4 border-b pb-2">証憑</h2>
-        <%= link_to rails_blob_path(@entry.statement_batch.pdf, disposition: "inline"),
-              target: "_blank", rel: "noopener",
-              class: "inline-flex items-center gap-2 text-sm font-medium text-teal-400 hover:underline" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
-          <span>証憑を開く（<%= @entry.statement_batch.pdf.filename %>）</span>
+    <%# 仕訳詳細パネル %>
+    <div data-tabs-target="panel" data-tab-name="detail">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <!-- 基本情報 -->
+        <%= render "shared/card" do %>
+          <h2 class="text-lg font-semibold mb-4 border-b pb-2">基本情報</h2>
+          <dl class="space-y-3">
+            <div class="flex justify-between">
+              <dt class="text-sm text-gray-400">取引日</dt>
+              <dd class="text-sm font-medium"><%= @entry.date %></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-sm text-gray-400">ソースタイプ</dt>
+              <dd class="text-sm font-medium"><%= @entry.source_type %></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-sm text-gray-400">明細期間</dt>
+              <dd class="text-sm font-medium"><%= @entry.source_period %></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-sm text-gray-400">カード利用者</dt>
+              <dd class="text-sm font-medium"><%= @entry.cardholder.presence || "-" %></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-sm text-gray-400">タグ</dt>
+              <dd class="text-sm font-medium"><%= @entry.tag.presence || "-" %></dd>
+            </div>
+          </dl>
         <% end %>
-      <% end %>
-    <% end %>
 
-    <!-- 借方 -->
-    <%= render "shared/card" do %>
-      <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-teal-400">借方</h2>
-      <% @entry.debit_lines.each_with_index do |line, i| %>
-        <% if i > 0 %>
-          <hr class="my-3 border-gray-700">
+        <!-- 摘要・メモ -->
+        <%= render "shared/card" do %>
+          <h2 class="text-lg font-semibold mb-4 border-b pb-2">摘要・メモ</h2>
+          <dl class="space-y-3">
+            <div>
+              <dt class="text-sm text-gray-400">摘要</dt>
+              <dd class="text-sm font-medium mt-1"><%= @entry.description.presence || "-" %></dd>
+            </div>
+            <div>
+              <dt class="text-sm text-gray-400">メモ</dt>
+              <dd class="text-sm font-medium mt-1"><%= @entry.memo.presence || "-" %></dd>
+            </div>
+          </dl>
         <% end %>
-        <dl class="space-y-3">
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">勘定科目</dt>
-            <dd class="text-sm font-medium"><%= line.account %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">補助科目</dt>
-            <dd class="text-sm font-medium"><%= line.sub_account.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">部門</dt>
-            <dd class="text-sm font-medium"><%= line.department.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">取引先</dt>
-            <dd class="text-sm font-medium"><%= line.partner.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">税区分</dt>
-            <dd class="text-sm font-medium"><%= line.tax_category.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">インボイス</dt>
-            <dd class="text-sm font-medium"><%= line.invoice.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">金額</dt>
-            <dd class="text-lg font-bold text-teal-400"><%= number_with_delimiter(line.amount) %>円</dd>
-          </div>
-        </dl>
-      <% end %>
-    <% end %>
 
-    <!-- 貸方 -->
-    <%= render "shared/card" do %>
-      <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-red-700">貸方</h2>
-      <% @entry.credit_lines.each_with_index do |line, i| %>
-        <% if i > 0 %>
-          <hr class="my-3 border-gray-700">
+        <!-- 証憑 -->
+        <% if @entry.statement_batch&.pdf&.attached? %>
+          <%= render "shared/card" do %>
+            <h2 class="text-lg font-semibold mb-4 border-b pb-2">証憑</h2>
+            <%= link_to rails_blob_path(@entry.statement_batch.pdf, disposition: "inline"),
+                  target: "_blank", rel: "noopener",
+                  class: "inline-flex items-center gap-2 text-sm font-medium text-teal-400 hover:underline" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <span>証憑を開く（<%= @entry.statement_batch.pdf.filename %>）</span>
+            <% end %>
+          <% end %>
         <% end %>
-        <dl class="space-y-3">
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">勘定科目</dt>
-            <dd class="text-sm font-medium"><%= line.account %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">補助科目</dt>
-            <dd class="text-sm font-medium"><%= line.sub_account.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">部門</dt>
-            <dd class="text-sm font-medium"><%= line.department.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">取引先</dt>
-            <dd class="text-sm font-medium"><%= line.partner.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">税区分</dt>
-            <dd class="text-sm font-medium"><%= line.tax_category.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">インボイス</dt>
-            <dd class="text-sm font-medium"><%= line.invoice.presence || "-" %></dd>
-          </div>
-          <div class="flex justify-between">
-            <dt class="text-sm text-gray-400">金額</dt>
-            <dd class="text-lg font-bold text-red-700"><%= number_with_delimiter(line.amount) %>円</dd>
-          </div>
-        </dl>
+
+        <!-- 借方 -->
+        <%= render "shared/card" do %>
+          <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-teal-400">借方</h2>
+          <% @entry.debit_lines.each_with_index do |line, i| %>
+            <% if i > 0 %>
+              <hr class="my-3 border-gray-700">
+            <% end %>
+            <dl class="space-y-3">
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">勘定科目</dt>
+                <dd class="text-sm font-medium"><%= line.account %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">補助科目</dt>
+                <dd class="text-sm font-medium"><%= line.sub_account.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">部門</dt>
+                <dd class="text-sm font-medium"><%= line.department.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">取引先</dt>
+                <dd class="text-sm font-medium"><%= line.partner.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">税区分</dt>
+                <dd class="text-sm font-medium"><%= line.tax_category.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">インボイス</dt>
+                <dd class="text-sm font-medium"><%= line.invoice.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">金額</dt>
+                <dd class="text-lg font-bold text-teal-400"><%= number_with_delimiter(line.amount) %>円</dd>
+              </div>
+            </dl>
+          <% end %>
+        <% end %>
+
+        <!-- 貸方 -->
+        <%= render "shared/card" do %>
+          <h2 class="text-lg font-semibold mb-4 border-b pb-2 text-red-700">貸方</h2>
+          <% @entry.credit_lines.each_with_index do |line, i| %>
+            <% if i > 0 %>
+              <hr class="my-3 border-gray-700">
+            <% end %>
+            <dl class="space-y-3">
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">勘定科目</dt>
+                <dd class="text-sm font-medium"><%= line.account %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">補助科目</dt>
+                <dd class="text-sm font-medium"><%= line.sub_account.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">部門</dt>
+                <dd class="text-sm font-medium"><%= line.department.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">取引先</dt>
+                <dd class="text-sm font-medium"><%= line.partner.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">税区分</dt>
+                <dd class="text-sm font-medium"><%= line.tax_category.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">インボイス</dt>
+                <dd class="text-sm font-medium"><%= line.invoice.presence || "-" %></dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-sm text-gray-400">金額</dt>
+                <dd class="text-lg font-bold text-red-700"><%= number_with_delimiter(line.amount) %>円</dd>
+              </div>
+            </dl>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+
+    <%# 編集履歴パネル %>
+    <div data-tabs-target="panel" data-tab-name="history" class="hidden">
+      <% if @revisions.empty? %>
+        <p class="text-gray-400">編集履歴はまだありません。</p>
+      <% else %>
+        <ul class="space-y-4">
+          <% @revisions.each do |rev| %>
+            <li class="bg-gray-900 border border-gray-700 rounded-lg p-4">
+              <div class="flex items-center justify-between mb-3">
+                <span class="text-sm text-gray-300"><%= rev.created_at.in_time_zone.strftime("%Y-%m-%d %H:%M") %></span>
+                <span class="text-xs text-gray-500"><%= rev.editor_label %></span>
+              </div>
+              <% if rev.reason.present? %>
+                <p class="text-sm text-gray-400 mb-3">変更理由: <%= rev.reason %></p>
+              <% end %>
+              <table class="w-full text-xs">
+                <thead>
+                  <tr class="text-gray-500">
+                    <th class="text-left py-1 font-medium">項目</th>
+                    <th class="text-left py-1 font-medium">変更前</th>
+                    <th class="text-left py-1 font-medium">変更後</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% rev.changes_diff.each do |field, (before, after)| %>
+                    <tr class="border-t border-gray-800">
+                      <td class="py-1.5 pr-3 text-gray-300 whitespace-nowrap"><%= field %></td>
+                      <td class="py-1.5 pr-3 text-red-400"><%= before.presence || "（空）" %></td>
+                      <td class="py-1.5 text-teal-400"><%= after.presence || "（空）" %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </li>
+          <% end %>
+        </ul>
       <% end %>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/rails/platform/db/migrate/20260620062736_create_journal_entry_revisions.rb
+++ b/rails/platform/db/migrate/20260620062736_create_journal_entry_revisions.rb
@@ -1,0 +1,16 @@
+class CreateJournalEntryRevisions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :journal_entry_revisions do |t|
+      t.references :journal_entry, null: false, foreign_key: true
+      # 編集者。User が将来削除されても履歴は会計記録として残すため null 許容 + nullify。
+      t.references :user, null: true, foreign_key: { on_delete: :nullify }
+      t.jsonb :changes_diff, null: false, default: {}  # { "借方_金額" => [before, after] }
+      t.jsonb :snapshot, null: false, default: {}       # 編集後の仕訳全体像（lines 含む）
+      t.string :reason                                   # 変更理由（任意）
+
+      t.timestamps
+    end
+
+    add_index :journal_entry_revisions, %i[journal_entry_id created_at]
+  end
+end

--- a/rails/platform/db/schema.rb
+++ b/rails/platform/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_20_032557) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_20_062736) do
   create_schema "n8n"
 
   # These are extensions that must be enabled in order to support this database
@@ -350,6 +350,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_20_032557) do
     t.datetime "updated_at", null: false
     t.index ["journal_entry_id", "side"], name: "idx_journal_entry_lines_entry_side"
     t.index ["journal_entry_id"], name: "index_journal_entry_lines_on_journal_entry_id"
+  end
+
+  create_table "journal_entry_revisions", force: :cascade do |t|
+    t.bigint "journal_entry_id", null: false
+    t.bigint "user_id"
+    t.jsonb "changes_diff", default: {}, null: false
+    t.jsonb "snapshot", default: {}, null: false
+    t.string "reason"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["journal_entry_id", "created_at"], name: "idx_on_journal_entry_id_created_at_9c0965e380"
+    t.index ["journal_entry_id"], name: "index_journal_entry_revisions_on_journal_entry_id"
+    t.index ["user_id"], name: "index_journal_entry_revisions_on_user_id"
   end
 
   create_table "licenses", id: { type: :string, limit: 26 }, force: :cascade do |t|
@@ -794,6 +807,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_20_032557) do
   add_foreign_key "journal_entries", "clients"
   add_foreign_key "journal_entries", "statement_batches"
   add_foreign_key "journal_entry_lines", "journal_entries"
+  add_foreign_key "journal_entry_revisions", "journal_entries"
+  add_foreign_key "journal_entry_revisions", "users", on_delete: :nullify
   add_foreign_key "line_followers", "clients"
   add_foreign_key "payment_cards", "clients"
   add_foreign_key "statement_batches", "clients"

--- a/rails/platform/spec/factories/journal_entry_revisions.rb
+++ b/rails/platform/spec/factories/journal_entry_revisions.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :journal_entry_revision do
+    association :journal_entry
+    association :user
+    changes_diff { { "摘要" => [ "旧摘要", "新摘要" ] } }
+    snapshot { { "摘要" => "新摘要" } }
+    reason { nil }
+  end
+end

--- a/rails/platform/spec/models/journal_entry_revision_spec.rb
+++ b/rails/platform/spec/models/journal_entry_revision_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe JournalEntryRevision, type: :model do
+  let(:client) { create(:client) }
+  let(:user) { create(:user) }
+
+  describe ".diff_snapshots" do
+    it "変化したキーのみ [before, after] で返すこと" do
+      before = { "摘要" => "A", "メモ" => "X", "借方_金額" => "100" }
+      after  = { "摘要" => "B", "メモ" => "X", "借方_金額" => "200" }
+
+      diff = described_class.diff_snapshots(before, after)
+
+      expect(diff).to eq({ "摘要" => [ "A", "B" ], "借方_金額" => [ "100", "200" ] })
+    end
+
+    it "新規追加・削除されたキーも検出すること" do
+      before = { "a" => "1" }
+      after  = { "a" => "1", "b" => "2" }
+
+      expect(described_class.diff_snapshots(before, after)).to eq({ "b" => [ nil, "2" ] })
+    end
+
+    it "差分が無ければ空ハッシュを返すこと" do
+      snap = { "摘要" => "A" }
+      expect(described_class.diff_snapshots(snap, snap)).to eq({})
+    end
+  end
+
+  describe ".record!" do
+    let(:entry) do
+      create(:journal_entry, client: client, description: "元の摘要",
+             debit_account: "旅費交通費", debit_amount: 1000, credit_amount: 1000)
+    end
+
+    it "差分がある場合にリビジョンを作成すること" do
+      before = entry.revision_snapshot
+      entry.update!(description: "修正後の摘要")
+
+      expect {
+        described_class.record!(entry: entry, before: before, user: user, reason: "摘要を訂正")
+      }.to change(described_class, :count).by(1)
+
+      rev = described_class.last
+      expect(rev.journal_entry).to eq(entry)
+      expect(rev.user).to eq(user)
+      expect(rev.reason).to eq("摘要を訂正")
+      expect(rev.changes_diff["摘要"]).to eq([ "元の摘要", "修正後の摘要" ])
+      expect(rev.snapshot["摘要"]).to eq("修正後の摘要")
+    end
+
+    it "差分が無い場合はリビジョンを作成しないこと" do
+      before = entry.revision_snapshot
+
+      expect {
+        described_class.record!(entry: entry, before: before, user: user, reason: "理由のみ")
+      }.not_to change(described_class, :count)
+    end
+
+    it "reason が空文字の場合は nil で保存すること" do
+      before = entry.revision_snapshot
+      entry.update!(memo: "メモ追加")
+
+      described_class.record!(entry: entry, before: before, user: user, reason: "")
+      expect(described_class.last.reason).to be_nil
+    end
+  end
+
+  describe "#editor_label" do
+    it "user がいればメールアドレスを返すこと" do
+      rev = build(:journal_entry_revision, user: user)
+      expect(rev.editor_label).to eq(user.email)
+    end
+
+    it "user が nil なら不明ラベルを返すこと" do
+      rev = build(:journal_entry_revision, user: nil)
+      expect(rev.editor_label).to eq("（不明な編集者）")
+    end
+  end
+end

--- a/rails/platform/spec/models/journal_entry_spec.rb
+++ b/rails/platform/spec/models/journal_entry_spec.rb
@@ -111,6 +111,32 @@ RSpec.describe JournalEntry, type: :model do
     end
   end
 
+  describe "#revision_snapshot" do
+    let(:entry) do
+      create(:journal_entry, description: "テスト摘要", tag: "amex", memo: "メモ",
+             cardholder: "山田太郎", status: "ok",
+             debit_account: "旅費交通費", debit_amount: 5000,
+             credit_account: "未払金", credit_amount: 5000)
+    end
+
+    it "日本語ラベルをキーとしたフラットなスナップショットを返すこと" do
+      snap = entry.revision_snapshot
+
+      expect(snap["摘要"]).to eq("テスト摘要")
+      expect(snap["メモ"]).to eq("メモ")
+      expect(snap["カード利用者"]).to eq("山田太郎")
+      expect(snap["ステータス"]).to eq("OK")
+      expect(snap["借方_勘定科目"]).to eq("旅費交通費")
+      expect(snap["借方_金額"]).to eq("5000")
+      expect(snap["貸方_勘定科目"]).to eq("未払金")
+    end
+
+    it "ステータスは日本語ラベルに変換されること" do
+      entry.update!(status: "review_required")
+      expect(entry.revision_snapshot["ステータス"]).to eq("要確認")
+    end
+  end
+
   describe "複合仕訳" do
     it "3行以上の仕訳を作成できる" do
       client = create(:client)

--- a/rails/platform/spec/requests/web/journal_entries_spec.rb
+++ b/rails/platform/spec/requests/web/journal_entries_spec.rb
@@ -359,6 +359,95 @@ RSpec.describe "Web::JournalEntries", type: :request do
         get edit_journal_entry_path(entry, client_code: client.code)
         expect(response.body).to include("テスト社")
       end
+
+      it "全ステータス（ok）でも詳細ページに編集ボタンが表示されること" do
+        ok_entry = create(:journal_entry, client: client, status: "ok")
+        get journal_entry_path(ok_entry, client_code: client.code)
+        expect(response.body).to include(edit_journal_entry_path(ok_entry, client_code: client.code))
+      end
+    end
+  end
+
+  describe "PATCH /journal_entries/:id (update)" do
+    let(:entry) do
+      create(:journal_entry, client: client, status: "ok", description: "元摘要",
+             debit_account: "旅費交通費", debit_amount: 5000,
+             credit_account: "未払金", credit_amount: 5000)
+    end
+
+    def update_params(description: "修正後の摘要", debit_amount: 5000, credit_amount: 5000, reason: nil)
+      {
+        journal_entry: {
+          description: description,
+          journal_entry_lines_attributes: {
+            "0" => { id: entry.debit_lines.first.id, side: "debit", account: "旅費交通費", amount: debit_amount },
+            "1" => { id: entry.credit_lines.first.id, side: "credit", account: "未払金", amount: credit_amount }
+          }
+        },
+        revision_reason: reason
+      }
+    end
+
+    context "未認証の場合" do
+      it "ログイン画面にリダイレクトすること" do
+        patch journal_entry_path(entry, client_code: client.code), params: update_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みの場合" do
+      before { sign_in user }
+
+      it "編集成功で仕訳詳細にリダイレクトしリビジョンを記録すること" do
+        expect {
+          patch journal_entry_path(entry, client_code: client.code), params: update_params(reason: "摘要を訂正")
+        }.to change(JournalEntryRevision, :count).by(1)
+
+        expect(response).to redirect_to(journal_entry_path(entry, client_code: client.code))
+        expect(entry.reload.description).to eq("修正後の摘要")
+      end
+
+      it "変更理由と編集者を記録すること" do
+        patch journal_entry_path(entry, client_code: client.code), params: update_params(reason: "摘要を訂正")
+
+        rev = JournalEntryRevision.last
+        expect(rev.reason).to eq("摘要を訂正")
+        expect(rev.user).to eq(user)
+        expect(rev.changes_diff["摘要"]).to eq([ "元摘要", "修正後の摘要" ])
+      end
+
+      it "変更が無い場合はリビジョンを作成しないこと" do
+        expect {
+          patch journal_entry_path(entry, client_code: client.code), params: update_params(description: "元摘要")
+        }.not_to change(JournalEntryRevision, :count)
+      end
+
+      it "貸借不一致のバリデーションエラー時はリビジョンを作成せず422を返すこと" do
+        expect {
+          patch journal_entry_path(entry, client_code: client.code),
+                params: update_params(credit_amount: 3000)
+        }.not_to change(JournalEntryRevision, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(entry.reload.description).to eq("元摘要")
+      end
+    end
+  end
+
+  describe "GET /journal_entries/:id 履歴タブ" do
+    let(:entry) { create(:journal_entry, client: client) }
+
+    before { sign_in user }
+
+    it "リビジョンがある場合に履歴タブへ表示されること" do
+      create(:journal_entry_revision, journal_entry: entry, user: user,
+             changes_diff: { "摘要" => [ "旧", "新" ] }, reason: "テスト理由")
+
+      get journal_entry_path(entry, client_code: client.code)
+
+      expect(response.body).to include("編集履歴")
+      expect(response.body).to include("テスト理由")
+      expect(response.body).to include('data-controller="tabs"')
     end
   end
 


### PR DESCRIPTION
## 概要

仕訳を全ステータスで編集可能にし、編集ごとに `journal_entry_revisions`（自作テーブル）へ差分・スナップショット・編集者・変更理由を記録。詳細ページに「仕訳詳細 / 編集履歴」タブを追加して履歴を表示する（ADR 0009-C）。

Closes #314
