### PR TITLE
fix(platform): 弥生CSVで非課税売上を「非課売上」に変換する (issue#349)

### DIFF
--- a/rails/platform/app/services/yayoi_export_service.rb
+++ b/rails/platform/app/services/yayoi_export_service.rb
@@ -4,9 +4,10 @@ class YayoiExportService
   SINGLE_ENTRY_FLAG = "2000"
   SINGLE_TYPE = "0"
 
-  TAX_CATEGORY_STANDARD = "課対仕入込10%"
-  TAX_CATEGORY_REDUCED  = "課対仕入込軽減8%"
-  TAX_CATEGORY_OUT      = "対象外"
+  TAX_CATEGORY_STANDARD          = "課対仕入込10%"
+  TAX_CATEGORY_REDUCED           = "課対仕入込軽減8%"
+  TAX_CATEGORY_NON_TAXABLE_SALES = "非課売上"
+  TAX_CATEGORY_OUT               = "対象外"
 
   def export_single_entry(entries)
     entries = entries.includes(:journal_entry_lines) if entries.respond_to?(:includes)
@@ -55,12 +56,17 @@ class YayoiExportService
     ]
   end
 
-  # クレカ明細等は適格／非適格の判定不能のため、すべて適格扱いで弥生の3区分に丸める。
+  # クレカ明細等は適格／非適格の判定不能のため、課税仕入はすべて適格扱いで弥生の課対仕入区分に丸める。
+  # 非課税「売上」（受取利息など）は弥生では「非課売上」が正しく、課税売上割合の按分計算に影響するため
+  # 「対象外」とは区別する。一方、非課税「仕入」・不課税・リバースチャージは弥生公式案内に従い「対象外」に集約する。
+  #   参考: https://support.yayoi-kk.co.jp/faq_Subcontents.html?page_id=27344
   # 空文字は弥生で「税区分なし」を意味するため、そのまま空文字で返す。
   def map_tax_category(raw)
     return "" if raw.blank?
 
-    if raw.include?("軽減") || raw.include?("8%")
+    if raw.include?("非課税売上") || raw.include?("非課売上")
+      TAX_CATEGORY_NON_TAXABLE_SALES
+    elsif raw.include?("軽減") || raw.include?("8%")
       TAX_CATEGORY_REDUCED
     elsif raw.include?("10%")
       TAX_CATEGORY_STANDARD

--- a/rails/platform/spec/services/yayoi_export_service_spec.rb
+++ b/rails/platform/spec/services/yayoi_export_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe YayoiExportService do
     end
   end
 
-  describe "税区分マッピング (適格扱い3区分への統一)" do
+  describe "税区分マッピング (弥生税区分への正規化)" do
     def build_entry(debit_tax:, credit_tax: "", date: Date.new(2026, 3, 1))
       create(:journal_entry, client: client, date: date,
              debit_account: "消耗品費", debit_tax_category: debit_tax, debit_amount: 1_000,
@@ -143,6 +143,16 @@ RSpec.describe YayoiExportService do
 
     it "「課対仕入（リバースチャージ）」を「対象外」に丸めること" do
       entry = build_entry(debit_tax: "課対仕入（リバースチャージ）")
+      expect(export_row(entry)[6]).to eq("対象外")
+    end
+
+    it "貸方の「非課税売上」を「非課売上」に変換すること（受取利息など。対象外とは区別）" do
+      entry = build_entry(debit_tax: "対象外", credit_tax: "非課税売上")
+      expect(export_row(entry)[13]).to eq("非課売上")
+    end
+
+    it "「非課税仕入」は「非課税売上」と誤判定せず「対象外」に丸めること" do
+      entry = build_entry(debit_tax: "非課税仕入")
       expect(export_row(entry)[6]).to eq("対象外")
     end
 


### PR DESCRIPTION
## 概要

`YayoiExportService#map_tax_category` が貸方の非課税売上（受取利息など）を「対象外」に丸めてしまい、消費税の**課税売上割合の按分計算**がズレるバグを修正する。弥生公式では非課税**売上**は「非課売上」が正しく、「対象外（不課税）」とは区別が必要。

## 変更内容

- `map_tax_category` 先頭に「非課税売上/非課売上」分岐を追加し `非課売上` を出力
- 非課税**仕入**・不課税・リバースチャージは弥生公式どおり `対象外` を維持（退行なし）
- 「非課税仕入」を誤判定しないことを確認
- 判定根拠の弥生公式URLをコードコメントに記載

## テスト

- `spec/services/yayoi_export_service_spec.rb` を更新
  - 非課税売上ケースを新規追加（貸方「非課税売上」→ `非課売上`）
  - 非課税仕入ケースを非退行確認として補強（借方「非課税仕入」→ `対象外`）
- `22 examples, 0 failures`（green 確認済み）

## 補足

本番反映は #333（一括反映）に含める。

## 判定根拠

- [弥生：不課税の取引を入力したい](https://support.yayoi-kk.co.jp/faq_Subcontents.html?page_id=27344)
- [弥生：インポートデータの税区分](https://support.yayoi-kk.co.jp/faq_Subcontents.html?page_id=27165)

Closes #349
