### PR TITLE
feat(platform): 重複アップロード時に処理済みバッチ導線を提示しfailedバッチを自動掃除 (issue#307)

### DIFF
--- a/rails/platform/app/controllers/api/v1/amex_statements_controller.rb
+++ b/rails/platform/app/controllers/api/v1/amex_statements_controller.rb
@@ -1,45 +1,10 @@
 module Api
   module V1
     class AmexStatementsController < BaseController
-      MAX_PDF_SIZE = 20.megabytes
+      include PdfStatementProcessable
 
       def process_statement
-        pdf = params[:pdf]
-        return render_error("PDFファイルをアップロードしてください") if pdf.blank?
-
-        unless Marcel::MimeType.for(pdf.tempfile, name: pdf.original_filename) == "application/pdf"
-          return render_error("PDF形式のファイルのみ対応しています")
-        end
-
-        if pdf.size > MAX_PDF_SIZE
-          return render_error("PDFファイルは20MB以下にしてください")
-        end
-
-        fingerprint = Digest::SHA256.hexdigest(pdf.read)
-        pdf.rewind
-
-        unless ActiveModel::Type::Boolean.new.cast(params[:force])
-          existing = @current_client.statement_batches
-            .where(pdf_fingerprint: fingerprint, status: %w[processing completed])
-            .first
-          if existing
-            return render json: {
-              error: existing.status == "processing" ? "この明細は現在処理中です" : "この明細は処理済みです",
-              duplicate: true,
-              existing_batch_id: existing.id
-            }, status: :conflict
-          end
-        end
-
-        batch = StatementBatch.ingest!(
-          client: @current_client,
-          source_type: "amex",
-          fingerprint: fingerprint,
-          attachable: pdf
-        )
-
-        AmexStatementProcessJob.perform_later(batch.id)
-        render json: { id: batch.id, status: "processing" }, status: :accepted
+        ingest_pdf_statement(source_type: "amex", job: AmexStatementProcessJob, noun: "明細")
       end
 
       def status

--- a/rails/platform/app/controllers/api/v1/bank_statements_controller.rb
+++ b/rails/platform/app/controllers/api/v1/bank_statements_controller.rb
@@ -1,45 +1,10 @@
 module Api
   module V1
     class BankStatementsController < BaseController
-      MAX_PDF_SIZE = 20.megabytes
+      include PdfStatementProcessable
 
       def process_statement
-        pdf = params[:pdf]
-        return render_error("PDFファイルをアップロードしてください") if pdf.blank?
-
-        unless Marcel::MimeType.for(pdf.tempfile, name: pdf.original_filename) == "application/pdf"
-          return render_error("PDF形式のファイルのみ対応しています")
-        end
-
-        if pdf.size > MAX_PDF_SIZE
-          return render_error("PDFファイルは20MB以下にしてください")
-        end
-
-        fingerprint = Digest::SHA256.hexdigest(pdf.read)
-        pdf.rewind
-
-        unless ActiveModel::Type::Boolean.new.cast(params[:force])
-          existing = @current_client.statement_batches
-            .where(pdf_fingerprint: fingerprint, status: %w[processing completed])
-            .first
-          if existing
-            return render json: {
-              error: existing.status == "processing" ? "この明細は現在処理中です" : "この明細は処理済みです",
-              duplicate: true,
-              existing_batch_id: existing.id
-            }, status: :conflict
-          end
-        end
-
-        batch = StatementBatch.ingest!(
-          client: @current_client,
-          source_type: "bank",
-          fingerprint: fingerprint,
-          attachable: pdf
-        )
-
-        BankStatementProcessJob.perform_later(batch.id)
-        render json: { id: batch.id, status: "processing" }, status: :accepted
+        ingest_pdf_statement(source_type: "bank", job: BankStatementProcessJob, noun: "明細")
       end
 
       def status

--- a/rails/platform/app/controllers/api/v1/invoices_controller.rb
+++ b/rails/platform/app/controllers/api/v1/invoices_controller.rb
@@ -1,45 +1,10 @@
 module Api
   module V1
     class InvoicesController < BaseController
-      MAX_PDF_SIZE = 20.megabytes
+      include PdfStatementProcessable
 
       def process_statement
-        pdf = params[:pdf]
-        return render_error("PDFファイルをアップロードしてください") if pdf.blank?
-
-        unless Marcel::MimeType.for(pdf.tempfile, name: pdf.original_filename) == "application/pdf"
-          return render_error("PDF形式のファイルのみ対応しています")
-        end
-
-        if pdf.size > MAX_PDF_SIZE
-          return render_error("PDFファイルは20MB以下にしてください")
-        end
-
-        fingerprint = Digest::SHA256.hexdigest(pdf.read)
-        pdf.rewind
-
-        unless ActiveModel::Type::Boolean.new.cast(params[:force])
-          existing = @current_client.statement_batches
-            .where(pdf_fingerprint: fingerprint, status: %w[processing completed])
-            .first
-          if existing
-            return render json: {
-              error: existing.status == "processing" ? "この請求書は現在処理中です" : "この請求書は処理済みです",
-              duplicate: true,
-              existing_batch_id: existing.id
-            }, status: :conflict
-          end
-        end
-
-        batch = StatementBatch.ingest!(
-          client: @current_client,
-          source_type: "invoice",
-          fingerprint: fingerprint,
-          attachable: pdf
-        )
-
-        InvoiceProcessJob.perform_later(batch.id)
-        render json: { id: batch.id, status: "processing" }, status: :accepted
+        ingest_pdf_statement(source_type: "invoice", job: InvoiceProcessJob, noun: "請求書")
       end
 
       def status

--- a/rails/platform/app/controllers/concerns/pdf_statement_processable.rb
+++ b/rails/platform/app/controllers/concerns/pdf_statement_processable.rb
@@ -43,9 +43,11 @@ module PdfStatementProcessable
       attachable: pdf
     )
 
+    job.perform_later(batch.id)
+    # ジョブを確実にエンキューしてから、置き換え済みの failed バッチを掃除する
+    # （perform_later が失敗した場合は古い failed を残したまま例外送出）。
     cleanup_superseded_failed_batches(fingerprint)
 
-    job.perform_later(batch.id)
     render json: { id: batch.id, status: "processing" }, status: :accepted
   end
 

--- a/rails/platform/app/controllers/concerns/pdf_statement_processable.rb
+++ b/rails/platform/app/controllers/concerns/pdf_statement_processable.rb
@@ -1,0 +1,60 @@
+module PdfStatementProcessable
+  extend ActiveSupport::Concern
+
+  MAX_PDF_SIZE = 20.megabytes
+
+  private
+
+  # amex / bank / invoice の process_statement で共通の取り込みフロー。
+  # source_type / job / noun（重複メッセージの名詞）のみ呼び出し側で差し替える。
+  def ingest_pdf_statement(source_type:, job:, noun:)
+    pdf = params[:pdf]
+    return render_error("PDFファイルをアップロードしてください") if pdf.blank?
+
+    unless Marcel::MimeType.for(pdf.tempfile, name: pdf.original_filename) == "application/pdf"
+      return render_error("PDF形式のファイルのみ対応しています")
+    end
+
+    if pdf.size > MAX_PDF_SIZE
+      return render_error("PDFファイルは20MB以下にしてください")
+    end
+
+    fingerprint = Digest::SHA256.hexdigest(pdf.read)
+    pdf.rewind
+
+    unless ActiveModel::Type::Boolean.new.cast(params[:force])
+      existing = @current_client.statement_batches
+        .where(pdf_fingerprint: fingerprint, status: %w[processing completed])
+        .first
+      if existing
+        return render json: {
+          error: existing.status == "processing" ? "この#{noun}は現在処理中です" : "この#{noun}は処理済みです",
+          duplicate: true,
+          existing_batch_id: existing.id,
+          existing_batch_url: statement_batch_path(existing.id)
+        }, status: :conflict
+      end
+    end
+
+    batch = StatementBatch.ingest!(
+      client: @current_client,
+      source_type: source_type,
+      fingerprint: fingerprint,
+      attachable: pdf
+    )
+
+    cleanup_superseded_failed_batches(fingerprint)
+
+    job.perform_later(batch.id)
+    render json: { id: batch.id, status: "processing" }, status: :accepted
+  end
+
+  # 取り込みに成功した（completed になりうる）ファイルと同一 fingerprint の、
+  # 放置された failed バッチを自テナントスコープで掃除する。
+  # processing / completed は対象外（failed のみ）。dependent: :destroy で関連仕訳も連動削除される。
+  def cleanup_superseded_failed_batches(fingerprint)
+    @current_client.statement_batches
+      .where(pdf_fingerprint: fingerprint, status: "failed")
+      .destroy_all
+  end
+end

--- a/rails/platform/app/javascript/controllers/base_pdf_upload_controller.js
+++ b/rails/platform/app/javascript/controllers/base_pdf_upload_controller.js
@@ -88,8 +88,6 @@ export default class extends Controller {
     this.showLoading()
     this.submitButtonTarget.disabled = true
 
-    const progressTab = window.open("about:blank", "_blank")
-
     const formData = new FormData()
     formData.append("pdf", this.file)
     formData.append("client_code", clientCode)
@@ -105,27 +103,17 @@ export default class extends Controller {
       const data = await response.json()
 
       if (response.status === 409 && data.duplicate) {
-        this.closeTab(progressTab)
-        this.hideLoading()
-        this.submitButtonTarget.disabled = false
-        if (confirm(`この${this.documentLabel}は既に処理済みです。再処理しますか？`)) {
-          await this.submitWithForce(formData)
-        }
+        this.showDuplicateError(data, formData)
         return
       }
 
       if (!response.ok) {
-        this.closeTab(progressTab)
         this.showError(data.error || `${this.documentLabel}の処理に失敗しました。`)
-        this.hideLoading()
-        this.submitButtonTarget.disabled = false
         return
       }
 
-      this.openProgressTab(progressTab, data.id)
-      this.resetForm()
+      this.navigateToBatch(data.id)
     } catch (error) {
-      this.closeTab(progressTab)
       this.showError(`通信エラー: ${error.message}`)
     } finally {
       this.hideLoading()
@@ -134,11 +122,11 @@ export default class extends Controller {
   }
 
   async submitWithForce(formData) {
+    this.hideError()
     this.showLoading()
     this.submitButtonTarget.disabled = true
 
-    const progressTab = window.open("about:blank", "_blank")
-    formData.append("force", "true")
+    formData.set("force", "true")
 
     try {
       const response = await fetch(this.uploadUrl, {
@@ -152,15 +140,12 @@ export default class extends Controller {
       const data = await response.json()
 
       if (!response.ok) {
-        this.closeTab(progressTab)
         this.showError(data.error || `${this.documentLabel}の処理に失敗しました。`)
         return
       }
 
-      this.openProgressTab(progressTab, data.id)
-      this.resetForm()
+      this.navigateToBatch(data.id)
     } catch (error) {
-      this.closeTab(progressTab)
       this.showError(`通信エラー: ${error.message}`)
     } finally {
       this.hideLoading()
@@ -168,26 +153,8 @@ export default class extends Controller {
     }
   }
 
-  openProgressTab(tab, batchId) {
-    const url = `/statement_batches/${batchId}`
-    if (tab) {
-      tab.location.href = url
-    } else {
-      window.location.href = url
-    }
-  }
-
-  closeTab(tab) {
-    if (tab) tab.close()
-  }
-
-  resetForm() {
-    this.file = null
-    this.fileInputTarget.value = ""
-    this.fileNameTarget.textContent = ""
-    this.fileNameTarget.classList.add("hidden")
-    this.submitButtonTarget.disabled = true
-    this.hideError()
+  navigateToBatch(batchId) {
+    window.location.href = `/statement_batches/${batchId}`
   }
 
   showLoading() {
@@ -199,11 +166,52 @@ export default class extends Controller {
   }
 
   showError(message) {
+    this.clearDuplicateActions()
     this.errorMessageTarget.textContent = message
     this.errorTarget.classList.remove("hidden")
   }
 
+  // 409 重複時: メッセージに加えて「処理済みバッチを開く」リンクと「再処理する」操作を提示する。
+  showDuplicateError(data, formData) {
+    this.errorMessageTarget.textContent =
+      `このファイルは既に処理済みです（バッチID ${data.existing_batch_id}）。`
+
+    this.clearDuplicateActions()
+
+    const actions = document.createElement("div")
+    actions.dataset.duplicateActions = ""
+    actions.className = "mt-3 flex items-center gap-4"
+
+    if (data.existing_batch_url) {
+      const link = document.createElement("a")
+      link.href = data.existing_batch_url
+      link.target = "_blank"
+      link.rel = "noopener"
+      link.textContent = "処理済みバッチを開く"
+      link.className = "text-teal-400 hover:underline text-sm font-medium"
+      actions.appendChild(link)
+    }
+
+    const reprocess = document.createElement("button")
+    reprocess.type = "button"
+    reprocess.textContent = "再処理する"
+    reprocess.className = "text-sm text-gray-300 hover:text-white underline"
+    reprocess.addEventListener("click", () => {
+      this.hideError()
+      this.submitWithForce(formData)
+    })
+    actions.appendChild(reprocess)
+
+    this.errorTarget.appendChild(actions)
+    this.errorTarget.classList.remove("hidden")
+  }
+
   hideError() {
+    this.clearDuplicateActions()
     this.errorTarget.classList.add("hidden")
+  }
+
+  clearDuplicateActions() {
+    this.errorTarget.querySelector("[data-duplicate-actions]")?.remove()
   }
 }

--- a/rails/platform/app/javascript/controllers/base_pdf_upload_controller.js
+++ b/rails/platform/app/javascript/controllers/base_pdf_upload_controller.js
@@ -121,6 +121,8 @@ export default class extends Controller {
     }
   }
 
+  // submit() で組み立てた formData（pdf / client_code を保持）をそのまま再利用する。
+  // append ではなく set を使い、再処理ボタン連打でも force が多重追加されないようにする。
   async submitWithForce(formData) {
     this.hideError()
     this.showLoading()

--- a/rails/platform/spec/requests/api/v1/amex_statements_spec.rb
+++ b/rails/platform/spec/requests/api/v1/amex_statements_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
 
     context "重複PDF検知" do
       it "同一PDFが処理済みの場合409を返すこと" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 
@@ -84,7 +84,7 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
       end
 
       it "409に処理済みバッチへのURLが含まれること (issue#307)" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         existing = create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 
@@ -95,7 +95,7 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
       end
 
       it "取り込み成功時に同一fingerprintのfailedバッチを掃除すること (issue#307)" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         stale = create(:statement_batch, :failed, client: client, pdf_fingerprint: fingerprint)
 
@@ -107,7 +107,7 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
 
       it "他テナントの同一fingerprintのfailedバッチは掃除しないこと (issue#307)" do
         other_client = create(:client, code: "other_client")
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         other_stale = create(:statement_batch, :failed, client: other_client, pdf_fingerprint: fingerprint)
 
@@ -118,7 +118,7 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
       end
 
       it "同一PDFが処理中の場合409を返すこと" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :processing, client: client, pdf_fingerprint: fingerprint)
 
@@ -131,7 +131,7 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
       end
 
       it "force: trueで重複チェックをスキップできること" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 

--- a/rails/platform/spec/requests/api/v1/amex_statements_spec.rb
+++ b/rails/platform/spec/requests/api/v1/amex_statements_spec.rb
@@ -83,6 +83,40 @@ RSpec.describe "Api::V1::AmexStatements", type: :request do
         expect(data["error"]).to include("処理済み")
       end
 
+      it "409に処理済みバッチへのURLが含まれること (issue#307)" do
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        existing = create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/amex_statements/process_statement", params: valid_params, headers: authorization_header
+
+        data = JSON.parse(response.body)
+        expect(data["existing_batch_url"]).to eq("/statement_batches/#{existing.id}")
+      end
+
+      it "取り込み成功時に同一fingerprintのfailedバッチを掃除すること (issue#307)" do
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        stale = create(:statement_batch, :failed, client: client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/amex_statements/process_statement", params: valid_params, headers: authorization_header
+
+        expect(response).to have_http_status(:accepted)
+        expect(StatementBatch.exists?(stale.id)).to be false
+      end
+
+      it "他テナントの同一fingerprintのfailedバッチは掃除しないこと (issue#307)" do
+        other_client = create(:client, code: "other_client")
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        other_stale = create(:statement_batch, :failed, client: other_client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/amex_statements/process_statement", params: valid_params, headers: authorization_header
+
+        expect(response).to have_http_status(:accepted)
+        expect(StatementBatch.exists?(other_stale.id)).to be true
+      end
+
       it "同一PDFが処理中の場合409を返すこと" do
         pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)

--- a/rails/platform/spec/requests/api/v1/bank_statements_spec.rb
+++ b/rails/platform/spec/requests/api/v1/bank_statements_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Api::V1::BankStatements", type: :request do
 
     context "重複PDF検知" do
       it "同一PDFが処理済みの場合409を返すこと" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 
@@ -84,7 +84,7 @@ RSpec.describe "Api::V1::BankStatements", type: :request do
       end
 
       it "409に処理済みバッチへのURLが含まれること (issue#307)" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         existing = create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 
@@ -95,7 +95,7 @@ RSpec.describe "Api::V1::BankStatements", type: :request do
       end
 
       it "取り込み成功時に同一fingerprintのfailedバッチを掃除すること (issue#307)" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         stale = create(:statement_batch, :failed, client: client, pdf_fingerprint: fingerprint)
 
@@ -107,7 +107,7 @@ RSpec.describe "Api::V1::BankStatements", type: :request do
 
       it "他テナントの同一fingerprintのfailedバッチは掃除しないこと (issue#307)" do
         other_client = create(:client, code: "other_client")
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         other_stale = create(:statement_batch, :failed, client: other_client, pdf_fingerprint: fingerprint)
 
@@ -118,7 +118,7 @@ RSpec.describe "Api::V1::BankStatements", type: :request do
       end
 
       it "同一PDFが処理中の場合409を返すこと" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :processing, client: client, pdf_fingerprint: fingerprint)
 
@@ -131,7 +131,7 @@ RSpec.describe "Api::V1::BankStatements", type: :request do
       end
 
       it "force: trueで重複チェックをスキップできること" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 

--- a/rails/platform/spec/requests/api/v1/bank_statements_spec.rb
+++ b/rails/platform/spec/requests/api/v1/bank_statements_spec.rb
@@ -83,6 +83,40 @@ RSpec.describe "Api::V1::BankStatements", type: :request do
         expect(data["error"]).to include("処理済み")
       end
 
+      it "409に処理済みバッチへのURLが含まれること (issue#307)" do
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        existing = create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/bank_statements/process_statement", params: valid_params, headers: authorization_header
+
+        data = JSON.parse(response.body)
+        expect(data["existing_batch_url"]).to eq("/statement_batches/#{existing.id}")
+      end
+
+      it "取り込み成功時に同一fingerprintのfailedバッチを掃除すること (issue#307)" do
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        stale = create(:statement_batch, :failed, client: client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/bank_statements/process_statement", params: valid_params, headers: authorization_header
+
+        expect(response).to have_http_status(:accepted)
+        expect(StatementBatch.exists?(stale.id)).to be false
+      end
+
+      it "他テナントの同一fingerprintのfailedバッチは掃除しないこと (issue#307)" do
+        other_client = create(:client, code: "other_client")
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        other_stale = create(:statement_batch, :failed, client: other_client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/bank_statements/process_statement", params: valid_params, headers: authorization_header
+
+        expect(response).to have_http_status(:accepted)
+        expect(StatementBatch.exists?(other_stale.id)).to be true
+      end
+
       it "同一PDFが処理中の場合409を返すこと" do
         pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)

--- a/rails/platform/spec/requests/api/v1/invoices_spec.rb
+++ b/rails/platform/spec/requests/api/v1/invoices_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Api::V1::Invoices", type: :request do
 
     context "重複PDF検知" do
       it "同一PDFが処理済みの場合409を返すこと" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 
@@ -98,7 +98,7 @@ RSpec.describe "Api::V1::Invoices", type: :request do
       end
 
       it "409に処理済みバッチへのURLが含まれること (issue#307)" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         existing = create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 
@@ -109,7 +109,7 @@ RSpec.describe "Api::V1::Invoices", type: :request do
       end
 
       it "取り込み成功時に同一fingerprintのfailedバッチを掃除すること (issue#307)" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         stale = create(:statement_batch, :failed, client: client, pdf_fingerprint: fingerprint)
 
@@ -121,7 +121,7 @@ RSpec.describe "Api::V1::Invoices", type: :request do
 
       it "他テナントの同一fingerprintのfailedバッチは掃除しないこと (issue#307)" do
         other_client = create(:client, code: "other_client")
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         other_stale = create(:statement_batch, :failed, client: other_client, pdf_fingerprint: fingerprint)
 
@@ -132,7 +132,7 @@ RSpec.describe "Api::V1::Invoices", type: :request do
       end
 
       it "同一PDFが処理中の場合409を返すこと" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :processing, client: client, pdf_fingerprint: fingerprint)
 
@@ -145,7 +145,7 @@ RSpec.describe "Api::V1::Invoices", type: :request do
       end
 
       it "force: trueで重複チェックをスキップできること" do
-        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        pdf_content = File.binread(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)
         create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
 

--- a/rails/platform/spec/requests/api/v1/invoices_spec.rb
+++ b/rails/platform/spec/requests/api/v1/invoices_spec.rb
@@ -97,6 +97,40 @@ RSpec.describe "Api::V1::Invoices", type: :request do
         expect(data["error"]).to include("処理済み")
       end
 
+      it "409に処理済みバッチへのURLが含まれること (issue#307)" do
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        existing = create(:statement_batch, :completed, client: client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/invoices/process_statement", params: valid_params, headers: authorization_header
+
+        data = JSON.parse(response.body)
+        expect(data["existing_batch_url"]).to eq("/statement_batches/#{existing.id}")
+      end
+
+      it "取り込み成功時に同一fingerprintのfailedバッチを掃除すること (issue#307)" do
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        stale = create(:statement_batch, :failed, client: client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/invoices/process_statement", params: valid_params, headers: authorization_header
+
+        expect(response).to have_http_status(:accepted)
+        expect(StatementBatch.exists?(stale.id)).to be false
+      end
+
+      it "他テナントの同一fingerprintのfailedバッチは掃除しないこと (issue#307)" do
+        other_client = create(:client, code: "other_client")
+        pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
+        fingerprint = Digest::SHA256.hexdigest(pdf_content)
+        other_stale = create(:statement_batch, :failed, client: other_client, pdf_fingerprint: fingerprint)
+
+        post "/api/v1/invoices/process_statement", params: valid_params, headers: authorization_header
+
+        expect(response).to have_http_status(:accepted)
+        expect(StatementBatch.exists?(other_stale.id)).to be true
+      end
+
       it "同一PDFが処理中の場合409を返すこと" do
         pdf_content = File.read(Rails.root.join("spec/fixtures/files/test_statement.pdf"))
         fingerprint = Digest::SHA256.hexdigest(pdf_content)


### PR DESCRIPTION
## 概要

重複アップロード時のUX問題（同一PDFを再アップロードすると409は正しく返るが、ユーザーに「既に処理済み」とその反映先が伝わらず画面が点滅するだけ）を改善する（issue#307）。amex / bank / invoice の3フローが対象。

## 変更内容

### サーバ側
- 409レスポンスに `existing_batch_url`（`/statement_batches/<id>`）を追加（`error` / `duplicate` / `existing_batch_id` は維持）
- 取り込み成功時に、同一fingerprintで `status: failed` のバッチを**自テナントスコープ**で自動削除（completedに置き換わった放置failedの掃除。processing/completedは対象外、`dependent: :destroy` で関連仕訳も連動削除）
- amex/bank/invoiceでほぼ同一だった重複検知ロジックを `PdfStatementProcessable` concern に集約（各コントローラの `process_statement` は1行委譲に）

### フロント側（`base_pdf_upload_controller.js`）
- アップロード前の `window.open("about:blank")` 先行確保を廃止し、**重複時の画面点滅を解消**（成功時は同窓で進捗画面へ遷移）
- 409時は `confirm` をやめ、エラー枠に「このファイルは既に処理済みです（バッチID N）」＋「処理済みバッチを開く」リンク＋「再処理する」操作を `createElement` で安全に提示

## テスト方法

- `make test` → **732 examples, 0 failures**
- 追加テスト（amex/bank/invoice 各3件）:
  - 409に `existing_batch_url` が含まれること
  - 取り込み成功時に同一fingerprintのfailedバッチが削除されること
  - 他テナントの同一fingerprintのfailedバッチは削除されないこと

## 補足（挙動変更）

点滅解消に伴い、アップロード成功時の遷移が「新規タブで進捗画面」→「同じタブで進捗画面へ遷移」に変わります（`await`後の`window.open`はポップアップブロッカーに弾かれるため、確実な同窓遷移を採用）。

## クリーンアップ方式について

issue記載の「failed batchの自動クリーンアップ」は、Rakeタスク（定期実行）やバッチ一覧UIではなく、**取り込み成功フローに密着したインライン自動削除**を採用。Rake非依存・対象はsuperseded failedのみで低リスク、CLAUDE.mdの「Rakeは原則作らない」方針にも沿う。

Closes #307
