### PR TITLE
fix(platform): クレカ警告ツールチップ・エクスポート絞り込み・業種クリアのUIバグ3件を修正 (issue#351)

### DIFF
--- a/rails/platform/app/views/clients/_form.html.erb
+++ b/rails/platform/app/views/clients/_form.html.erb
@@ -23,7 +23,7 @@
 
       <div>
         <label class="block text-sm font-medium text-gray-300 mb-2">業種（複数選択可）</label>
-        <%= f.hidden_field :industries, value: "" %>
+        <%= hidden_field_tag "client[industries][]", "" %>
         <div class="space-y-2">
           <% Client::INDUSTRY_LABELS.each do |code, label| %>
             <label class="flex items-center gap-2 cursor-pointer">

--- a/rails/platform/app/views/journal_entries/index.html.erb
+++ b/rails/platform/app/views/journal_entries/index.html.erb
@@ -50,10 +50,10 @@
       </button>
       <div data-dropdown-target="menu" class="hidden absolute right-0 mt-1 w-56 bg-gray-900 border border-gray-700 rounded-md shadow-lg z-30">
         <%= link_to "CSV（従来形式）",
-              export_journal_entries_path(client_code: @client_code, source_type: @source_type.presence, csv_export_status: @csv_export_status.presence, format_type: "csv"),
+              export_journal_entries_path(client_code: @client_code, source_type: @source_type.presence, csv_export_status: @csv_export_status.presence, status: @status_filter.presence, format_type: "csv"),
               class: "block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700" %>
         <%= link_to "弥生会計（単一仕訳）",
-              export_journal_entries_path(client_code: @client_code, source_type: @source_type.presence, csv_export_status: @csv_export_status.presence, format_type: "yayoi_single"),
+              export_journal_entries_path(client_code: @client_code, source_type: @source_type.presence, csv_export_status: @csv_export_status.presence, status: @status_filter.presence, format_type: "yayoi_single"),
               class: "block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700" %>
       </div>
     </div>
@@ -132,7 +132,7 @@
               <%# 右端固定列 %>
               <td class="sticky right-[4rem] z-10 bg-gray-900 group-hover:bg-gray-800 px-3 py-2 whitespace-nowrap border-l border-gray-700">
                 <% if entry.card_last_four.present? && @registered_last_fours.include?(entry.card_last_four) %>
-                  <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-900 text-red-300 mr-1" title="末尾****#{entry.card_last_four}のカードが登録済みです。AMEX明細と重複する可能性があります。">
+                  <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-900 text-red-300 mr-1" title="末尾****<%= entry.card_last_four %>のカードが登録済みです。AMEX明細と重複する可能性があります。">
                     クレカ警告
                   </span>
                 <% end %>


### PR DESCRIPTION
## 概要

Opus 4.8コード監査で発見したUI軽微バグ3件を修正。いずれもデータ損失・セキュリティ影響なし、表示/UXレベルの不具合。

## 変更内容

### 1. クレカ警告ツールチップにカード番号がリテラル表示される
- `journal_entries/index.html.erb` L135 の title 属性で Ruby の `#{}` 補間を使っていたが、ERB タグの外なので展開されず `#{entry.card_last_four}` がそのまま表示されていた
- `<%= entry.card_last_four %>` に書き換え

### 2. CSV/弥生エクスポートにステータス絞り込みが反映されない
- エクスポートリンクの `export_journal_entries_path` に `status` パラメータが渡されておらず、ステータス絞り込み中でも全件がエクスポートされていた
- `source_type` / `csv_export_status` と同様に `status: @status_filter.presence` を追加（CSV・弥生両リンク）
- コントローラの `export` アクションは既に `apply_status_filter` を適用済みのため、パラメータを渡すだけで正しく動作

### 3. 全業種チェック解除で industries がクリアされない
- `clients/_form.html.erb` の `f.hidden_field :industries` は name=`client[industries]` を生成するが、チェックボックスは name=`client[industries][]` で送信するため name が不一致
- 全チェック解除時に空値が正しく送信されるよう `hidden_field_tag "client[industries][]", ""` に変更

## テスト

- `make test` → **734 examples, 0 failures**（既存spec全パス確認済み）
- ビュー属性の修正のみで新規specは不要と判断（ブラウザ目視で確認）

Closes #351
